### PR TITLE
Refine resource indexes and background identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@
 - `ai/` owns provider adapters; `ui/` owns reusable UI components.
 - `scripts/` contains thin operator and LaunchAgent one-shot entrypoints. Put
   reusable behavior in the owning package rather than duplicating it in a CLI.
+- Scheduled source-guard and mounted-resource jobs prefer one-shot modes of the
+  local py2app executable when it exists, preserving the stable macOS app/TCC
+  identity. The source Python path is a compatibility fallback, not the
+  preferred installed runtime.
 - `launchers/` owns the canonical Finder-friendly `.command` entrypoints. The
   root `启动.command` is a compatibility stub for deployed source-mode
   LaunchAgents and must not grow a second implementation.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ independently deployed microservices. Editable sources:
 - Opt-in attachment cataloging plus a private local content-addressed archive that deduplicates identical bytes; file and image kinds are selected explicitly.
 - Optional, separately installed WeChat source guard with grace, pause, restart budget, exponential backoff, content-free receipts, and no `KeepAlive` loop.
 - Provider-neutral filesystem snapshots for the attachment archive, including plan, run, verify, and read-only restore planning.
-- Default no-OAuth selected-resource backup through an existing mounted filesystem such as Google Drive for Desktop, with exact link occurrences, shared-CAS files, Obsidian indexes, catalog snapshots, and honest `sync_delegated` receipts.
+- Default no-OAuth selected-resource backup through an existing mounted filesystem such as Google Drive for Desktop, with exact link occurrences, shared-CAS files, lightweight Obsidian indexes, catalog snapshots, and honest `sync_delegated` receipts.
 - Optional advanced selected-chat file sync through the Google Drive API, with a separate selection/control plane, durable queue, chat/month shortcuts, retry/reconcile, and no automatic deletion.
 - Optional link preview context for public URLs; it is off by default and must be enabled explicitly.
 - CLI and `.command` maintenance entrypoints for users whose menu bar icon is hidden.
@@ -316,6 +316,8 @@ Source reliability helpers:
 .venv/bin/python scripts/resource_backup.py set-target "<existing-mounted-directory>"
 .venv/bin/python scripts/resource_backup.py set-link-export-mode redacted
 .venv/bin/python scripts/resource_backup.py init
+.venv/bin/python scripts/resource_backup.py backfill --all
+.venv/bin/python scripts/resource_backup.py backfill --all --apply
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD --apply
 .venv/bin/python scripts/resource_backup.py status
@@ -355,15 +357,21 @@ but does not load it; `--load-now` is the separate activation step.
 `resource_backup.py install-agent` installs and loads its short-lived scheduled
 worker and therefore belongs only after the manual canary. Mounted-resource,
 attachment-archive, and direct-Drive backfills are dry plans unless `--apply`
-is present. Drive `enable` does not authenticate, select chats, backfill, or run an
-upload. Backup `verify` checks bytes visible at the configured filesystem target
+is present. Mounted-resource `backfill --all` scans all history still available
+in the selected chats' local WeChat shards; it remains idempotent and does not
+move live cursors. Drive `enable` does not authenticate, select chats, backfill,
+or run an upload. Backup `verify` checks bytes visible at the configured filesystem target
 and deliberately makes no claim about provider-side upload. See the
 [source reliability guide](docs/source-reliability.md) for mounted handoff,
 optional Drive API, states, resolver rules, storage layout, and failure boundaries.
 
 Each run also maintains a discoverable Obsidian entrypoint at
 `<monitor_obsidian_subdir>/00-资源索引.md`. It links to each selected chat's own
-`00-资源索引.md` and monthly pages. These are generated, app-owned Markdown files
+`00-资源索引.md` and monthly pages. Monthly pages are deliberately light: day,
+time, and a clickable link/file only. An observed WeChat link title is used when
+available; otherwise the full exact URL is the visible label. Sender, hashes,
+source-message identity, and handoff details remain in private catalogs instead
+of the reading surface. These are generated, app-owned Markdown files
 even when their names do not contain `.generated`; that suffix is used only when
 the preferred filename already belongs to the user and must not be overwritten.
 
@@ -437,7 +445,11 @@ For a local app-bundle LaunchAgent identity:
 
 The `--alias` app points back to this source checkout and its `.venv`; it is
 useful for local autostart notification identity, not as a standalone
-distributable build.
+distributable build. When that app bundle exists, the optional source-guard and
+mounted-resource LaunchAgents also invoke short-lived modes of the same app
+executable. This keeps scheduled folder access under the project app identity
+instead of presenting a new bare `Python` process every interval. A source-only
+install without the bundle retains the explicit `.venv/bin/python` fallback.
 
 ## Runtime Data Migration
 
@@ -597,7 +609,7 @@ flowchart LR
   LAUNCHERS["launchers/<br/>Finder entrypoints"]
   ROOTSTART["启动.command<br/>compatibility stub"]
   TESTS["tests/<br/>unittest package"]
-  AGENTS["LaunchAgents<br/>absolute checkout paths"]
+  AGENTS["LaunchAgents<br/>app identity preferred<br/>source Python fallback"]
   BUNDLE["Alias app bundle<br/>checkout + .venv"]
   CLIENTS["MCP clients<br/>absolute mcp_server.py"]
 
@@ -612,7 +624,7 @@ flowchart LR
   LAUNCHERS --> SCRIPTS
   SETUP --> BUNDLE
   AGENTS --> BUNDLE
-  AGENTS --> SCRIPTS
+  AGENTS -. "source-only fallback" .-> SCRIPTS
   CLIENTS --> MCP
   TESTS -. "validates" .-> Root
   TESTS -. "validates" .-> Packages

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,7 +129,7 @@ DeepSeek 按实际 token 用量计费，输入缓存命中、输入缓存未命�
 - 附件 catalog 与本地 content-addressed archive：archive 默认关闭；启用后相同 bytes 自动 dedup，图片仍需单独 opt-in。
 - 可选、单独安装的微信 source guard：grace、pause、restart budget、exponential backoff、content-free receipts，且没有 `KeepAlive` busy loop。
 - Provider-neutral filesystem snapshot：支持 attachment archive 的 plan、run、verify 和只读 restore plan。
-- 默认 no-OAuth selected-resource mounted backup：把 exact links 与共享 CAS files 交给现有 Google Drive for Desktop 等挂载目录，同时生成 Obsidian index、catalog snapshot 和诚实的 `sync_delegated` receipt。
+- 默认 no-OAuth selected-resource mounted backup：把 exact links 与共享 CAS files 交给现有 Google Drive for Desktop 等挂载目录，同时生成轻量 Obsidian index、catalog snapshot 和诚实的 `sync_delegated` receipt。
 - 可选 advanced Google Drive API lane：拥有独立 selection/control plane、durable queue、群聊/月 shortcut 与 retry/reconcile，不自动删除。
 - 链接和转发展开：可选择补充公开网页标题/摘要；远程链接预览默认关闭。本地微信 XML 里可见的转发聊天记录会尽量解析。
 - MCP Server：让 Claude Desktop、Claude Code、Cursor、OpenClaw 等 MCP 客户端只读查询群聊、搜索、总结、查看图片；发送消息默认关闭。
@@ -289,6 +289,8 @@ Source reliability 运维脚本：
 .venv/bin/python scripts/resource_backup.py set-target "<已经存在的挂载目录>"
 .venv/bin/python scripts/resource_backup.py set-link-export-mode redacted
 .venv/bin/python scripts/resource_backup.py init
+.venv/bin/python scripts/resource_backup.py backfill --all
+.venv/bin/python scripts/resource_backup.py backfill --all --apply
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD --apply
 .venv/bin/python scripts/resource_backup.py status
@@ -327,14 +329,19 @@ Source reliability 运维脚本：
 才是单独的 activation。`resource_backup.py install-agent` 会安装并加载短命 scheduled worker，必须放在
 manual canary 通过之后。
 Mounted-resource、attachment-archive 与 direct-Drive backfill 默认都是 dry plan，只有显式
-`--apply` 才登记历史 item。Drive `enable` 不会顺手 auth、选群、backfill 或 upload。Backup `verify`
+`--apply` 才登记历史 item。Mounted-resource `backfill --all` 会扫描被选群聊在本地 WeChat shards
+里仍然可读的全部历史；它保持 idempotent，且不移动 live cursor。Drive `enable` 不会顺手 auth、
+选群、backfill 或 upload。Backup `verify`
 只验证 configured filesystem target 上看得到的 bytes，绝不宣称 provider-side upload 已完成。Drive
 mounted handoff、可选 Drive API、完整状态、resolver 规则、存储结构和失败边界见
 [来源可靠性指南](docs/source-reliability.zh-CN.md)。
 
 每轮 resource backup 还会维护一个容易发现的 Obsidian 总入口：
 `<monitor_obsidian_subdir>/00-资源索引.md`。它链接到每个显式选中群聊自己的
-`00-资源索引.md` 与月度页面。这些文件即使名字里没有 `.generated`，也仍然是
+`00-资源索引.md` 与月度页面。月度页面刻意保持轻量，只显示日期、时间和可点击的链接/文件：
+WeChat 有 observed title 时使用 title；没有 title 时直接把完整 exact URL 作为可见 label。
+sender、hash、source-message identity 和 handoff 详情继续留在私有 catalog，不挤进阅读层。
+这些文件即使名字里没有 `.generated`，也仍然是
 app-owned generated Markdown；只有首选文件名已被猫手写内容占用、程序必须避免覆盖时，
 才会退到 `00-资源索引.generated.md` 或月份 `.generated.md`。
 
@@ -361,7 +368,10 @@ identity，并使用仓库里的 `resources/app_icon.icns`，避免通知中心�
 ```
 
 这里的 `--alias` app 依赖当前源码目录和 `.venv`，适合本机 LaunchAgent /
-系统通知 identity，不是 standalone distributable build。
+系统通知 identity，不是 standalone distributable build。只要这个 app bundle 存在，可选的
+source-guard 与 mounted-resource LaunchAgent 也会调用同一个 app executable 的短命 one-shot
+mode，让定时文件访问归在项目 app identity 下，而不是每 300 秒出现一只新的裸 `Python`。
+纯 source 安装没有 bundle 时，仍保留显式 `.venv/bin/python` fallback。
 
 ## Runtime Data Migration
 
@@ -613,7 +623,7 @@ flowchart LR
   LAUNCHERS["launchers/<br/>Finder entrypoints"]
   ROOTSTART["启动.command<br/>compatibility stub"]
   TESTS["tests/<br/>unittest package"]
-  AGENTS["LaunchAgents<br/>绝对 checkout path"]
+  AGENTS["LaunchAgents<br/>优先 app identity<br/>source Python fallback"]
   BUNDLE["Alias app bundle<br/>checkout + .venv"]
   CLIENTS["MCP clients<br/>绝对 mcp_server.py path"]
 
@@ -628,7 +638,7 @@ flowchart LR
   LAUNCHERS --> SCRIPTS
   SETUP --> BUNDLE
   AGENTS --> BUNDLE
-  AGENTS --> SCRIPTS
+  AGENTS -. "source-only fallback" .-> SCRIPTS
   CLIENTS --> MCP
   TESTS -. "验证" .-> Root
   TESTS -. "验证" .-> Packages

--- a/app.py
+++ b/app.py
@@ -11,6 +11,12 @@ import time
 import traceback
 from datetime import datetime
 
+from core.background_jobs import dispatch_background_job
+
+_BACKGROUND_EXIT_CODE = dispatch_background_job(sys.argv[1:])
+if _BACKGROUND_EXIT_CODE is not None:
+    raise SystemExit(_BACKGROUND_EXIT_CODE)
+
 import rumps
 
 # --- For dialog top-most + custom dialogs ---

--- a/core/background_jobs.py
+++ b/core/background_jobs.py
@@ -1,0 +1,56 @@
+"""Run short-lived project jobs through the stable macOS app identity when present."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+RESOURCE_BACKUP_MODE = "--resource-backup-run"
+SOURCE_GUARD_MODE = "--source-guard-run"
+
+
+def app_bundle_executable(project_dir: str | os.PathLike[str]) -> Path | None:
+    executable = (
+        Path(project_dir).resolve()
+        / "dist"
+        / "WeGroupchatObsidian.app"
+        / "Contents"
+        / "MacOS"
+        / "WeGroupchatObsidian"
+    )
+    if executable.is_file() and os.access(executable, os.X_OK):
+        return executable.resolve()
+    return None
+
+
+def background_program_arguments(
+    project_dir: str | os.PathLike[str],
+    mode: str,
+    python_fallback: list[str],
+) -> tuple[list[str], str]:
+    executable = app_bundle_executable(project_dir)
+    if executable is not None:
+        return [str(executable), mode], "app_bundle"
+    return list(python_fallback), "python"
+
+
+def runtime_identity(program_arguments: list[str] | tuple[str, ...]) -> str:
+    args = [str(value) for value in program_arguments]
+    if args and ".app/Contents/MacOS/" in args[0]:
+        return "app_bundle"
+    if args and (args[0].endswith("/python") or args[0].endswith("/python3")):
+        return "python"
+    return "unknown"
+
+
+def dispatch_background_job(argv: list[str] | tuple[str, ...]) -> int | None:
+    args = list(argv)
+    if args == [RESOURCE_BACKUP_MODE]:
+        from scripts.resource_backup import main
+
+        return int(main(["run"]))
+    if args == [SOURCE_GUARD_MODE]:
+        from scripts.wechat_source_guard_agent import main
+
+        return int(main())
+    return None

--- a/core/resource_backup.py
+++ b/core/resource_backup.py
@@ -223,21 +223,12 @@ def _single_line(value, fallback="", limit=240):
     return (text[:limit] or fallback)
 
 
-def _markdown_label(value, fallback="链接"):
-    return (
-        _single_line(value, fallback, 240)
-        .replace("\\", "\\\\")
-        .replace("[", "\\[")
-        .replace("]", "\\]")
-    )
-
-
-def _markdown_inline_code(value, fallback="attachment"):
-    text = _single_line(value, fallback, 240)
-    longest = max((len(match.group(0)) for match in re.finditer(r"`+", text)), default=0)
-    fence = "`" * (longest + 1)
-    padding = " " if text.startswith("`") or text.endswith("`") else ""
-    return f"{fence}{padding}{text}{padding}{fence}"
+def _markdown_label(value, fallback="链接", *, limit=240):
+    text = "".join(" " if ord(char) < 32 else char for char in str(value or ""))
+    text = re.sub(r"\s+", " ", text).strip() or fallback
+    if limit is not None:
+        text = text[:limit]
+    return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 
 def _frontmatter_scalar(value):
@@ -1066,20 +1057,6 @@ class MountedResourceBackup:
             "unresolved_files": unresolved_files,
         }
 
-    @staticmethod
-    def _message_groups(rows):
-        groups = []
-        current_key = None
-        current = None
-        for row in rows:
-            key = (row.get("source_message_id"), row.get("source_timestamp"))
-            if key != current_key:
-                current_key = key
-                current = []
-                groups.append(current)
-            current.append(row)
-        return groups
-
     def _render_month(
         self, chat_alias, month, rows, delivery_map, *, target_view=False
     ):
@@ -1089,7 +1066,7 @@ class MountedResourceBackup:
             "---",
             "source_app: we-groupchat-obsidian",
             "source_kind: resource_index",
-            "source_schema_version: 1",
+            "source_schema_version: 2",
             f"source_chat: {_frontmatter_scalar(display_chat)}",
             f"month: {_frontmatter_scalar(display_month)}",
             "---",
@@ -1097,74 +1074,81 @@ class MountedResourceBackup:
             INDEX_MARKER,
             f"# {display_chat} · {display_month} 资源索引",
             "",
-            "> 文件与链接在同一消息块中出现，只表示共同出现；除非另有证据，不代表内容关联。",
+            "> 点击即可打开；详细来源与归档记录保留在本地 catalog。",
             "",
         ]
-        for group in self._message_groups(rows):
-            first = group[0]
-            when = str(first.get("source_time") or "")
-            if not when and first.get("source_timestamp"):
-                when = datetime.fromtimestamp(int(first["source_timestamp"])).strftime("%Y-%m-%d %H:%M")
-            sender = _single_line(
-                first.get("source_sender"), "未知发送者", 80
-            )
-            heading_time = _single_line(
-                when[5:] if len(when) >= 16 else when,
+        current_day = ""
+        for item in rows:
+            when = str(item.get("source_time") or "")
+            if not when and item.get("source_timestamp"):
+                when = datetime.fromtimestamp(
+                    int(item["source_timestamp"])
+                ).strftime("%Y-%m-%d %H:%M")
+            day = _single_line(
+                when[5:10] if len(when) >= 10 else display_month,
                 display_month,
-                40,
+                20,
             )
-            lines.append(f"### {heading_time} · {sender}")
-            lines.append("")
-            kinds = {str(item.get("kind") or "") for item in group}
-            for item in group:
-                if item.get("kind") == "link":
-                    url = (
-                        self._export_url(item.get("observed_url") or "")
-                        if target_view else str(item.get("observed_url") or "")
+            clock = _single_line(
+                when[11:16] if len(when) >= 16 else "",
+                "--:--",
+                10,
+            )
+            if day != current_day:
+                if current_day:
+                    lines.append("")
+                lines.extend([f"## {day}", ""])
+                current_day = day
+
+            if item.get("kind") == "link":
+                url = (
+                    self._export_url(item.get("observed_url") or "")
+                    if target_view else str(item.get("observed_url") or "")
+                )
+                title = str(item.get("original_name") or "").strip()
+                if url:
+                    label_source = title or url
+                    label = _markdown_label(
+                        label_source,
+                        "链接",
+                        limit=240 if title else None,
                     )
-                    label = _markdown_label(item.get("original_name"), "链接")
-                    if url:
-                        lines.append(f"- 链接：[{label}](<{_markdown_url(url)}>)")
-                    else:
-                        lines.append(f"- 链接：{label}（URL 未导出）")
-                    lines.append(f"  - URL identity：`{str(item.get('url_sha256') or '')[:16]}`")
+                    lines.append(
+                        f"- {clock} · 🔗 [{label}](<{_markdown_url(url)}>)"
+                    )
                 else:
-                    name = _markdown_inline_code(
-                        item.get("original_name"), "attachment"
+                    label = _markdown_label(title, "链接")
+                    lines.append(f"- {clock} · 🔗 {label}（URL 未导出）")
+                continue
+
+            name = _markdown_label(item.get("original_name"), "attachment")
+            digest = str(item.get("object_sha256") or "")
+            delivery = delivery_map.get(digest) if digest else None
+            link = ""
+            unavailable = ""
+            if target_view:
+                relpath = str(delivery.get("target_relpath") or "") if delivery else ""
+                if relpath:
+                    link = os.path.join("..", "..", "..", relpath).replace(
+                        os.sep,
+                        "/",
                     )
-                    lines.append(f"- 文件：{name}")
-                    status = str(item.get("status") or "unknown")
-                    lines.append(f"  - 本地归档状态：{status}")
-                    digest = str(item.get("object_sha256") or "")
-                    if digest:
-                        lines.append(f"  - SHA-256：`{digest}`")
-                    delivery = delivery_map.get(digest) if digest else None
-                    if target_view:
-                        relpath = str(delivery.get("target_relpath") or "") if delivery else ""
-                        if relpath:
-                            relative = os.path.join(
-                                "..", "..", "..", relpath
-                            ).replace(os.sep, "/")
-                            lines.append(
-                                f"  - 备份对象：[打开](<{_markdown_url(relative)}>)"
-                            )
-                        lines.append(
-                            "  - Handoff："
-                            + (str(delivery.get("status")) if delivery else "pending")
-                        )
-                    else:
-                        if digest and item.get("object_relpath"):
-                            local_path = os.path.join(
-                                self.archive_root, str(item["object_relpath"])
-                            )
-                            lines.append(f"  - 本地文件：[打开]({_file_url(local_path)})")
-                        lines.append(
-                            "  - Drive handoff："
-                            + (str(delivery.get("status")) if delivery else "pending")
-                        )
-            if len(group) > 1 and len(kinds) > 1:
-                lines.append("- 关系说明：同条消息共同出现，内容关联未确认。")
-            lines.extend(["", f"<!-- source_message_id: {first.get('source_message_id', '')} -->", ""])
+                else:
+                    unavailable = "（待同步）"
+            elif digest and item.get("object_relpath"):
+                local_path = os.path.join(
+                    self.archive_root,
+                    str(item["object_relpath"]),
+                )
+                link = _file_url(local_path)
+            else:
+                unavailable = "（等待本地文件）"
+            if link:
+                lines.append(
+                    f"- {clock} · 📎 [{name}](<{_markdown_url(link)}>)"
+                )
+            else:
+                lines.append(f"- {clock} · 📎 {name}{unavailable}")
         return "\n".join(lines).rstrip() + "\n"
 
     @staticmethod
@@ -1210,7 +1194,7 @@ class MountedResourceBackup:
                 INDEX_MARKER,
                 f"# {_single_line(chat_alias, '未命名群聊', 120)} · 资源索引",
                 "",
-                "> 这里收录显式选中监控群中的链接与文件 occurrence。主题笔记负责解释，资源索引负责寻找。",
+                "> 按月份查看链接与文件。",
                 "",
             ]
             for month in sorted(months, reverse=True):
@@ -1284,7 +1268,7 @@ class MountedResourceBackup:
                 INDEX_MARKER,
                 "# 资源索引",
                 "",
-                "> 这里汇总显式选中资源备份的群聊入口；每个群聊页面再按月份列出链接与文件。",
+                "> 按群聊进入链接与文件清单。",
                 "",
             ]
             for summary in sorted(

--- a/core/resource_backup_launch_agent.py
+++ b/core/resource_backup_launch_agent.py
@@ -8,6 +8,11 @@ import sys
 import tempfile
 from pathlib import Path
 
+from .background_jobs import (
+    RESOURCE_BACKUP_MODE,
+    background_program_arguments,
+    runtime_identity,
+)
 from .config import DATA_DIR
 
 
@@ -88,9 +93,14 @@ def install(project_dir: str | os.PathLike[str], interval_seconds: int = 300) ->
         environment["WE_GROUPCHAT_OBSIDIAN_DATA_DIR"] = os.environ[
             "WE_GROUPCHAT_OBSIDIAN_DATA_DIR"
         ]
+    program_arguments, runtime_identity = background_program_arguments(
+        project,
+        RESOURCE_BACKUP_MODE,
+        [sys.executable, str(script), "run"],
+    )
     payload = {
         "Label": RESOURCE_BACKUP_LAUNCH_AGENT_LABEL,
-        "ProgramArguments": [sys.executable, str(script), "run"],
+        "ProgramArguments": program_arguments,
         "WorkingDirectory": str(project),
         "RunAtLoad": True,
         "StartInterval": interval,
@@ -109,6 +119,7 @@ def install(project_dir: str | os.PathLike[str], interval_seconds: int = 300) ->
             "state": "install_failed",
             "installed": path.is_file(),
             "loaded": False,
+            "runtime_identity": runtime_identity,
             "error": (loaded.stderr or loaded.stdout).strip()[:240],
         }
     return {
@@ -116,6 +127,7 @@ def install(project_dir: str | os.PathLike[str], interval_seconds: int = 300) ->
         "installed": True,
         "loaded": True,
         "interval_seconds": interval,
+        "runtime_identity": runtime_identity,
     }
 
 
@@ -143,8 +155,17 @@ def status() -> dict:
         "print",
         f"{_domain()}/{RESOURCE_BACKUP_LAUNCH_AGENT_LABEL}",
     )
+    identity = "not_installed"
+    try:
+        with path.open("rb") as handle:
+            payload = plistlib.load(handle)
+        identity = runtime_identity(payload.get("ProgramArguments") or [])
+    except (OSError, plistlib.InvalidFileException, TypeError, ValueError):
+        if path.is_file():
+            identity = "unknown"
     return {
         "state": "loaded" if report.returncode == 0 else "not_loaded",
         "installed": path.is_file(),
         "loaded": report.returncode == 0,
+        "runtime_identity": identity,
     }

--- a/docs/resource-capture-and-mounted-backup-spec.md
+++ b/docs/resource-capture-and-mounted-backup-spec.md
@@ -190,11 +190,10 @@ Files use structured `message.resources` entries with `kind=file`. The occurrenc
 
 Links and files in the same message share `source_message_id`. This is sufficient to query and display co-occurrence.
 
-No direct link-to-file semantic edge is created in v1. User interfaces must label mixed-message groups as:
-
-```text
-同条消息共同出现，内容关联未确认
-```
+No direct link-to-file semantic edge is created in v1. The durable catalog may
+expose co-occurrence for audit or later confirmation, but the lightweight
+resource-finding index does not need to display sender or a co-occurrence
+disclaimer.
 
 A future explicit relation requires independent evidence such as user confirmation, an evidence span, or byte-identical materialization.
 
@@ -216,17 +215,18 @@ Recommended layout:
 
 The scope-root `00-资源索引.md` links to every selected chat that currently has
 captured occurrences and shows link/file/month counts. Each chat-level
-`00-资源索引.md` contains month links and counts. Monthly notes group resources by source message and show:
+`00-资源索引.md` contains month links and counts. Monthly notes are a lightweight
+reading surface grouped by day and show:
 
 - time;
-- sender;
-- exact link and link identity;
-- file name;
-- local archive state;
-- file SHA-256;
-- local CAS link when available;
-- mounted handoff state;
-- an explicit co-occurrence disclaimer for mixed groups.
+- a clickable observed title when present;
+- otherwise the full exact URL as the visible clickable label;
+- a clickable file name when the CAS or mounted object is available;
+- one short unavailable state only when a file cannot be opened.
+
+Sender, source-message identity, URL identity, hashes, resolution state,
+co-occurrence, and mounted handoff details remain in the private durable
+catalogs and receipts rather than the reading projection.
 
 The index contains references only. It does not copy file bytes into the Obsidian vault.
 
@@ -292,6 +292,11 @@ KeepAlive: absent
 ProcessType: Background
 LowPriorityIO: true
 ```
+
+If the local py2app bundle exists, both the mounted-resource worker and source
+guard use short-lived command modes of its executable. This preserves the
+stable macOS app/TCC identity instead of launching a new bare Python identity on
+every interval. Source-only distributions retain the Python script fallback.
 
 Each wake executes `scripts/resource_backup.py run` once. The process captures
 new occurrences, resolves a bounded number of pending files, refreshes local
@@ -427,6 +432,8 @@ python scripts/resource_backup.py set-selected-chats 1
 python scripts/resource_backup.py set-target "/path/chosen/in/Finder"
 python scripts/resource_backup.py set-link-export-mode redacted
 python scripts/resource_backup.py init
+python scripts/resource_backup.py backfill --all
+python scripts/resource_backup.py backfill --all --apply
 python scripts/resource_backup.py backfill --from YYYY-MM-DD
 python scripts/resource_backup.py backfill --from YYYY-MM-DD --apply
 python scripts/resource_backup.py run --resolve-limit 10
@@ -435,7 +442,8 @@ python scripts/resource_backup.py install-agent --interval-seconds 300
 ```
 
 `init` is from-now only. Re-selection also starts a new from-now epoch. Explicit
-`backfill --apply` does not move that live cursor. `run` remains safe before the target is available: it
+`backfill --apply` does not move that live cursor. `backfill --all` means all
+history still locally readable from known WeChat shards. `run` remains safe before the target is available: it
 captures eligible occurrences and refreshes the local Obsidian index, then
 reports the target state without fabricating a remote success. The final
 `install-agent` step is intentionally separate so code review and canary testing

--- a/docs/source-reliability.md
+++ b/docs/source-reliability.md
@@ -34,6 +34,11 @@ runs one check, takes a non-blocking lock, persists a small private state file,
 and exits. If `WE_GROUPCHAT_OBSIDIAN_DATA_DIR` is set when the plist is built,
 the LaunchAgent preserves that override explicitly.
 
+When `dist/WeGroupchatObsidian.app` exists, the plist invokes its
+`--source-guard-run` one-shot mode so macOS attributes protected-folder access
+to the stable project app identity. Source-only installations retain the
+`.venv/bin/python scripts/wechat_source_guard_agent.py` fallback.
+
 Process-list availability is proven by inspecting the guard process itself; it
 does not depend on whether a normal user session can see the system `launchd`.
 Source freshness uses exact stats for cached known `message/` shard paths and
@@ -271,6 +276,8 @@ the worker never recreates a missing mount path.
 .venv/bin/python scripts/resource_backup.py set-target "<existing-mounted-directory>"
 .venv/bin/python scripts/resource_backup.py set-link-export-mode redacted
 .venv/bin/python scripts/resource_backup.py init
+.venv/bin/python scripts/resource_backup.py backfill --all
+.venv/bin/python scripts/resource_backup.py backfill --all --apply
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD --apply
 .venv/bin/python scripts/resource_backup.py status
@@ -281,7 +288,10 @@ the worker never recreates a missing mount path.
 
 `init` seeds from-now cursors only. Re-selecting a removed chat creates a new
 private selection epoch and skips the unselected gap. Historical backfill is a
-separate dry-plan/apply command and does not move live cursors. `run` captures deterministic occurrences,
+separate dry-plan/apply command and does not move live cursors. `backfill --all`
+starts at timestamp zero and therefore means all history still available in the
+known local WeChat message shards, not an assurance about provider-retained
+remote history. `run` captures deterministic occurrences,
 resolves due files into the shared CAS, refreshes local Obsidian indexes even
 when the target is unavailable, and then attempts mounted handoff.
 
@@ -328,7 +338,9 @@ short-lived scheduler can be installed explicitly:
 
 The agent uses `RunAtLoad` plus `StartInterval`, `ProcessType=Background`, and
 `LowPriorityIO`, with no `KeepAlive`. Each wake runs one bounded process and
-exits. Installing it is an activation action; merging source does not install it.
+exits. When the local app bundle exists it invokes `--resource-backup-run`
+through that executable; source-only installs retain the Python CLI fallback.
+Installing it is an activation action; merging source does not install it.
 
 ## 5. Optional advanced direct selected-chat Google Drive API sync
 

--- a/docs/source-reliability.zh-CN.md
+++ b/docs/source-reliability.zh-CN.md
@@ -30,6 +30,11 @@ Source guard 默认关闭。开启 policy、安装 LaunchAgent plist、加载 La
 写入很小的私有 state，然后退出。构建 plist 时如果设置了
 `WE_GROUPCHAT_OBSIDIAN_DATA_DIR`，LaunchAgent 会显式保留这个 override。
 
+如果 `dist/WeGroupchatObsidian.app` 已存在，plist 会调用它的
+`--source-guard-run` one-shot mode，让 macOS 把 protected-folder access 归到稳定的项目 app
+identity。纯 source 安装继续使用 `.venv/bin/python scripts/wechat_source_guard_agent.py`
+fallback。
+
 Process-list availability 通过读取 guard 当前进程自身来证明，不依赖普通用户 session
 能否看见系统级 `launchd`。Source freshness 只对 cached key inventory 中已知的
 `message/` shard 路径及其 WAL/SHM siblings 做 exact stat；它不会递归遍历 DB root 或
@@ -238,6 +243,8 @@ worker 不会在 mount 缺失时把那个路径重新创建成普通本地目录
 .venv/bin/python scripts/resource_backup.py set-target "<已经存在的挂载目录>"
 .venv/bin/python scripts/resource_backup.py set-link-export-mode redacted
 .venv/bin/python scripts/resource_backup.py init
+.venv/bin/python scripts/resource_backup.py backfill --all
+.venv/bin/python scripts/resource_backup.py backfill --all --apply
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD
 .venv/bin/python scripts/resource_backup.py backfill --from YYYY-MM-DD --apply
 .venv/bin/python scripts/resource_backup.py status
@@ -247,7 +254,9 @@ worker 不会在 mount 缺失时把那个路径重新创建成普通本地目录
 ```
 
 `init` 只初始化 from-now cursors。停选后重新选择会建立新的 private selection epoch，不会吞回停选 gap；
-历史 backfill 是独立 dry-plan/apply 命令，也不会移动 live cursor。`run` 捕获 deterministic occurrences、把 due files resolve 到共享
+历史 backfill 是独立 dry-plan/apply 命令，也不会移动 live cursor。`backfill --all` 从 timestamp zero
+开始，表示扫描 known local WeChat message shards 中仍然可读的全部历史，并不保证 provider 远端仍保留
+更早内容。`run` 捕获 deterministic occurrences、把 due files resolve 到共享
 CAS、即使 target 不可用也继续刷新本地 Obsidian index，然后才尝试 mounted handoff。
 
 ```text
@@ -282,7 +291,9 @@ Ordinary status 只有在 current catalog、target objects、有效 latest `COMP
 ```
 
 Agent 使用 `RunAtLoad + StartInterval`、`ProcessType=Background`、`LowPriorityIO`，没有 `KeepAlive`；
-每次 wake 只运行一个 bounded process 然后退出。安装是 activation action，merge source 不会自动安装。
+每次 wake 只运行一个 bounded process 然后退出。本地 app bundle 存在时调用它的
+`--resource-backup-run` mode；纯 source 安装保留 Python CLI fallback。安装是 activation action，
+merge source 不会自动安装。
 
 ## 5. 可选 advanced selected-chat Google Drive API 直传
 

--- a/scripts/resource_backup.py
+++ b/scripts/resource_backup.py
@@ -113,7 +113,13 @@ def build_parser():
     sub.add_parser("init")
     sub.add_parser("scan")
     backfill = sub.add_parser("backfill")
-    backfill.add_argument("--from", dest="from_date", required=True)
+    backfill_scope = backfill.add_mutually_exclusive_group(required=True)
+    backfill_scope.add_argument("--from", dest="from_date")
+    backfill_scope.add_argument(
+        "--all",
+        action="store_true",
+        help="Scan all locally available history for the selected chats.",
+    )
     backfill.add_argument("--apply", action="store_true")
     resolve = sub.add_parser("resolve")
     resolve.add_argument("--limit", type=int, default=50)
@@ -231,7 +237,8 @@ def main(argv=None):
         result = _capture(config, source=True).scan()
     elif args.command == "backfill":
         result = _capture(config, source=True).backfill(
-            _from_timestamp(args.from_date), apply=args.apply
+            0 if args.all else _from_timestamp(args.from_date),
+            apply=args.apply,
         )
     elif args.command == "resolve":
         result = _capture(config).resolve_pending_files(limit=max(1, args.limit))

--- a/scripts/wechat_source_guard.py
+++ b/scripts/wechat_source_guard.py
@@ -16,6 +16,11 @@ if str(PROJECT_DIR) not in sys.path:
     sys.path.insert(0, str(PROJECT_DIR))
 
 from core.config import DATA_DIR, load_config, save_config
+from core.background_jobs import (
+    SOURCE_GUARD_MODE,
+    background_program_arguments,
+    runtime_identity,
+)
 from core.launch_agent import launch_agent_status
 from core.project_identity import SOURCE_GUARD_LAUNCH_AGENT_LABEL
 from core.wechat_source_guard import (
@@ -35,9 +40,14 @@ def build_agent_plist(config: dict, project_dir: Path = PROJECT_DIR) -> dict:
     interval = int(config.get("wechat_source_guard_interval_seconds", 300) or 300)
     python = project_dir / ".venv" / "bin" / "python"
     entrypoint = project_dir / "scripts" / "wechat_source_guard_agent.py"
+    program_arguments, _runtime_identity = background_program_arguments(
+        project_dir,
+        SOURCE_GUARD_MODE,
+        [str(python), str(entrypoint)],
+    )
     payload = {
         "Label": SOURCE_GUARD_LAUNCH_AGENT_LABEL,
-        "ProgramArguments": [str(python), str(entrypoint)],
+        "ProgramArguments": program_arguments,
         "WorkingDirectory": str(project_dir),
         "RunAtLoad": True,
         "StartInterval": interval,
@@ -122,6 +132,14 @@ def print_status(config: dict) -> int:
     process_state = "unknown" if process is None else "running" if process else "absent"
     plist = agent_plist_path()
     agent = launch_agent_status(SOURCE_GUARD_LAUNCH_AGENT_LABEL)
+    agent_identity = "not_installed"
+    try:
+        with plist.open("rb") as handle:
+            payload = plistlib.load(handle)
+        agent_identity = runtime_identity(payload.get("ProgramArguments") or [])
+    except (OSError, plistlib.InvalidFileException, TypeError, ValueError):
+        if plist.is_file():
+            agent_identity = "unknown"
     print("WeChat source guard")
     print(f"  enabled: {report['enabled']}")
     print(f"  state: {report['state']}")
@@ -134,6 +152,7 @@ def print_status(config: dict) -> int:
     print(f"  source freshness: {report.get('source_freshness') or 'unknown'}")
     print(f"  agent installed: {plist.exists()}")
     print(f"  agent loaded: {agent.loaded}")
+    print(f"  agent runtime identity: {agent_identity}")
     return 0
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ OPTIONS = {
         "anthropic",
         "openai",
         "requests",
+        "scripts",
         "objc",
         "ai",
         "core",

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch
+
+from core.background_jobs import dispatch_background_job, runtime_identity
+
+
+class BackgroundJobDispatchTests(unittest.TestCase):
+    def test_runtime_identity_distinguishes_app_bundle_from_python(self):
+        self.assertEqual(
+            runtime_identity(["/tmp/App.app/Contents/MacOS/App", "--job"]),
+            "app_bundle",
+        )
+        self.assertEqual(runtime_identity(["/tmp/.venv/bin/python", "job.py"]), "python")
+
+    def test_non_background_invocation_leaves_menu_app_startup_alone(self):
+        self.assertIsNone(dispatch_background_job(["--autostart"]))
+
+    def test_resource_backup_mode_runs_one_shot_without_menu_app(self):
+        with patch("scripts.resource_backup.main", return_value=7) as main:
+            result = dispatch_background_job(["--resource-backup-run"])
+
+        self.assertEqual(result, 7)
+        main.assert_called_once_with(["run"])
+
+    def test_source_guard_mode_runs_one_shot_without_menu_app(self):
+        with patch("scripts.wechat_source_guard_agent.main", return_value=3) as main:
+            result = dispatch_background_job(["--source-guard-run"])
+
+        self.assertEqual(result, 3)
+        main.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resource_backup.py
+++ b/tests/test_resource_backup.py
@@ -282,7 +282,7 @@ class ResourceBackupTests(unittest.TestCase):
         self.assertEqual(len(copied_files), 2)
         self.assertFalse(any(unselected_digest in path for path in copied_files))
 
-    def test_resource_index_groups_coobserved_links_and_files_without_copying_bytes(self):
+    def test_resource_index_is_a_light_resource_list_without_sender_or_ledger_details(self):
         capture = self._ready_capture()
         backup = self._backup(capture)
         backup.run()
@@ -305,16 +305,50 @@ class ResourceBackupTests(unittest.TestCase):
         self.assertEqual(len(month_files), 1)
         with open(month_files[0], encoding="utf-8") as handle:
             text = handle.read()
-        self.assertIn("同条消息共同出现，内容关联未确认", text)
-        self.assertIn("https://example.com/A?token=secret-value", text)
-        self.assertIn("report.pdf", text)
-        self.assertIn("Drive handoff：sync_delegated", text)
+        self.assertIn(
+            "[https://example.com/A?token=secret-value]"
+            "(<https://example.com/A?token=secret-value>)",
+            text,
+        )
+        self.assertIn("📎 [report.pdf]", text)
+        self.assertNotIn("Faye", text)
+        self.assertNotIn("URL identity", text)
+        self.assertNotIn("SHA-256", text)
+        self.assertNotIn("Drive handoff", text)
+        self.assertNotIn("同条消息共同出现", text)
+        self.assertNotIn("source_message_id", text)
         vault_files = [
             os.path.join(dirpath, filename)
             for dirpath, _dirs, filenames in os.walk(self.obsidian_root)
             for filename in filenames
         ]
         self.assertTrue(all(path.endswith(".md") for path in vault_files))
+
+    def test_resource_index_prefers_observed_title_and_uses_exact_url_as_fallback(self):
+        capture = self._ready_capture()
+        rows = capture.occurrences()
+        links = [row for row in rows if row["kind"] == "link"]
+        links[0]["original_name"] = "Observed title"
+        links[1]["original_name"] = ""
+        backup = self._backup(capture)
+
+        text = backup._render_month(
+            "猫猫研究群",
+            "2026-08",
+            links,
+            {},
+            target_view=False,
+        )
+
+        self.assertIn(
+            "[Observed title](<https://example.com/A?token=secret-value>)",
+            text,
+        )
+        self.assertIn(
+            "[https://example.com/a?x=1](<https://example.com/a?x=1>)",
+            text,
+        )
+        self.assertNotIn("[链接]", text)
 
     def test_resource_indexes_have_a_discoverable_scope_root(self):
         capture = self._ready_capture()
@@ -1256,6 +1290,25 @@ class ResourceBackupCliTests(unittest.TestCase):
     def test_source_unavailable_is_a_local_state_not_system_exit(self):
         with patch.object(resource_backup_cli, "get_cached_keys", return_value={}):
             self.assertIsNone(resource_backup_cli._source({"db_dir": ""}))
+
+    def test_backfill_all_is_an_explicit_all_history_plan(self):
+        output = io.StringIO()
+        capture = unittest.mock.Mock()
+        capture.backfill.return_value = {
+            "state": "planned",
+            "discovered_links": 3,
+            "inserted_links": 0,
+        }
+        with (
+            patch.object(resource_backup_cli, "load_config", return_value=self.config),
+            patch.object(resource_backup_cli, "_capture", return_value=capture),
+            redirect_stdout(output),
+        ):
+            result = resource_backup_cli.main(["backfill", "--all"])
+
+        self.assertEqual(result, 0)
+        capture.backfill.assert_called_once_with(0, apply=False)
+        self.assertEqual(json.loads(output.getvalue())["state"], "planned")
 
     def test_cli_run_with_source_unavailable_still_handoffs(self):
         output = io.StringIO()

--- a/tests/test_resource_backup_launch_agent.py
+++ b/tests/test_resource_backup_launch_agent.py
@@ -22,6 +22,20 @@ class ResourceBackupLaunchAgentTests(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def make_app(self):
+        executable = (
+            self.project
+            / "dist"
+            / "WeGroupchatObsidian.app"
+            / "Contents"
+            / "MacOS"
+            / "WeGroupchatObsidian"
+        )
+        executable.parent.mkdir(parents=True)
+        executable.write_text("#!/bin/sh\n", encoding="utf-8")
+        executable.chmod(0o755)
+        return executable
+
     def tearDown(self):
         self.tmp.cleanup()
 
@@ -30,6 +44,7 @@ class ResourceBackupLaunchAgentTests(unittest.TestCase):
         return subprocess.CompletedProcess([], returncode, stdout="", stderr=stderr)
 
     def test_install_writes_short_lived_background_agent_without_keepalive(self):
+        executable = self.make_app()
         with (
             patch.object(launch_agent.Path, "home", return_value=self.home),
             patch.object(launch_agent, "DATA_DIR", str(self.data_dir)),
@@ -45,6 +60,7 @@ class ResourceBackupLaunchAgentTests(unittest.TestCase):
 
         self.assertEqual(result["state"], "installed")
         self.assertEqual(result["interval_seconds"], 60)
+        self.assertEqual(result["runtime_identity"], "app_bundle")
         self.assertTrue(plist_path.is_file())
         with plist_path.open("rb") as handle:
             payload = plistlib.load(handle)
@@ -52,7 +68,10 @@ class ResourceBackupLaunchAgentTests(unittest.TestCase):
             payload["Label"],
             launch_agent.RESOURCE_BACKUP_LAUNCH_AGENT_LABEL,
         )
-        self.assertEqual(payload["ProgramArguments"][-1], "run")
+        self.assertEqual(
+            payload["ProgramArguments"],
+            [str(executable.resolve()), "--resource-backup-run"],
+        )
         self.assertEqual(payload["WorkingDirectory"], str(self.project.resolve()))
         self.assertTrue(payload["RunAtLoad"])
         self.assertEqual(payload["StartInterval"], 60)
@@ -67,6 +86,23 @@ class ResourceBackupLaunchAgentTests(unittest.TestCase):
         self.assertEqual(run.call_args_list[0].args[0], "launchctl")
         self.assertEqual(run.call_args_list[0].args[1], "bootout")
         self.assertEqual(run.call_args_list[1].args[1], "bootstrap")
+
+    def test_install_falls_back_to_source_python_when_no_app_bundle_exists(self):
+        with (
+            patch.object(launch_agent.Path, "home", return_value=self.home),
+            patch.object(launch_agent, "DATA_DIR", str(self.data_dir)),
+            patch.object(launch_agent, "_run", return_value=self.completed()),
+        ):
+            result = launch_agent.install(self.project, interval_seconds=300)
+            with launch_agent.plist_path().open("rb") as handle:
+                payload = plistlib.load(handle)
+
+        self.assertEqual(result["runtime_identity"], "python")
+        self.assertTrue(payload["ProgramArguments"][0].endswith("/python"))
+        self.assertTrue(
+            payload["ProgramArguments"][1].endswith("scripts/resource_backup.py")
+        )
+        self.assertEqual(payload["ProgramArguments"][2], "run")
 
     def test_install_fails_without_publishing_a_loaded_state(self):
         responses = [self.completed(), self.completed(1, "bootstrap failed")]
@@ -98,6 +134,7 @@ class ResourceBackupLaunchAgentTests(unittest.TestCase):
         self.assertEqual(status["state"], "loaded")
         self.assertTrue(status["installed"])
         self.assertTrue(status["loaded"])
+        self.assertEqual(status["runtime_identity"], "python")
         self.assertEqual(removed["state"], "uninstalled")
         self.assertEqual(removed_again["state"], "uninstalled")
         self.assertFalse(plist_path.exists())

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -42,6 +42,9 @@ class SetupPy2AppTests(unittest.TestCase):
     def test_py2app_does_not_package_repository_tests(self):
         self.assertNotIn("tests", self._setup_options()["packages"])
 
+    def test_py2app_packages_background_cli_dispatch_targets(self):
+        self.assertIn("scripts", self._setup_options()["packages"])
+
     def test_setup_py_keeps_dependencies_in_requirements_file(self):
         keywords = self._setup_call_keywords()
 

--- a/tests/test_wechat_source_guard.py
+++ b/tests/test_wechat_source_guard.py
@@ -269,14 +269,39 @@ class SourceGuardLaunchAgentTests(unittest.TestCase):
     def test_plist_is_one_shot_start_interval_without_keepalive(self):
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
+            executable = (
+                project
+                / "dist"
+                / "WeGroupchatObsidian.app"
+                / "Contents"
+                / "MacOS"
+                / "WeGroupchatObsidian"
+            )
+            executable.parent.mkdir(parents=True)
+            executable.write_text("#!/bin/sh\n", encoding="utf-8")
+            executable.chmod(0o755)
             payload = build_agent_plist(
                 {"wechat_source_guard_interval_seconds": 420},
                 project_dir=project,
             )
         self.assertEqual(payload["StartInterval"], 420)
         self.assertNotIn("KeepAlive", payload)
+        self.assertEqual(
+            payload["ProgramArguments"],
+            [str(executable.resolve()), "--source-guard-run"],
+        )
+
+    def test_plist_falls_back_to_source_python_without_app_bundle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            payload = build_agent_plist({}, project_dir=project)
+
         self.assertTrue(payload["ProgramArguments"][0].endswith("/.venv/bin/python"))
-        self.assertTrue(payload["ProgramArguments"][1].endswith("/scripts/wechat_source_guard_agent.py"))
+        self.assertTrue(
+            payload["ProgramArguments"][1].endswith(
+                "/scripts/wechat_source_guard_agent.py"
+            )
+        )
 
     def test_plist_preserves_explicit_data_dir_override(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- render selected-resource Markdown as a lightweight day/time link and file index with exact-URL fallback
- prefer the py2app identity for scheduled source/resource one-shots
- add explicit all-local-history backfill and update bilingual operator contracts

## Validation
- 90 focused tests passed
- 746 public full-suite tests passed from /tmp
- public defaults remain qwen, blank model, empty selected chats, and direct Drive sync disabled
- diff privacy scan found no new machine/chat identifiers
- sanitized share ZIP contains the new background dispatcher/tests and no runtime/build artifacts