### PR TITLE
Add Windows compatibility preview

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 ## Source ownership
 
-- `app.py` is the macOS menu-bar and py2app application entrypoint.
+- `app.py` is the shared macOS menu-bar / Windows tray application entrypoint
+  and remains the py2app target on macOS. `ui/windows_rumps.py` is only a thin
+  compatibility surface; do not fork the application workflow by platform.
 - `mcp_server.py` is the direct FastMCP entrypoint.
 - `setup.py` is the py2app packaging entrypoint. These are the only Python
   files that belong at repository root.
@@ -13,11 +15,18 @@
   saves or non-atomic config writes. `core/app_runtime.py` owns the menu-app
   process singleton.
 - `ai/` owns provider adapters; `ui/` owns reusable UI components.
+- Windows platform boundaries live in narrowly named `core/windows_*.py` or
+  generic `core/platform_*.py` adapters. Windows raw-key import must feed the
+  original verified per-database key map and `WeChatDB` decryption path. The raw
+  key may be retained only after explicit autostart enrollment and only in
+  Windows Credential Manager; never place it in config, logs, task arguments or
+  the repository, and never replace the canonical database/summary implementation.
 - `scripts/` contains thin operator entrypoints and compatibility cleanup
   commands. Put
   reusable behavior in the owning package rather than duplicating it in a CLI.
-- Source-guard and mounted-resource timers run inside the long-lived py2app
-  menu-bar process. macOS App Data consent is process-lifetime access, so their
+- Source-guard and mounted-resource timers run inside the long-lived menu-bar
+  process on supported platforms. Source guard and its App Data consent contract
+  are macOS-only, so Windows must keep that timer disabled. Their
   retired short-lived LaunchAgent modes must remain no-op cleanup surfaces and
   must not be reintroduced as Python or app-bundle interval workers.
 - Explicit resource CLI source operations remain operator entrypoints, but app
@@ -28,6 +37,13 @@
 - `launchers/` owns the canonical Finder-friendly `.command` entrypoints. The
   root `启动.command` is a compatibility stub for deployed source-mode
   LaunchAgents and must not grow a second implementation.
+- `launchers/启动.ps1` owns Windows setup/start orchestration and root `启动.cmd`
+  is its thin double-click stub. Keep `.cmd` as UTF-8 without BOM plus CRLF and
+  `.ps1` as UTF-8 with BOM plus CRLF for Windows PowerShell 5.1/non-ASCII paths.
+  Windows login autostart is a current-user Task Scheduler definition managed
+  only by `scripts/windows_autostart.py`; it must keep duplicate instances out,
+  use bounded abnormal-exit restart, and contain no credential. Implementation
+  and verification must not silently install it.
 - `tests/` is an importable unittest package. New tests belong there and use
   `tests.<module>` for focused invocation.
 
@@ -70,6 +86,19 @@ Run from repository root:
 .venv/bin/python -m compileall -q app.py mcp_server.py setup.py ai core ui scripts tests
 for launcher in 启动.command launchers/*.command; do bash -n "$launcher"; done
 ```
+
+On Windows, also run from the checkout root:
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest tests.test_windows_key_extractor tests.test_windows_rumps tests.test_windows_launcher tests.test_windows_autostart tests.test_windows_runtime tests.test_windows_console
+.\.venv\Scripts\python.exe -m compileall -q app.py mcp_server.py setup.py ai core ui scripts tests
+cmd.exe /d /c "启动.cmd --setup-only --yes --no-pause"
+```
+
+Windows source acceptance is separate from synthetic decryption coverage: the
+privacy-safe readiness command may exit `2` until the operator privately supplies
+a valid raw key. Never print or commit raw keys, page keys, account paths, chat
+content or runtime config while diagnosing that gate.
 
 Use focused `tests.<module>` runs while iterating, then the full suite for
 shared code, packaging, public-boundary or runtime changes. Source completion,

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 Local-first WeChat group chat summaries, monitor review, and Obsidian knowledge output.
 
-Status: functional, source-distributed macOS application. It has a menu-bar app,
-MCP server, operator CLIs, durable local state, recovery/backup workers and a
-full regression suite; review the data-flow and account-safety notes before
-using it on real chat data. A bundled Python runtime or signed installer is not
-currently distributed.
+Status: functional, source-distributed macOS application with a Windows 4.x
+compatibility preview. The original database, summary, monitor, Obsidian and MCP
+flows remain canonical; the Windows layer supplies source discovery, verified
+database-key derivation, a tray adapter, Credential Manager storage and native
+launch/autostart entrypoints. Review the platform limits and account-safety
+notes before using real chat data. No bundled Python runtime or signed installer
+is currently distributed.
 
-A local-first macOS tool for reading your own WeChat desktop database, summarizing group chats, searching messages, and turning high-value group-chat updates into an Obsidian-friendly Markdown knowledge base.
+A local-first desktop tool for reading your own WeChat database, summarizing group chats, searching messages, and turning high-value group-chat updates into an Obsidian-friendly Markdown knowledge base.
 
-This is not official WeChat/Tencent software, not a WeChat bot, not employee-monitoring software, and not fully offline when you enable cloud AI, remote link preview, or MCP sending. It does not use a WeChat API, does not run a remote service, and does not send your chat history to this project. The app reads local database files on your Mac and calls the AI provider you configure.
+This is not official WeChat/Tencent software, not a WeChat bot, not employee-monitoring software, and not fully offline when you enable cloud AI, remote link preview, or MCP sending. It does not use a WeChat API, does not run a remote service, and does not send your chat history to this project. The app reads local database files on your computer and calls the AI provider you configure.
 
 Project lineage: this standalone derivative builds on [Qizhan7/mac-wechat-summary](https://github.com/Qizhan7/mac-wechat-summary), which established the local macOS menu-bar summary and MCP foundation. This repository is not connected through GitHub's fork network and is not maintained as an upstream pull-request branch; it continues as a separate local-first Obsidian workflow project. See [NOTICE.md](NOTICE.md).
 
@@ -176,7 +178,7 @@ independently deployed microservices. Editable sources:
 ## Privacy and Safety
 
 - Runtime data is local by default: `~/.we-groupchat-obsidian/`.
-- API keys are stored in macOS Keychain, not in the repo.
+- API keys are stored in macOS Keychain or Windows Credential Manager, not in the repo.
 - WeChat database keys, logs, SQLite files, Markdown exports, and `.venv/` should never be committed.
 - The attachment catalog, local archive, source-guard state/receipts, and backup
   snapshot manifests/catalogs are private runtime data. Archive objects contain the original
@@ -187,7 +189,7 @@ independently deployed microservices. Editable sources:
   filesystem snapshot backend still has no provider API and cannot verify
   provider-side upload.
 - Direct Google Drive sync is a different opt-in backend. It requests only the
-  `drive.file` OAuth scope. The refresh token stays in macOS Keychain; access
+  `drive.file` OAuth scope. The refresh token stays in the platform credential store; access
   tokens stay in memory; the user's Installed desktop app OAuth client JSON is
   copied to private runtime storage with mode `0600` and must never be
   committed. For selected chats, the configured stable alias, file name, and
@@ -243,10 +245,9 @@ quick-start file and omits internal handoff docs such as
 
 ## Requirements
 
-- macOS 12+
+- macOS 12+ with WeChat for macOS, or Windows with Weixin 4.x
 - Python 3.10+
-- WeChat for macOS, logged in
-- Xcode Command Line Tools
+- Xcode Command Line Tools on macOS only
 - One AI provider API key, or local Ollama
 - Obsidian is optional
 
@@ -256,6 +257,8 @@ When DeepSeek is selected without an explicit `ai_model`, the current default
 is `deepseek-v4-flash`; a different compatible model can still be configured.
 
 ## Quick Start
+
+### macOS
 
 ```bash
 git clone https://github.com/IndelibleVivi/we-groupchat-obsidian.git
@@ -275,6 +278,56 @@ If WeChat was updated or key extraction needs a fresh authorization:
 ./启动.command --allow-wechat-resign
 ```
 
+### Windows compatibility preview
+
+```powershell
+git clone https://github.com/IndelibleVivi/we-groupchat-obsidian.git
+cd we-groupchat-obsidian
+.\启动.cmd
+```
+
+The launcher uses the checkout-local `.venv`, asks before installing or updating
+dependencies, auto-detects a Weixin 4.x `db_storage` root, and starts the same
+`app.py` through a Windows tray adapter. Windows PowerShell 5.1 and non-ASCII
+checkout paths are supported by the checked-in launcher encoding contract.
+
+Current Windows Weixin databases still need the account's 64-hex-character
+`raw key`. WGO deliberately does not download, bundle, or execute a third-party
+key extractor. Obtain the raw key using a tool and method you independently
+trust and are authorized to use, then enter it privately when the launcher asks,
+or run:
+
+```powershell
+.\启动.cmd --refresh-data-source
+```
+
+The raw key is read with masked input, is not accepted as a command-line value,
+and is never written to config, logs or Task Scheduler arguments. An ordinary
+refresh uses it only in memory. WGO derives a key for each existing database,
+accepts only keys that pass the original page-HMAC verification, and stores only
+that verified per-database map under the current user's protected runtime
+directory. A wrong raw key fails without replacing the existing map.
+
+`--install-autostart` is the explicit exception to non-retention: it first asks
+for and fully verifies the raw key, then stores it in Windows Credential Manager
+and creates a current-user Task Scheduler logon task. The task ignores duplicate
+instances and retries an abnormal exit up to three times at one-minute intervals.
+At startup, or when required database shards appear, WGO can use that remembered
+credential to re-derive and verify page keys without prompting. Autostart never
+silently updates a changed Python environment. Here, automatic renewal means
+deriving new database-shard page keys from the remembered raw key; WGO does not
+scan process memory or guess a rotated raw key. If the account raw key changes,
+run `--install-autostart` again to replace it through masked input. Run `启动.cmd`
+manually after a dependency change. `--uninstall-autostart` removes both the task
+and the remembered raw key while leaving already derived page keys untouched.
+
+Windows preview scope currently includes encrypted-source reading, tray summary
+and search, monitor/Obsidian output, MCP read tools, Unicode clipboard support,
+Windows Credential Manager and per-user login autostart. macOS WeChat re-signing,
+source guard, notification-click routing, real MCP UI sending, py2app packaging,
+and the advanced attachment/mounted-backup lanes remain macOS-only or
+macOS-validated; they are not claimed as Windows-supported.
+
 ### Documentation map
 
 - `README.md` / `README.zh-CN.md`: current user, operator, privacy, and project
@@ -288,6 +341,20 @@ If WeChat was updated or key extraction needs a fresh authorization:
   selection, projection, handoff, status, and failure semantics.
 
 ## Useful Commands
+
+Windows entrypoints:
+
+| Command | Purpose |
+| --- | --- |
+| `.\启动.cmd` | Check/install with consent, initialize the data source if needed, and start the tray app |
+| `.\启动.cmd --setup-only` | Check dependencies and print a privacy-safe source readiness summary |
+| `.\启动.cmd --health-check` | Run the Windows source readiness check |
+| `.\启动.cmd --refresh-data-source` | Privately prompt for the raw key and rebuild verified per-database keys |
+| `.\启动.cmd --install-autostart` | Verify/remember the raw key, then install current-user login start and bounded crash restart |
+| `.\启动.cmd --uninstall-autostart` | Remove the scheduled task and remembered raw key |
+| `.\启动.cmd --autostart-status` | Inspect the Windows scheduled task |
+
+macOS entrypoints:
 
 The canonical Finder helpers live in `launchers/` and can be double-clicked or
 run from Terminal. The root `启动.command` remains as the single compatibility
@@ -448,7 +515,7 @@ are written.
 
 The mounted target has a separate human-facing entrypoint at
 `<target>/wgo-resource-backup/00-打开微信资源备份.md`; the menu-bar command
-`📂 在 Finder 打开文件备份` reveals it directly. Its `文件备份` pages contain
+`📂 在文件夹中显示文件备份` reveals it directly. Its `文件备份` pages contain
 only delivered files, grouped by selected chat and month; each digest appears
 once with its occurrence count and links to the existing CAS object. A separate
 `待补齐附件` family groups queued, cache-unavailable, retry, local-space,
@@ -662,19 +729,20 @@ Real sends use a two-step confirmation flow. First call `prepare_send_message(te
 ## Repository Layout
 
 ```text
-app.py                   # macOS menu-bar application entrypoint
+app.py                   # shared menu-bar/tray application entrypoint
 mcp_server.py            # FastMCP server entrypoint
 setup.py                 # py2app packaging entrypoint
 ai/                      # replaceable AI provider adapters
 core/                    # domain logic, durable state, privacy and reliability contracts
-ui/                      # reusable UI components
+ui/                      # reusable UI components and Windows rumps adapter
 scripts/                 # thin operator entrypoints and legacy-agent cleanup
-launchers/               # canonical Finder-friendly .command entrypoints
+launchers/               # canonical macOS .command and Windows PowerShell entrypoints
 tests/                   # importable unittest package
 c_src/                   # macOS WeChat key scanner
 resources/               # app and menu-bar assets
 docs/                    # user, operator, architecture and formal-contract documentation
 启动.command             # root compatibility stub for existing installs/LaunchAgents
+启动.cmd                 # Windows double-click compatibility stub
 ```
 
 The three root-level Python files are deliberate application/build entrypoints,
@@ -732,6 +800,14 @@ surfaces target installed executables and a standalone bundle instead.
 .venv/bin/python -m unittest -v tests.test_resource_backup
 .venv/bin/python -m compileall -q app.py mcp_server.py setup.py ai core ui scripts tests
 for launcher in 启动.command launchers/*.command; do bash -n "$launcher"; done
+```
+
+On Windows, use the exact checkout interpreter and verify the native launcher:
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest tests.test_windows_key_extractor tests.test_windows_rumps tests.test_windows_launcher tests.test_windows_autostart tests.test_windows_runtime tests.test_windows_console
+.\.venv\Scripts\python.exe -m compileall -q app.py mcp_server.py setup.py ai core ui scripts tests
+cmd.exe /d /c "启动.cmd --setup-only --yes --no-pause"
 ```
 
 ## What Changed in This Fork

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,19 +2,21 @@
 
 本地优先的微信群聊总结、关注推送与 Obsidian 知识库工具。
 
-当前状态：可完整运行的 source-distributed macOS app。它已经拥有菜单栏 app、MCP Server、
-operator CLI、持久化本地状态、recovery/backup workers 和完整 regression suite；请先读完
-数据流和账号安全边界，再在真实聊天数据上使用。当前不分发 bundled Python runtime
-或已签名 installer。
+当前状态：可完整运行的 source-distributed macOS app，并提供 Windows 微信 4.x 适配预览。
+原有数据库、总结、关注推送、Obsidian 与 MCP 主链仍是 canonical implementation；Windows
+只补 source discovery、经验证的逐库密钥派生、托盘适配、凭据管理器和启动/自启边界。
+请先读完平台限制、数据流和账号安全边界，再在真实聊天数据上使用。当前不分发 bundled
+Python runtime 或已签名 installer。
 
-一个本地优先的 macOS 微信群聊总结工具。它读取你电脑上的微信本地数据库，生成群聊摘要、关键词搜索结果，并把值得关注的新消息整理成 Obsidian-friendly Markdown 笔记。
+一个本地优先的桌面微信群聊总结工具。它读取你电脑上的微信本地数据库，生成群聊摘要、关键词搜索结果，并把值得关注的新消息整理成 Obsidian-friendly Markdown 笔记。
 
-它不是微信/Tencent 官方软件，不是微信机器人，不是员工监控工具；当你启用云端 AI、远程链接预览或 MCP 发送时，它也不是完全离线工具。它不接入微信官方/非官方接口，也不会替你把聊天记录上传到项目作者的服务器。所有运行状态、数据库 key、知识库和导出文件默认都保存在你自己的 Mac 上。
+它不是微信/Tencent 官方软件，不是微信机器人，不是员工监控工具；当你启用云端 AI、远程链接预览或 MCP 发送时，它也不是完全离线工具。它不接入微信官方/非官方接口，也不会替你把聊天记录上传到项目作者的服务器。所有运行状态、数据库 key、知识库和导出文件默认都保存在你自己的电脑上。
 
 项目来源说明：本项目是基于 [Qizhan7/mac-wechat-summary](https://github.com/Qizhan7/mac-wechat-summary) 的 standalone derivative。原项目打下了 macOS 菜单栏总结、本地微信数据库读取和 MCP 访问的基础；这个仓库没有挂在 GitHub fork network 里，也不作为 upstream PR 分支维护，而是继续发展成一个独立的 local-first Obsidian workflow 项目。见 [NOTICE.md](NOTICE.md)。
 
 ![Python](https://img.shields.io/badge/Python-3.10+-blue)
-![macOS](https://img.shields.io/badge/macOS-only-lightgrey)
+![macOS](https://img.shields.io/badge/macOS-supported-brightgreen)
+![Windows](https://img.shields.io/badge/Windows-preview-yellow)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-blue)
 
 ## Obsidian 输出预览
@@ -152,7 +154,7 @@ DeepSeek 按实际 token 用量计费，输入缓存命中、输入缓存未命�
   显式授权，重启后必定归零，也不会从 config 恢复；关闭后，in-flight resolver 会在下一次读取附件
   bytes 之前取消。Links-only backfill 不读取附件 cache。
 - 聊天内容会发送给你自己配置的 AI provider。使用 Ollama 本地模型时，内容可以完全不离开本机；使用云端 provider 时，请按对应服务的隐私规则自行判断。
-- API Key 存储在 macOS Keychain，不写入 repo。
+- API Key 存储在 macOS 钥匙串或 Windows 凭据管理器，不写入 repo。
 - 本地配置、书签、monitor state、数据库 key、日志、SQLite DB 和 Markdown 导出默认在 `~/.we-groupchat-obsidian/` 或你的 Obsidian vault 中，不应该提交到 git。旧 `~/.wechat-summary/` 只作为本机 migration/compatibility 路径保留。
 - Attachment catalog、本地 archive、source-guard state/receipts 和 backup snapshot manifest/catalog 都是私有 runtime data。
   Archive object 含原始附件 bytes，绝不能提交或公开。
@@ -160,7 +162,7 @@ DeepSeek 按实际 token 用量计费，输入缓存命中、输入缓存未命�
   对应 provider 可能按自己的隐私规则接收附件 bytes 和 manifest。Filesystem snapshot backend 仍然没有
   provider API，也不能验证 provider-side upload 是否完成。
 - Direct Google Drive sync 是不同的 opt-in backend，只请求 `drive.file` OAuth scope。Refresh token 只在
-  macOS Keychain，access token 只在内存；用户自己的 Installed desktop app OAuth client JSON 会复制到
+  平台凭据存储，access token 只在内存；用户自己的 Installed desktop app OAuth client JSON 会复制到
   `0600` private runtime storage，绝不能提交。被选群聊的 configured stable alias、文件名与文件 bytes 会
   上传到用户自己的 Drive；raw `@chatroom` username、消息 body/XML、`source_message_id`、`wxid` 与
   WeChat cache path 不进入 Drive metadata。程序不删除 Drive 文件、微信 cache 或本地 CAS object。
@@ -200,11 +202,11 @@ internal continuity docs。
 
 ### 前置条件
 
-- macOS 12+
+- macOS 12+ 与 macOS 微信，或 Windows 与 Windows 微信 4.x
 - Python 3.10+
-- 微信桌面版，并已登录
+- 微信桌面版已登录并完成本地数据同步
 - 至少一个 AI provider API Key，或本地 Ollama
-- Xcode Command Line Tools，用于编译 key scanner
+- Xcode Command Line Tools 仅 macOS 需要，用于编译 key scanner
 - Obsidian 可选；只想生成 Markdown 文件时不需要安装
 
 支持的 AI provider：
@@ -218,7 +220,7 @@ internal continuity docs。
 选择 DeepSeek 且没有显式填写 `ai_model` 时，当前默认使用
 `deepseek-v4-flash`；仍可在配置中指定其他兼容 model。
 
-### 快速开始
+### macOS 快速开始
 
 ```bash
 git clone https://github.com/IndelibleVivi/we-groupchat-obsidian.git
@@ -236,6 +238,46 @@ cd we-groupchat-obsidian
 
 这一步可能会退出微信，并要求输入 Mac 登录密码。输入密码时终端不显示字符是正常的。
 
+### Windows 适配预览
+
+```powershell
+git clone https://github.com/IndelibleVivi/we-groupchat-obsidian.git
+cd we-groupchat-obsidian
+.\启动.cmd
+```
+
+Windows 启动器只使用当前 checkout 的 `.venv`，首次安装或依赖变化时先征求同意；它会
+自动发现 Windows 微信 4.x 的 `db_storage`，再通过 Windows 托盘 adapter 启动同一份
+`app.py`。仓库固定了 `.cmd` 的 CRLF 和 `.ps1` 的 UTF-8 BOM/CRLF，兼容 Windows
+PowerShell 5.1 与含中文的 checkout path。
+
+Windows 微信 4.x 的加密数据库仍需要当前账户的 64 位十六进制 `raw key`。WGO 不会
+下载、捆绑或执行第三方 key extractor；请只使用你独立信任、确认有权使用的方法取得
+raw key，然后在启动器的遮蔽输入框中输入，或运行：
+
+```powershell
+.\启动.cmd --refresh-data-source
+```
+
+raw key 不接受命令行明文参数，也绝不写入 config、log 或计划任务参数。普通刷新只在
+内存中为已有数据库逐个派生页密钥。WGO 继续使用原实现的 page HMAC 验证，只把验证
+成功的逐库密钥 map 写入当前 Windows 用户 ACL 保护的 runtime 目录；错误 raw key 不会
+覆盖已有 map。
+
+`--install-autostart` 是普通刷新“不留存 raw key”规则的显式例外：命令会先遮蔽输入并完整验证 raw key，
+再把它保存到 Windows 凭据管理器，并创建当前用户的计划任务。任务忽略重复实例，进程异常
+退出后按一分钟间隔最多重启三次；启动或发现新增必需数据库时，WGO 可以用这份凭据自动
+重新派生并验证逐库密钥。这里的“自动续期”只指从已记住的 raw key 补齐新数据库分片；WGO 不会
+扫描内存或猜测已轮换的 raw key。如果账户 raw key 确实变了，重新运行 `--install-autostart`
+遮蔽输入并替换凭据。自启不会在后台静默升级已经变化的 Python 环境，拉取到依赖变化后
+应先手动运行一次 `启动.cmd`。`--uninstall-autostart` 会删除计划任务和被记住的 raw key，
+但不删除已经派生的逐库密钥。
+
+Windows 预览当前覆盖：加密 source 读取、托盘总结与搜索、关注推送/Obsidian 输出、
+MCP 读取、Unicode 剪贴板、Windows 凭据管理器与当前用户登录自启。macOS 微信重签名、
+source guard、通知点击跳转、MCP 真实 UI 发送、py2app 打包，以及高级附件/mounted-backup
+链仍是 macOS-only 或只在 macOS 验证；这里不把它们宣称为 Windows 已支持。
+
 ### 文档地图
 
 - `README.md` / `README.zh-CN.md`：当前用户、operator、隐私和项目概览 authority。
@@ -247,6 +289,20 @@ cd we-groupchat-obsidian
   projection、handoff、status 与 failure semantics 的 formal spec。
 
 ## 常用命令
+
+Windows 入口：
+
+| 命令 | 用途 |
+| --- | --- |
+| `.\启动.cmd` | 经同意检查/安装依赖，必要时初始化数据源，再启动托盘 app |
+| `.\启动.cmd --setup-only` | 只检查依赖并输出 privacy-safe 数据源状态 |
+| `.\启动.cmd --health-check` | 执行 Windows 数据源健康检查 |
+| `.\启动.cmd --refresh-data-source` | 遮蔽输入 raw key，重建经验证的逐库密钥 |
+| `.\启动.cmd --install-autostart` | 验证/记住 raw key，再安装当前用户登录自启与有界异常保活 |
+| `.\启动.cmd --uninstall-autostart` | 删除计划任务和记住的 raw key |
+| `.\启动.cmd --autostart-status` | 查看 Windows 计划任务状态 |
+
+macOS 入口：
 
 Canonical Finder helper 统一放在 `launchers/`，都可以双击运行或在 Terminal
 执行。根目录只保留一个极薄的 `启动.command` compatibility entrypoint，供已有
@@ -394,7 +450,7 @@ descendant 已是 symlink 或非目录，会在写 generated file 或 target byt
 
 Mounted target 另有一个真正给人打开的入口：
 `<target>/wgo-resource-backup/00-打开微信资源备份.md`；菜单栏的
-`📂 在 Finder 打开文件备份` 会直接在 Finder 中 reveal 它。入口下的 `文件备份` 页面只列文件，
+`📂 在文件夹中显示文件备份` 会直接在系统文件管理器中 reveal 它。入口下的 `文件备份` 页面只列文件，
 按显式选中的群聊与月份分组，但只收录真正 delivered 的文件；同一 digest 只出现一行，并显示它在
 群聊记录中的 occurrence 次数。独立的 `待补齐附件` family 会按尚未尝试、cache unavailable、retry、
 本地空间、需处理、awaiting handoff 与 unknown 分组，且不生成可点击 target link。Portal 同时报告
@@ -627,7 +683,7 @@ MCP 默认偏只读，但 read tools 会把本地 chat-derived data 暴露给 MC
 ## 项目结构
 
 ```text
-app.py                   # macOS 菜单栏应用入口
+app.py                   # 共享菜单栏 / 托盘应用入口
 mcp_server.py            # FastMCP Server 入口
 setup.py                 # py2app 打包入口
 ai/                      # 可替换 AI provider 适配层
@@ -642,7 +698,7 @@ core/
   wechat_source_guard.py        # 长驻 app 内的 optional source guard
   google_drive_*.py             # 独立 advanced Drive API queue/OAuth/projection
   mcp_send_*.py / sender.py     # 两步确认 policy 与可选 UI send
-ui/                      # 可复用 macOS UI 组件
+ui/                      # 可复用 UI 与 Windows rumps adapter
 scripts/
   configure_monitor.py / health_check.py / refresh_data_source.py
   backfill_history.py / catch_up_monitor.py / organize_obsidian.py
@@ -650,12 +706,13 @@ scripts/
   google_drive_file_sync.py / wechat_source_guard.py
   daily_digest.py / review_queue.py / repair_relations.py
   autostart.py / build_share_package.py
-launchers/               # canonical Finder 双击 .command entrypoints
+launchers/               # canonical macOS .command 与 Windows PowerShell entrypoints
 tests/                   # 可 import 的 unittest package
 c_src/                   # key scanner C 代码
 resources/               # 图标资源
 docs/                    # 用户、运维、架构与 formal contract 文档
 启动.command             # 已有 source install / LaunchAgent 的 root compatibility stub
+启动.cmd                 # Windows 双击 compatibility stub
 ```
 
 Repo root 只保留 `app.py`、`mcp_server.py` 与 `setup.py` 三个明确的应用/打包 entrypoint，
@@ -712,6 +769,14 @@ runtime 都使用绝对 checkout path。只有当这些表面改为 installed ex
 for launcher in 启动.command launchers/*.command; do bash -n "$launcher"; done
 ```
 
+Windows 使用 checkout 内的精确解释器并验证原生入口：
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest tests.test_windows_key_extractor tests.test_windows_rumps tests.test_windows_launcher tests.test_windows_autostart tests.test_windows_runtime tests.test_windows_console
+.\.venv\Scripts\python.exe -m compileall -q app.py mcp_server.py setup.py ai core ui scripts tests
+cmd.exe /d /c "启动.cmd --setup-only --yes --no-pause"
+```
+
 部分测试会 import macOS/AppKit 或加密相关依赖；如果本地环境卡在 import 阶段，先用上面的窄测试确认核心逻辑，再单独排查依赖。
 
 ## 常见问题
@@ -753,11 +818,11 @@ macOS 菜单栏图标太多、刘海区域或菜单栏管理工具都可能把�
 
 ## 公开仓库状态
 
-这个 repo 不应该包含个人聊天数据库、导出 Markdown、API Key、Keychain 内容、日志、`.venv`、`~/.we-groupchat-obsidian/`、legacy `~/.wechat-summary/` 或任何微信账号标识。`.gitignore` 已覆盖常见运行文件，但公开前仍建议手动检查 `git status --short` 和 secret pattern scan。
+这个 repo 不应该包含个人聊天数据库、导出 Markdown、API Key、钥匙串/凭据管理器内容、日志、`.venv`、`~/.we-groupchat-obsidian/`、legacy `~/.wechat-summary/` 或任何微信账号标识。`.gitignore` 已覆盖常见运行文件，但公开前仍建议手动检查 `git status --short` 和 secret pattern scan。
 
 ## 和原仓库相比改了什么
 
-这个 fork 没有改变原项目的核心方向：仍然是在用户自己的 Mac 上读取本地微信数据库，用用户自己配置的 AI provider 做群聊总结。这里的大部分改动来自实际使用反馈：菜单栏图标找不到怎么办，微信更新后 key 失效怎么办，LaunchAgent 显示 loaded 但没真的运行怎么办，关注推送如何避免变成噪音，Obsidian 输出怎样才能长期检索和迁移。
+这个 fork 没有改变原项目的核心方向：仍然是在用户自己的电脑上读取本地微信数据库，用用户自己配置的 AI provider 做群聊总结。这里的大部分改动来自实际使用反馈：菜单栏/托盘图标找不到怎么办，微信更新后 key 失效怎么办，后台启动显示已配置但没真的运行怎么办，关注推送如何避免变成噪音，Obsidian 输出怎样才能长期检索和迁移。
 
 - 更完整的本地运维入口：`setup-only`、健康检查、关注推送配置、刷新数据源、历史回填、整理 Obsidian 输出、安装/卸载自启动，都有 CLI 或 `.command` 入口。
 - 微信更新恢复路径更明确：通过 `./launchers/健康检查.command` 判断 re-sign、missing keys、monitor、Obsidian、LaunchAgent 状态，再用 `./launchers/刷新数据源.command` 修复，不依赖菜单栏图标一定可见。

--- a/app.py
+++ b/app.py
@@ -1,6 +1,4 @@
-"""
-WeChat Group Chat AI Summary - macOS menu bar tool
-"""
+"""WeChat Group Chat AI Summary desktop tray/menu-bar application."""
 import os
 import queue
 import re
@@ -18,7 +16,10 @@ _BACKGROUND_EXIT_CODE = dispatch_background_job(sys.argv[1:])
 if _BACKGROUND_EXIT_CODE is not None:
     raise SystemExit(_BACKGROUND_EXIT_CODE)
 
-import rumps
+if sys.platform == "win32":
+    from ui import windows_rumps as rumps
+else:
+    import rumps
 
 # --- For dialog top-most + custom dialogs ---
 try:
@@ -87,7 +88,9 @@ from core.notification_target import (
     notification_open_commands_for_path,
     target_path_from_notification,
 )
-from core.keychain import save_key, load_key
+from core.platform_open import open_target
+from core.platform_clipboard import copy_text
+from core.keychain import credential_store_label, save_key, load_key
 from core.key_extractor import (
     is_wechat_running,
     is_wechat_signed,
@@ -97,6 +100,7 @@ from core.key_extractor import (
     check_new_databases,
 )
 from core.wechat_db import WeChatDB
+from core.windows_key_extractor import WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT
 from core.wechat_source_guard import WeChatSourceGuard
 from core.bookmark import get_bookmark, set_bookmark, get_summary_time, clear_all_bookmarks
 from core.chat_groups import (
@@ -260,11 +264,11 @@ def _on_notification_click(notification):
         return
     for command in notification_open_commands_for_path(path):
         try:
-            result = subprocess.run(command, check=False)
+            result = open_target(command[1])
         except Exception as e:
             print(f"[notify] open target failed via {command[1]}: {e}")
             continue
-        if result.returncode == 0:
+        if result is None or result.returncode == 0:
             method = "Obsidian URI" if command[1].startswith("obsidian://") else "default open"
             print(f"[notify] opened target via {method}: {path}")
             return
@@ -273,6 +277,8 @@ def _on_notification_click(notification):
 
 
 def _wechat_signing_message():
+    if sys.platform == "win32":
+        return "请运行 启动.cmd --refresh-data-source，并安全输入当前账户 raw key"
     return "请重新双击启动.command，完成微信授权"
 
 
@@ -561,7 +567,10 @@ class WeGroupchatObsidianApp(rumps.App):
             except Exception:
                 pass
             self._source_guard_timer = None
-        if not self.config.get("wechat_source_guard_enabled", False):
+        if (
+            sys.platform == "win32"
+            or not self.config.get("wechat_source_guard_enabled", False)
+        ):
             return
         interval = max(
             60,
@@ -575,7 +584,7 @@ class WeGroupchatObsidianApp(rumps.App):
         print(f"[source-guard] long-lived timer started: every {interval} seconds")
 
     def _on_source_guard_timer(self, _):
-        if self.config.get("wechat_source_guard_enabled", False):
+        if sys.platform != "win32" and self.config.get("wechat_source_guard_enabled", False):
             self._start_source_guard_consumer()
 
     def _start_source_guard_consumer(self):
@@ -669,7 +678,7 @@ class WeGroupchatObsidianApp(rumps.App):
             callback=self._run_resource_backup_now,
         ))
         menu.add(rumps.MenuItem(
-            "📂 在 Finder 打开文件备份",
+            "📂 在文件夹中显示文件备份",
             callback=self._open_resource_backup_portal,
         ))
         menu.add(rumps.MenuItem(
@@ -739,7 +748,12 @@ class WeGroupchatObsidianApp(rumps.App):
             try:
                 confirmed = self._confirm_dialog(
                     "允许本次 app 会话解析微信附件？",
-                    "macOS 可能显示一次“访问其他 App 数据”提示。授权仅用于显式选中群聊的微信附件 cache；补链接不需要此权限。关闭本开关会立即停止新的文件解析。",
+                    (
+                        "macOS 可能显示一次“访问其他 App 数据”提示。"
+                        if sys.platform == "darwin" else
+                        "Windows 会直接读取当前账户目录中的微信附件 cache。"
+                    )
+                    + "授权仅用于显式选中群聊；补链接不需要此权限。关闭本开关会立即停止新的文件解析。",
                     ok="开启",
                 )
             finally:
@@ -776,7 +790,7 @@ class WeGroupchatObsidianApp(rumps.App):
                 "请先选择群聊并运行一次“立即更新资源索引”。",
             )
             return
-        subprocess.run(["open", "-R", portal_path])
+        open_target(portal_path, reveal=True)
 
     def _start_resource_backup_consumer(self, *, manual):
         threading.Thread(
@@ -1417,7 +1431,7 @@ class WeGroupchatObsidianApp(rumps.App):
                 "完成授权并至少成功运行一次后才能打开。",
             )
             return
-        subprocess.run(["open", link])
+        open_target(link)
 
     def _reauthorize_drive_sync(self, _):
         self._delayed_run(self._show_drive_sync_auth_dialog)
@@ -1448,7 +1462,7 @@ class WeGroupchatObsidianApp(rumps.App):
             _notify(
                 "Google Drive 群文件备份",
                 "授权完成",
-                "refresh token 已存入 macOS Keychain；sync 和群聊选择没有被改变。",
+                f"refresh token 已存入{credential_store_label()}；sync 和群聊选择没有被改变。",
             )
             print(f"[drive-sync] auth state={status.get('state')}")
         except GoogleDriveAuthError as exc:
@@ -1463,7 +1477,7 @@ class WeGroupchatObsidianApp(rumps.App):
     # ── Topic monitor menu ────────────────────────────────────
 
     def _build_monitor_menu(self):
-        """Build macOS notification monitor submenu."""
+        """Build the notification monitor submenu."""
         monitor = rumps.MenuItem("🔔 关注推送")
 
         enabled = self.config.get("monitor_enabled", False)
@@ -1829,7 +1843,7 @@ class WeGroupchatObsidianApp(rumps.App):
         ).start()
 
     def _test_monitor_notification(self, _):
-        _notify("关注推送", "系统通知可用", "如果你看到这条，macOS 通知链路是通的")
+        _notify("关注推送", "系统通知可用", "如果你看到这条，系统通知链路是通的")
 
     def _toggle_background_notifications(self, _):
         enabled = not bool(self.config.get("background_notifications_enabled", True))
@@ -2095,13 +2109,13 @@ class WeGroupchatObsidianApp(rumps.App):
 
     def _open_monitor_hits_dir(self, _):
         os.makedirs(HITS_DIR, exist_ok=True)
-        subprocess.run(["open", HITS_DIR])
+        open_target(HITS_DIR)
 
     def _open_monitor_knowledge_dir(self, _):
         root = self.config.get("monitor_obsidian_root") or OBSIDIAN_ROOT
         subdir = self.config.get("monitor_obsidian_subdir")
         ensure_obsidian_vault(root, obsidian_subdir=subdir)
-        subprocess.run(["open", os.path.join(os.path.expanduser(root), safe_obsidian_subdir(subdir))])
+        open_target(os.path.join(os.path.expanduser(root), safe_obsidian_subdir(subdir)))
 
     def _set_monitor_obsidian_root(self, _):
         self._delayed_run(self._show_monitor_obsidian_root_dialog)
@@ -2299,7 +2313,7 @@ class WeGroupchatObsidianApp(rumps.App):
     def _check_mcp_ready(self):
         """Check if MCP Server can start normally, return issue list (empty = ready)."""
         project_dir = os.path.dirname(os.path.abspath(__file__))
-        venv_python = os.path.join(project_dir, ".venv", "bin", "python3")
+        venv_python = self._project_python(project_dir)
         mcp_server = os.path.join(project_dir, "mcp_server.py")
 
         issues = []
@@ -2328,12 +2342,18 @@ class WeGroupchatObsidianApp(rumps.App):
     def _get_mcp_config_snippet(self, client="claude_desktop"):
         """Generate MCP client configuration."""
         project_dir = os.path.dirname(os.path.abspath(__file__))
-        venv_python = os.path.join(project_dir, ".venv", "bin", "python3")
+        venv_python = self._project_python(project_dir)
         mcp_server = os.path.join(project_dir, "mcp_server.py")
 
         if client == "claude_desktop":
             return claude_desktop_config(venv_python, mcp_server)
         return claude_code_add_command(venv_python, mcp_server)
+
+    @staticmethod
+    def _project_python(project_dir):
+        if sys.platform == "win32":
+            return os.path.join(project_dir, ".venv", "Scripts", "python.exe")
+        return os.path.join(project_dir, ".venv", "bin", "python3")
 
     def _build_mcp_menu(self):
         """Build MCP service submenu."""
@@ -2377,15 +2397,13 @@ class WeGroupchatObsidianApp(rumps.App):
 
     def _copy_claude_desktop_config(self, _):
         snippet = self._get_mcp_config_snippet("claude_desktop")
-        process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
-        process.communicate(snippet.encode("utf-8"))
+        copy_text(snippet)
         _notify("MCP 服务", "已复制到剪贴板",
                 "粘贴到 claude_desktop_config.json 即可")
 
     def _copy_claude_code_config(self, _):
         snippet = self._get_mcp_config_snippet("claude_code")
-        process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
-        process.communicate(snippet.encode("utf-8"))
+        copy_text(snippet)
         _notify("MCP 服务", "已复制到剪贴板",
                 "在终端粘贴执行即可添加 MCP 服务")
 
@@ -2395,7 +2413,7 @@ class WeGroupchatObsidianApp(rumps.App):
 
     def _do_mcp_test(self):
         project_dir = os.path.dirname(os.path.abspath(__file__))
-        venv_python = os.path.join(project_dir, ".venv", "bin", "python3")
+        venv_python = self._project_python(project_dir)
         mcp_server = os.path.join(project_dir, "mcp_server.py")
 
         if not os.path.isfile(venv_python):
@@ -2673,7 +2691,7 @@ class WeGroupchatObsidianApp(rumps.App):
         try:
             clicked, text = self._input_dialog(
                 "设置 API Key",
-                f"当前 AI 服务：{provider_name}\n{hint}\n\nKey 将安全存储在 macOS 钥匙串中",
+                f"当前 AI 服务：{provider_name}\n{hint}\n\nKey 将安全存储在{credential_store_label()}中",
                 ok="保存", width=380,
             )
 
@@ -2681,10 +2699,10 @@ class WeGroupchatObsidianApp(rumps.App):
                 key = text.strip()
                 if save_key("ai-api-key", key):
                     self.ai = None
-                    _notify("微信总结", "API Key 已保存", "密钥已安全存储在 macOS 钥匙串中")
+                    _notify("微信总结", "API Key 已保存", f"密钥已安全存储在{credential_store_label()}中")
                     self._rebuild_settings_menu()
                 else:
-                    _notify("微信总结", "保存失败", "无法写入钥匙串")
+                    _notify("微信总结", "保存失败", f"无法写入{credential_store_label()}")
         finally:
             self._release_front()
 
@@ -2713,27 +2731,61 @@ class WeGroupchatObsidianApp(rumps.App):
     def open_config_file(self, _):
         if not os.path.exists(CONFIG_FILE):
             self._update_config()
-        subprocess.run(["open", CONFIG_FILE])
+        open_target(CONFIG_FILE)
 
     def _open_summary_dir(self, _):
-        subprocess.run(["open", SUMMARY_DIR])
+        open_target(SUMMARY_DIR)
 
     # ── Initialization ──────────────────────────────────────────
+
+    def _refresh_windows_keys_from_credential(self, keys):
+        """Renew missing Windows page keys from an explicitly remembered raw key."""
+        if sys.platform != "win32":
+            return keys
+        db_dir = self.config.get("db_dir", "")
+        if not db_dir or not os.path.isdir(db_dir):
+            return keys
+        missing = check_new_databases(db_dir, keys or {})
+        if keys and not missing:
+            return keys
+        raw_key_hex = load_key(WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT)
+        if not raw_key_hex:
+            return keys
+        try:
+            refreshed = extract_keys(raw_key_hex=raw_key_hex)
+        finally:
+            raw_key_hex = None
+        if refreshed:
+            print(f"[init] Windows 数据源自动续期: {len(refreshed)} 个数据库")
+            return refreshed
+        print("[init] Windows 数据源自动续期失败；已保留现有逐库密钥")
+        return keys
 
     def _init_background(self):
         print("[init] 开始后台初始化...")
         self._set_status(ICON_LOADING)
 
-        keys = get_cached_keys()
+        keys = self._refresh_windows_keys_from_credential(get_cached_keys())
         print(f"[init] 缓存密钥: {'有' if keys else '无'}")
         signed = is_wechat_signed()
-        print(f"[init] 微信签名: {'正常' if signed else '需要重新授权'}")
+        if sys.platform == "win32":
+            print("[init] Windows 数据源不需要修改微信签名")
+        else:
+            print(f"[init] 微信签名: {'正常' if signed else '需要重新授权'}")
 
         if not signed and keys:
             _notify("微信总结", "检测到微信签名已失效",
                     f"当前缓存密钥仍可使用；如读不到新消息，{_wechat_signing_message()}")
 
         if not keys:
+            if sys.platform == "win32":
+                _notify(
+                    "微信总结",
+                    "需要初始化 Windows 数据源",
+                    _wechat_signing_message(),
+                )
+                self._set_status(ICON_ERROR)
+                return
             if not is_wechat_running():
                 _notify("微信总结", "初始化失败", "请先启动微信并登录")
                 self._set_status(ICON_ERROR)
@@ -2753,7 +2805,7 @@ class WeGroupchatObsidianApp(rumps.App):
                 self._set_status(ICON_ERROR)
                 return
 
-        print(f"[init] db_dir: {self.config.get('db_dir')}")
+        print("[init] db_dir: configured")
         if not self.config.get("db_dir") or not os.path.isdir(self.config["db_dir"]):
             _notify("微信总结", "未找到微信数据目录", "请检查配置")
             self._set_status(ICON_ERROR)
@@ -2765,7 +2817,7 @@ class WeGroupchatObsidianApp(rumps.App):
             self._start_attachment_archive_consumer()
         if self.config.get("resource_backup_enabled", False):
             self._start_resource_backup_consumer(manual=False)
-        if self.config.get("wechat_source_guard_enabled", False):
+        if sys.platform != "win32" and self.config.get("wechat_source_guard_enabled", False):
             self._start_source_guard_consumer()
         if (
             self.config.get("google_drive_file_sync_enabled", False)
@@ -3234,7 +3286,7 @@ class WeGroupchatObsidianApp(rumps.App):
                     f"{date_str} · {msg_count}条消息 · {total_chunks}段已总结")
             print(f"[daily] ✓ {group_name} {date_str} 总结完成")
 
-            subprocess.run(["open", summary_file])
+            open_target(summary_file)
             self._set_status(ICON_DONE)
 
         except UserCancelled:
@@ -3369,7 +3421,7 @@ class WeGroupchatObsidianApp(rumps.App):
             print(f"[summary] ✓ {group_name} 总结完成")
 
             # Auto-open summary file
-            subprocess.run(["open", summary_file])
+            open_target(summary_file)
 
             self._set_status(ICON_DONE)
 
@@ -3439,8 +3491,7 @@ class WeGroupchatObsidianApp(rumps.App):
     def _copy_summary(self, _):
         if not self._last_summary:
             return
-        process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
-        process.communicate(self._last_summary["text"].encode("utf-8"))
+        copy_text(self._last_summary["text"])
         _notify("微信总结", "已复制", "总结内容已复制到剪贴板")
 
     def _rebuild_summary_history(self):
@@ -3497,7 +3548,7 @@ class WeGroupchatObsidianApp(rumps.App):
 
     def _make_open_file_callback(self, filepath):
         def callback(_):
-            subprocess.run(["open", filepath])
+            open_target(filepath)
         return callback
 
     # ── Group management ────────────────────────────────────────
@@ -3812,7 +3863,7 @@ class WeGroupchatObsidianApp(rumps.App):
             print(f"[batch] ✓ 分组「{group_name}」总结完成")
 
             # Auto-open summary file
-            subprocess.run(["open", summary_file])
+            open_target(summary_file)
 
             self._set_status(ICON_DONE)
 
@@ -4185,7 +4236,7 @@ class WeGroupchatObsidianApp(rumps.App):
             _notify("微信总结", f"🔍 搜索完成", f"「{kw_str}」命中 {total_count} 条消息")
             print(f"[搜索] ✓ 搜索完成，结果已保存")
 
-            subprocess.run(["open", filepath])
+            open_target(filepath)
             self._set_status(ICON_DONE)
 
         except UserCancelled:
@@ -4282,6 +4333,9 @@ class WeGroupchatObsidianApp(rumps.App):
     @rumps.clicked("🔄 刷新数据源")
     def reextract_keys(self, _):
         print("[keys] 点击🔄 刷新数据源")
+        if sys.platform == "win32":
+            self._delayed_run(self._show_windows_raw_key_dialog)
+            return
         if not is_wechat_running():
             print("[keys] ✗ 微信未运行")
             _notify("微信总结", "微信未运行", "请先启动微信并登录")
@@ -4293,11 +4347,45 @@ class WeGroupchatObsidianApp(rumps.App):
         print("[keys] 开始刷新数据源...")
         threading.Thread(target=self._do_reextract, daemon=True).start()
 
-    def _do_reextract(self):
-        self._set_status(ICON_LOADING)
-        _notify("微信总结", "正在刷新数据源", "需要管理员权限...")
+    def _show_windows_raw_key_dialog(self):
+        self._bring_to_front()
         try:
-            keys = extract_keys()
+            window = rumps.Window(
+                message=(
+                    "输入当前 Windows 微信 4.x 账户 raw key。\n"
+                    "它只在内存中用于为现有数据库派生并验证页密钥，"
+                    "不会写入日志、配置或命令行。"
+                ),
+                title="刷新 Windows 数据源",
+                default_text="",
+                ok="派生并验证",
+                cancel="取消",
+                dimensions=(520, 24),
+                secure=True,
+            )
+            response = window.run()
+            if not response.clicked:
+                return
+            raw_key_hex = str(response.text or "").strip()
+            if not re.fullmatch(r"[0-9a-fA-F]{64}", raw_key_hex):
+                _notify("微信总结", "raw key 格式错误", "请输入 64 位十六进制字符")
+                return
+            threading.Thread(
+                target=self._do_reextract,
+                kwargs={"raw_key_hex": raw_key_hex},
+                daemon=True,
+            ).start()
+        finally:
+            self._release_front()
+
+    def _do_reextract(self, raw_key_hex=None):
+        self._set_status(ICON_LOADING)
+        if sys.platform == "win32":
+            _notify("微信总结", "正在刷新数据源", "正在派生并验证现有数据库密钥...")
+        else:
+            _notify("微信总结", "正在刷新数据源", "需要管理员权限...")
+        try:
+            keys = extract_keys(raw_key_hex=raw_key_hex)
             print(f"[keys] extract_keys 返回: {len(keys) if keys else 0} 个密钥")
             if keys:
                 self.db = WeChatDB(self.config["db_dir"], keys)

--- a/core/app_runtime.py
+++ b/core/app_runtime.py
@@ -1,9 +1,9 @@
 """Long-lived menu-app process ownership."""
 from __future__ import annotations
 
-import fcntl
 import os
 
+from . import file_lock as fcntl
 from .config import DATA_DIR, ensure_private_dir
 
 

--- a/core/attachment_archive.py
+++ b/core/attachment_archive.py
@@ -7,7 +7,6 @@ rolling back a Knowledge event or causing another AI pass.
 from __future__ import annotations
 
 import errno
-import fcntl
 import glob
 import hashlib
 import json
@@ -20,6 +19,8 @@ import tempfile
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+
+from . import file_lock as fcntl
 from datetime import datetime
 
 from .config import DATA_DIR

--- a/core/config.py
+++ b/core/config.py
@@ -1,13 +1,16 @@
 """Configuration management - app config and WeChat data path detection."""
-import fcntl
+import glob
 import json
 import os
 import re
 import shlex
 import stat
+import sys
 import tempfile
+import time
 import uuid
 
+from . import file_lock as fcntl
 from .project_identity import DATA_DIR_NAME, LEGACY_DATA_DIR_NAME
 from .taxonomy_assignment import FREE_FORM_PROFILE
 
@@ -26,7 +29,7 @@ DEFAULT_CONFIG = {
     "keys_file": os.path.join(DATA_DIR, "all_keys.json"),
     "decrypted_dir": os.path.join(DATA_DIR, "decrypted"),
     "ai_provider": "qwen",  # Options: qwen, ollama, deepseek, claude, openai, custom
-    "ai_model": "",          # Empty uses default model; API key stored in macOS Keychain
+    "ai_model": "",          # Empty uses default model; API key uses the OS credential store
     "ollama_url": "http://localhost:11434",
     "ollama_model": "qwen3:8b",
     "auto_refresh_on_open": False,
@@ -121,6 +124,11 @@ class ConfigConflictError(ConfigError):
 def ensure_private_dir(path=DATA_DIR):
     """Create a local data directory and restrict it to the current user."""
     os.makedirs(path, exist_ok=True)
+    if os.name == "nt":
+        from .windows_permissions import restrict_path_to_current_user
+
+        restrict_path_to_current_user(path, is_directory=True)
+        return
     try:
         os.chmod(path, 0o700)
     except OSError:
@@ -129,6 +137,11 @@ def ensure_private_dir(path=DATA_DIR):
 
 def ensure_private_file(path):
     """Best-effort private permissions for local config/cache metadata."""
+    if os.name == "nt":
+        from .windows_permissions import restrict_path_to_current_user
+
+        restrict_path_to_current_user(path, is_directory=False)
+        return
     try:
         os.chmod(path, 0o600)
     except OSError:
@@ -164,7 +177,7 @@ def normalize_path_value(value):
     text = str(value or "").strip()
     if not text:
         return ""
-    if "\\" in text:
+    if os.name != "nt" and "\\" in text:
         try:
             parts = shlex.split(text)
             if len(parts) == 1:
@@ -172,6 +185,23 @@ def normalize_path_value(value):
         except ValueError:
             text = text.replace("\\ ", " ").replace("\\~", "~")
     return os.path.expanduser(text)
+
+
+def _atomic_replace(source, destination):
+    """Publish a file atomically, tolerating brief Windows reader handles."""
+    deadline = time.monotonic() + 2.0
+    while True:
+        try:
+            os.replace(source, destination)
+            return
+        except PermissionError as exc:
+            if (
+                os.name != "nt"
+                or getattr(exc, "winerror", None) not in {5, 32}
+                or time.monotonic() >= deadline
+            ):
+                raise
+            time.sleep(0.01)
 
 
 def _rebase_legacy_data_path(value):
@@ -540,7 +570,7 @@ class ConfigStore:
                 handle.write("\n")
                 handle.flush()
                 os.fsync(handle.fileno())
-            os.replace(temp_path, self.path)
+            _atomic_replace(temp_path, self.path)
             temp_path = ""
             ensure_private_file(self.path)
             try:
@@ -659,20 +689,63 @@ def _load_saved_config():
     return ConfigStore().update(lambda current: current)
 
 
-def auto_detect_db_dir():
-    """Auto-detect macOS WeChat database path."""
+def _windows_db_candidates(*, environ, home_dir):
+    roots = []
+    appdata = str(environ.get("APPDATA") or "").strip()
+    config_dir = os.path.join(appdata, "Tencent", "xwechat", "config")
+    if os.path.isdir(config_dir):
+        for ini_path in sorted(glob.glob(os.path.join(config_dir, "*.ini"))):
+            try:
+                with open(ini_path, "rb") as handle:
+                    raw = handle.read(4096)
+            except OSError:
+                continue
+            text = ""
+            for encoding in ("utf-8-sig", "gb18030"):
+                try:
+                    text = raw.decode(encoding).strip().strip('"')
+                    break
+                except UnicodeDecodeError:
+                    continue
+            if text:
+                roots.append(os.path.expandvars(os.path.expanduser(text)))
+
+    roots.extend((home_dir, os.path.join(home_dir, "Documents")))
+    candidates = []
+    seen = set()
+    patterns = (
+        os.path.join("xwechat_files", "*", "db_storage"),
+        os.path.join("*", "db_storage"),
+    )
+    for root in roots:
+        root = os.path.abspath(str(root or ""))
+        if not os.path.isdir(root):
+            continue
+        for pattern in patterns:
+            for storage in glob.glob(os.path.join(root, pattern)):
+                storage = os.path.abspath(storage)
+                if not os.path.isdir(storage) or storage in seen:
+                    continue
+                seen.add(storage)
+                candidates.append(storage)
+    return candidates
+
+
+def _macos_db_candidates(*, home_dir):
     bases = [
-        os.path.expanduser(
-            "~/Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files"
+        os.path.join(
+            home_dir,
+            "Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files",
         ),
-        os.path.expanduser(
-            "~/Library/Containers/com.tencent.xinWeChat/Data/Documents"
+        os.path.join(
+            home_dir,
+            "Library/Containers/com.tencent.xinWeChat/Data/Documents",
         ),
-        os.path.expanduser(
-            "~/Library/Containers/com.tencent.xinWeChat/Data/Library/Application Support"
+        os.path.join(
+            home_dir,
+            "Library/Containers/com.tencent.xinWeChat/Data/Library/Application Support",
         ),
     ]
-
     candidates = []
     seen = set()
     for base in bases:
@@ -688,6 +761,18 @@ def auto_detect_db_dir():
                     continue
                 seen.add(storage)
                 candidates.append(storage)
+    return candidates
+
+
+def auto_detect_db_dir(*, platform_name=None, environ=None, home_dir=None):
+    """Auto-detect the current WeChat 4.x ``db_storage`` directory."""
+    platform_name = platform_name or sys.platform
+    environ = os.environ if environ is None else environ
+    home_dir = os.path.expanduser("~") if home_dir is None else os.path.abspath(home_dir)
+    if platform_name == "win32":
+        candidates = _windows_db_candidates(environ=environ, home_dir=home_dir)
+    else:
+        candidates = _macos_db_candidates(home_dir=home_dir)
 
     if not candidates:
         return None

--- a/core/daily_digest.py
+++ b/core/daily_digest.py
@@ -9,7 +9,12 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .config import DATA_DIR, ensure_private_dir, ensure_private_file
-from .knowledge import _obsidian_link, ensure_obsidian_vault, safe_obsidian_subdir
+from .knowledge import (
+    _obsidian_link,
+    _obsidian_relpath,
+    ensure_obsidian_vault,
+    safe_obsidian_subdir,
+)
 from .review_queue import QUEUE_ACTIONABILITIES, ReviewQueue, priority_for_item
 from .source_contract import projection_source_lines
 
@@ -416,8 +421,8 @@ def _obsidian_digest_root(config: dict) -> tuple[str, str]:
     if not obsidian_root:
         return "", ""
     obsidian_subdir = safe_obsidian_subdir(config.get("monitor_obsidian_subdir"))
-    relative_root = os.path.join(obsidian_subdir, "Daily Digest")
-    return os.path.join(obsidian_root, relative_root), relative_root
+    relative_root = _obsidian_relpath(obsidian_subdir, "Daily Digest")
+    return os.path.join(obsidian_root, *relative_root.split("/")), relative_root
 
 
 def _digest_month(date_label: str) -> str:
@@ -479,9 +484,9 @@ def digest_output_path(
         current_month = _now_dt(config, now_func=now_func).strftime("%Y-%m")
         if month and month != current_month:
             digest_root = os.path.join(digest_root, month)
-            relative_root = os.path.join(relative_root, month)
+            relative_root = _obsidian_relpath(relative_root, month)
         filename = f"{date_label} Daily Digest.md"
-        obsidian_path = os.path.join(relative_root, filename)
+        obsidian_path = _obsidian_relpath(relative_root, filename)
         return os.path.join(digest_root, filename), obsidian_path
 
     return os.path.join(DAILY_DIGEST_DIR, f"{date_label}-daily-digest.md"), ""

--- a/core/file_lock.py
+++ b/core/file_lock.py
@@ -1,0 +1,105 @@
+"""Cross-platform advisory file locking with ``fcntl.flock`` semantics."""
+from __future__ import annotations
+
+import errno
+import os
+
+
+LOCK_SH = 1
+LOCK_EX = 2
+LOCK_NB = 4
+LOCK_UN = 8
+
+
+if os.name == "nt":
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    _LOCKFILE_FAIL_IMMEDIATELY = 0x00000001
+    _LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
+    _ERROR_LOCK_VIOLATION = 33
+    _ERROR_NOT_LOCKED = 158
+    _ERROR_IO_PENDING = 997
+
+    class _Overlapped(ctypes.Structure):
+        _fields_ = [
+            ("Internal", ctypes.c_size_t),
+            ("InternalHigh", ctypes.c_size_t),
+            ("Offset", wintypes.DWORD),
+            ("OffsetHigh", wintypes.DWORD),
+            ("hEvent", wintypes.HANDLE),
+        ]
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _lock_file_ex = _kernel32.LockFileEx
+    _lock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    _lock_file_ex.restype = wintypes.BOOL
+    _unlock_file_ex = _kernel32.UnlockFileEx
+    _unlock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    _unlock_file_ex.restype = wintypes.BOOL
+
+    def _windows_handle(fd: int):
+        raw_handle = msvcrt.get_osfhandle(fd)
+        if raw_handle == -1:
+            raise OSError(errno.EBADF, os.strerror(errno.EBADF))
+        return wintypes.HANDLE(raw_handle)
+
+    def flock(fd: int, operation: int) -> None:
+        """Lock one sentinel byte, matching the supported ``flock`` operations."""
+        supported_mask = LOCK_SH | LOCK_EX | LOCK_NB | LOCK_UN
+        if operation & ~supported_mask:
+            raise ValueError("unsupported file lock operation")
+
+        handle = _windows_handle(fd)
+        overlapped = _Overlapped()
+        if operation & LOCK_UN:
+            if operation != LOCK_UN:
+                raise ValueError("LOCK_UN cannot be combined with another operation")
+            if not _unlock_file_ex(handle, 0, 1, 0, ctypes.byref(overlapped)):
+                error_code = ctypes.get_last_error()
+                if error_code != _ERROR_NOT_LOCKED:
+                    raise ctypes.WinError(error_code)
+            return
+
+        lock_kind = operation & (LOCK_SH | LOCK_EX)
+        if lock_kind not in (LOCK_SH, LOCK_EX):
+            raise ValueError("exactly one of LOCK_SH or LOCK_EX is required")
+        flags = _LOCKFILE_EXCLUSIVE_LOCK if lock_kind == LOCK_EX else 0
+        if operation & LOCK_NB:
+            flags |= _LOCKFILE_FAIL_IMMEDIATELY
+        if _lock_file_ex(handle, flags, 0, 1, 0, ctypes.byref(overlapped)):
+            return
+
+        error_code = ctypes.get_last_error()
+        if operation & LOCK_NB and error_code in (
+            _ERROR_LOCK_VIOLATION,
+            _ERROR_IO_PENDING,
+        ):
+            raise BlockingIOError(errno.EACCES, "file lock is already held")
+        raise ctypes.WinError(error_code)
+
+else:
+    import fcntl as _fcntl
+
+    LOCK_SH = _fcntl.LOCK_SH
+    LOCK_EX = _fcntl.LOCK_EX
+    LOCK_NB = _fcntl.LOCK_NB
+    LOCK_UN = _fcntl.LOCK_UN
+
+    def flock(fd: int, operation: int) -> None:
+        """Delegate to the native POSIX ``flock`` implementation."""
+        _fcntl.flock(fd, operation)

--- a/core/google_drive_auth.py
+++ b/core/google_drive_auth.py
@@ -1,4 +1,4 @@
-"""Installed-app Google Drive OAuth with PKCE and Keychain refresh-token storage."""
+"""Installed-app Google Drive OAuth with PKCE and OS credential storage."""
 from __future__ import annotations
 
 import base64
@@ -15,7 +15,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import requests
 
-from .config import DATA_DIR, ensure_private_dir
+from .config import DATA_DIR, _atomic_replace, ensure_private_dir, ensure_private_file
 from .keychain import delete_key, load_key, save_key
 
 
@@ -59,9 +59,9 @@ def _atomic_private_json(path: str, payload: dict) -> None:
             handle.write("\n")
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(temp_path, path)
+        _atomic_replace(temp_path, path)
         temp_path = ""
-        os.chmod(path, 0o600)
+        ensure_private_file(path)
     finally:
         if fd >= 0:
             os.close(fd)

--- a/core/google_drive_file_sync.py
+++ b/core/google_drive_file_sync.py
@@ -1,7 +1,6 @@
 """Selected-chat file discovery, shared-CAS preservation, and Google Drive projection."""
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import mimetypes
@@ -15,6 +14,8 @@ import urllib.parse
 import uuid
 from contextlib import contextmanager
 from datetime import datetime
+
+from . import file_lock as fcntl
 
 from .attachment_archive import AttachmentArchive
 from .config import DATA_DIR, selected_drive_sync_chats

--- a/core/key_extractor.py
+++ b/core/key_extractor.py
@@ -43,7 +43,11 @@ def _first_pid(args):
 
 
 def process_lookup_available():
-    """Return whether this process can inspect macOS process names."""
+    """Return whether this process can inspect the platform process list."""
+    if sys.platform == "win32":
+        from .windows_key_extractor import process_lookup_available as windows_lookup
+
+        return windows_lookup()
     try:
         pid = str(os.getpid())
         result = subprocess.run(
@@ -60,6 +64,11 @@ def process_lookup_available():
 
 def get_wechat_pid():
     """Get WeChat main process PID for key scanning."""
+    if sys.platform == "win32":
+        from .windows_key_extractor import get_wechat_pids
+
+        pids = get_wechat_pids()
+        return pids[0] if pids else None
     for name in WECHAT_PROCESS_NAMES:
         pid = _first_pid(["pgrep", "-x", name])
         if pid:
@@ -80,6 +89,13 @@ def is_wechat_running():
 
 def get_wechat_app_path():
     """Get WeChat.app path, preferring system-installed location."""
+    if sys.platform == "win32":
+        candidates = (
+            os.path.join(os.environ.get("ProgramFiles", ""), "Tencent", "Weixin", "Weixin.exe"),
+            os.path.join(os.environ.get("ProgramFiles", ""), "Tencent", "WeChat", "WeChat.exe"),
+            os.path.join(os.environ.get("ProgramFiles(x86)", ""), "Tencent", "WeChat", "WeChat.exe"),
+        )
+        return next((path for path in candidates if os.path.isfile(path)), None)
     try:
         result = subprocess.run(
             ["osascript", "-e", 'POSIX path of (path to application "WeChat")'],
@@ -105,6 +121,8 @@ def is_required_database(rel_path):
 
 def is_wechat_signed():
     """Check if WeChat has been re-signed (hardened runtime removed)."""
+    if sys.platform == "win32":
+        return True
     app_path = get_wechat_app_path()
     if not app_path:
         return False
@@ -125,6 +143,8 @@ def is_wechat_signed():
 
 def compile_scanner():
     """Compile C key scanner."""
+    if sys.platform == "win32":
+        return process_lookup_available()
     os.makedirs(DATA_DIR, exist_ok=True)
 
     if os.path.exists(C_BINARY):
@@ -146,12 +166,30 @@ def compile_scanner():
         return False
 
 
-def extract_keys():
-    """Run C scanner to extract keys, requires sudo.
+def extract_keys(raw_key_hex=None):
+    """Refresh platform database keys.
+
+    macOS runs the original C scanner with administrator authorization.
+    Windows requires an explicit raw key and derives verified page keys.
 
     Returns:
         dict: {db_rel_path: {"enc_key": hex_string}, ...} or None.
     """
+    if sys.platform == "win32":
+        if raw_key_hex is None:
+            return None
+        from .windows_key_extractor import extract_keys_from_raw_key
+
+        config = load_config()
+        db_dir = config.get("db_dir", "")
+        keys_path = config.get("keys_file") or KEYS_FILE
+        if not db_dir or not os.path.isdir(db_dir):
+            return None
+        return extract_keys_from_raw_key(raw_key_hex, db_dir, keys_path)
+
+    if raw_key_hex is not None:
+        raise RuntimeError("raw_key_import_is_windows_only")
+
     if not compile_scanner():
         return None
 
@@ -222,6 +260,13 @@ def extract_keys():
         return None
 
     return keys
+
+
+def extract_keys_from_raw_key(raw_key_hex):
+    """Explicitly derive Windows Weixin page keys from a user-supplied raw key."""
+    if sys.platform != "win32":
+        raise RuntimeError("raw_key_import_is_windows_only")
+    return extract_keys(raw_key_hex=raw_key_hex)
 
 
 def _parse_raw_keys_from_text(text):

--- a/core/keychain.py
+++ b/core/keychain.py
@@ -1,5 +1,6 @@
-"""macOS Keychain storage - securely store API keys in system keychain."""
+"""Platform credential storage for API keys and OAuth refresh tokens."""
 import subprocess
+import sys
 from typing import Optional
 
 from .project_identity import KEYCHAIN_SERVICE_NAME, LEGACY_KEYCHAIN_SERVICE_NAMES
@@ -8,19 +9,96 @@ SERVICE_NAME = KEYCHAIN_SERVICE_NAME
 LEGACY_SERVICE_NAMES = LEGACY_KEYCHAIN_SERVICE_NAMES
 
 
+def credential_store_label() -> str:
+    return "Windows 凭据管理器" if sys.platform == "win32" else "macOS 钥匙串"
+
+
 def _service_names(include_legacy: bool = False) -> tuple[str, ...]:
     if include_legacy:
         return (SERVICE_NAME, *LEGACY_SERVICE_NAMES)
     return (SERVICE_NAME,)
 
 
+def _windows_target(service_name: str, account: str) -> str:
+    return f"{service_name}:{account}"
+
+
+def _windows_save_key(account: str, password: str) -> bool:
+    try:
+        import pywintypes
+        import win32cred
+    except ImportError:
+        return False
+    try:
+        win32cred.CredWrite({
+            "Type": win32cred.CRED_TYPE_GENERIC,
+            "TargetName": _windows_target(SERVICE_NAME, account),
+            "CredentialBlob": str(password),
+            "Persist": win32cred.CRED_PERSIST_LOCAL_MACHINE,
+            "UserName": account,
+        }, 0)
+        return True
+    except (OSError, TypeError, pywintypes.error):
+        return False
+
+
+def _windows_load_key(account: str) -> Optional[str]:
+    try:
+        import pywintypes
+        import win32cred
+    except ImportError:
+        return None
+    for service_name in _service_names(include_legacy=True):
+        try:
+            credential = win32cred.CredRead(
+                _windows_target(service_name, account),
+                win32cred.CRED_TYPE_GENERIC,
+                0,
+            )
+        except (OSError, pywintypes.error):
+            continue
+        blob = credential.get("CredentialBlob", b"")
+        if isinstance(blob, bytes):
+            try:
+                if len(blob) % 2 == 0 and b"\x00" in blob:
+                    value = blob.decode("utf-16-le").rstrip("\x00")
+                else:
+                    value = blob.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+        else:
+            value = str(blob or "")
+        if value:
+            return value
+    return None
+
+
+def _windows_delete_key(account: str) -> bool:
+    try:
+        import pywintypes
+        import win32cred
+    except ImportError:
+        return False
+    try:
+        win32cred.CredDelete(
+            _windows_target(SERVICE_NAME, account),
+            win32cred.CRED_TYPE_GENERIC,
+            0,
+        )
+        return True
+    except (OSError, pywintypes.error):
+        return False
+
+
 def save_key(account: str, password: str) -> bool:
-    """Save a key to macOS Keychain.
+    """Save a key to macOS Keychain or Windows Credential Manager.
 
     Args:
         account: Account identifier (e.g. "ai-api-key")
         password: Key/password to store
     """
+    if sys.platform == "win32":
+        return _windows_save_key(account, password)
     try:
         # -U: update if already exists
         subprocess.run(
@@ -39,7 +117,9 @@ def save_key(account: str, password: str) -> bool:
 
 
 def load_key(account: str) -> Optional[str]:
-    """Load a key from macOS Keychain."""
+    """Load a key from the current platform credential store."""
+    if sys.platform == "win32":
+        return _windows_load_key(account)
     for service_name in _service_names(include_legacy=True):
         try:
             result = subprocess.run(
@@ -60,7 +140,9 @@ def load_key(account: str) -> Optional[str]:
 
 
 def delete_key(account: str) -> bool:
-    """Delete a key from Keychain."""
+    """Delete a key from the current platform credential store."""
+    if sys.platform == "win32":
+        return _windows_delete_key(account)
     try:
         subprocess.run(
             [

--- a/core/knowledge.py
+++ b/core/knowledge.py
@@ -10,15 +10,16 @@ import threading
 import time
 import unicodedata
 from datetime import datetime
-from urllib.parse import quote
+from pathlib import Path
 
-from .config import DATA_DIR
+from .config import DATA_DIR, _atomic_replace
 from .link_preview import is_wechat_record_url
 from .project_identity import PROJECT_SLUG
 from .source_contract import (
     atomic_source_lines,
     aware_iso_from_timestamp,
     is_history_summary,
+    local_datetime_from_timestamp,
     projection_source_lines,
 )
 from .taxonomy_assignment import TaxonomyResolution, resolve_taxonomy_profile
@@ -453,7 +454,19 @@ def _file_url(path):
     text = str(path or "").strip()
     if not text:
         return ""
-    return "file://" + quote(text)
+    return Path(os.path.abspath(os.path.expanduser(text))).as_uri()
+
+
+def _obsidian_relpath(*parts):
+    """Return an Obsidian vault-relative path, independent of host separators."""
+    logical_parts = []
+    for value in parts:
+        logical_parts.extend(
+            part
+            for part in re.split(r"[/\\]+", str(value or ""))
+            if part
+        )
+    return "/".join(logical_parts)
 
 
 def _month_from_time(value):
@@ -464,9 +477,10 @@ def _month_from_time(value):
 def _file_month_dir(config, month):
     if not month:
         return ""
-    db_dir = os.path.abspath(os.path.expanduser(str(config.get("db_dir") or "")))
-    if not db_dir:
+    db_value = str(config.get("db_dir") or "").strip()
+    if not db_value:
         return ""
+    db_dir = os.path.abspath(os.path.expanduser(db_value))
     wxid_dir = os.path.dirname(db_dir.rstrip(os.sep))
     candidate = os.path.join(wxid_dir, "msg", "file", month)
     return candidate if os.path.isdir(candidate) else ""
@@ -590,7 +604,7 @@ def _note_heading(topic):
 def _obsidian_link(obsidian_path, title):
     if not obsidian_path:
         return f"[[{title}]]"
-    target = os.path.splitext(obsidian_path)[0]
+    target = os.path.splitext(_obsidian_relpath(obsidian_path))[0]
     return f"[[{target}|{title}]]"
 
 
@@ -724,7 +738,7 @@ def safe_obsidian_subdir(value):
         clean = safe_path_part(part, "", max_len=80)
         if clean and clean not in {".", ".."}:
             parts.append(clean)
-    return os.path.join(*parts) if parts else OBSIDIAN_SUBDIR
+    return _obsidian_relpath(*parts) if parts else OBSIDIAN_SUBDIR
 
 
 def build_message_hash(messages):
@@ -1375,7 +1389,11 @@ class KnowledgeStore:
             conn.close()
 
     def full_obsidian_path(self, obsidian_path):
-        return os.path.join(self.obsidian_root, obsidian_path) if obsidian_path else ""
+        logical_path = _obsidian_relpath(obsidian_path)
+        return (
+            os.path.join(self.obsidian_root, *logical_path.split("/"))
+            if logical_path else ""
+        )
 
     @staticmethod
     def _prepare_candidate_for_context(candidate, ctx, config):
@@ -1813,7 +1831,9 @@ class KnowledgeStore:
         lines.extend(["", "## 来源"])
         for event in events:
             senders = ", ".join(_json_loads(event["senders_json"]))
-            when = event["window_end"] or datetime.fromtimestamp(event["created_at"]).strftime("%Y-%m-%d %H:%M")
+            when = event["window_end"] or local_datetime_from_timestamp(
+                event["created_at"]
+            ).strftime("%Y-%m-%d %H:%M")
             label = RELATION_LABELS.get(event["relation"], event["relation"])
             window = f"{event['window_start']} ~ {event['window_end']}".strip(" ~")
             lines.append(f"- {when} · {label} · {senders or '未知'} · {window}")
@@ -1841,7 +1861,8 @@ class KnowledgeStore:
         current_path="",
         reserved_paths=None,
     ):
-        reserved_paths = set(reserved_paths or [])
+        reserved_paths = {_obsidian_relpath(path) for path in (reserved_paths or [])}
+        current_path = _obsidian_relpath(current_path)
         chat_part = safe_path_part(vault_chat_name or source_chat, "未命名群聊", max_len=80)
         category_part = safe_path_part(category)
         links = []
@@ -1855,10 +1876,15 @@ class KnowledgeStore:
             files = _normalize_file_refs(_json_loads(row["files_json"]))
         title_part = safe_path_part(_display_title(title, links, files), "关注内容", max_len=90)
         filename = title_part
-        rel_path = os.path.join(self.obsidian_subdir, chat_part, category_part, f"{filename}.md")
+        rel_path = _obsidian_relpath(
+            self.obsidian_subdir, chat_part, category_part, f"{filename}.md",
+        )
         existing = conn.execute(
-            "SELECT topic_id FROM topics WHERE obsidian_path = ? AND topic_id != ?",
-            (rel_path, topic_id),
+            """
+            SELECT topic_id FROM topics
+            WHERE obsidian_path IN (?, ?) AND topic_id != ?
+            """,
+            (rel_path, rel_path.replace("/", "\\"), topic_id),
         ).fetchone()
         full_path = self.full_obsidian_path(rel_path)
         if (
@@ -1871,10 +1897,18 @@ class KnowledgeStore:
         date_part = safe_path_part(_compact_path_date(first_seen), "", max_len=5)
         if date_part:
             dated_filename = f"{date_part} {title_part}".strip()
-            dated_rel_path = os.path.join(self.obsidian_subdir, chat_part, category_part, f"{dated_filename}.md")
+            dated_rel_path = _obsidian_relpath(
+                self.obsidian_subdir,
+                chat_part,
+                category_part,
+                f"{dated_filename}.md",
+            )
             dated_existing = conn.execute(
-                "SELECT topic_id FROM topics WHERE obsidian_path = ? AND topic_id != ?",
-                (dated_rel_path, topic_id),
+                """
+                SELECT topic_id FROM topics
+                WHERE obsidian_path IN (?, ?) AND topic_id != ?
+                """,
+                (dated_rel_path, dated_rel_path.replace("/", "\\"), topic_id),
             ).fetchone()
             dated_full_path = self.full_obsidian_path(dated_rel_path)
             if (
@@ -1883,7 +1917,12 @@ class KnowledgeStore:
                 and (not os.path.exists(dated_full_path) or dated_rel_path == current_path)
             ):
                 return dated_rel_path
-        return os.path.join(self.obsidian_subdir, chat_part, category_part, f"{filename}-{topic_id}.md")
+        return _obsidian_relpath(
+            self.obsidian_subdir,
+            chat_part,
+            category_part,
+            f"{filename}-{topic_id}.md",
+        )
 
     def _chat_folder_from_path(self, obsidian_path):
         parts = [p for p in re.split(r"[/\\]+", str(obsidian_path or "")) if p]
@@ -1953,8 +1992,7 @@ class KnowledgeStore:
             "scope": scope,
             "chat": chat,
             "month": "",
-            "rel_path": os.path.join(self.obsidian_subdir, chat, OBSIDIAN_DATE_INDEX_FILENAME)
-            if chat else os.path.join(self.obsidian_subdir, OBSIDIAN_DATE_INDEX_FILENAME),
+            "rel_path": _obsidian_relpath(self.obsidian_subdir, chat, OBSIDIAN_DATE_INDEX_FILENAME),
             "topics": topics,
             "include_chat": include_chat,
             "archives": [],
@@ -1962,8 +2000,8 @@ class KnowledgeStore:
 
     def _date_index_archive_dir_rel_path(self, chat):
         if chat:
-            return os.path.join(self.obsidian_subdir, chat, "按日期")
-        return os.path.join(self.obsidian_subdir, "按日期")
+            return _obsidian_relpath(self.obsidian_subdir, chat, "按日期")
+        return _obsidian_relpath(self.obsidian_subdir, "按日期")
 
     def _date_index_specs(self, topics=None):
         if topics is None:
@@ -2191,7 +2229,7 @@ class KnowledgeStore:
                     handle.write(text)
                     handle.flush()
                     os.fsync(handle.fileno())
-                os.replace(tmp_path, target)
+                _atomic_replace(tmp_path, target)
                 tmp_path = ""
             finally:
                 if fd >= 0:
@@ -3310,7 +3348,7 @@ class KnowledgeStore:
 
     @staticmethod
     def _now_text(ts):
-        return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+        return local_datetime_from_timestamp(ts).strftime("%Y-%m-%d %H:%M")
 
 
 def normalize_candidate(decision):

--- a/core/mcp_config.py
+++ b/core/mcp_config.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import json
+import shlex
+import subprocess
+import sys
 
 from .project_identity import MCP_SERVER_ID
 
@@ -21,5 +24,15 @@ def claude_desktop_config(venv_python: str, mcp_server: str) -> str:
     )
 
 
-def claude_code_add_command(venv_python: str, mcp_server: str) -> str:
-    return f"claude mcp add {MCP_SERVER_ID} {venv_python} {mcp_server}"
+def claude_code_add_command(
+    venv_python: str,
+    mcp_server: str,
+    *,
+    platform_name: str | None = None,
+) -> str:
+    arguments = [venv_python, mcp_server]
+    if (platform_name or sys.platform) == "win32":
+        invocation = subprocess.list2cmdline(arguments)
+    else:
+        invocation = shlex.join(arguments)
+    return f"claude mcp add {MCP_SERVER_ID} {invocation}"

--- a/core/platform_clipboard.py
+++ b/core/platform_clipboard.py
@@ -1,0 +1,40 @@
+"""Copy Unicode text through the current desktop clipboard."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+
+def _copy_windows(text: str, *, attempts: int = 5) -> None:
+    import win32clipboard
+
+    last_error = None
+    for attempt in range(attempts):
+        try:
+            win32clipboard.OpenClipboard()
+            try:
+                win32clipboard.EmptyClipboard()
+                win32clipboard.SetClipboardText(text, win32clipboard.CF_UNICODETEXT)
+            finally:
+                win32clipboard.CloseClipboard()
+            return
+        except Exception as exc:
+            last_error = exc
+            if attempt + 1 < attempts:
+                time.sleep(0.05 * (attempt + 1))
+    raise RuntimeError("Windows clipboard is busy") from last_error
+
+
+def copy_text(text: str) -> None:
+    """Copy text without passing it through a shell or command-line argument."""
+    value = str(text)
+    if sys.platform == "win32":
+        _copy_windows(value)
+        return
+    subprocess.run(
+        ["pbcopy"],
+        input=value.encode("utf-8"),
+        check=True,
+        timeout=5,
+    )

--- a/core/platform_open.py
+++ b/core/platform_open.py
@@ -1,0 +1,24 @@
+"""Open local paths and URLs with the current desktop shell."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def open_target(target: str, *, reveal: bool = False):
+    """Open a path/URL, or reveal a local path in its file manager."""
+    value = os.fspath(target)
+    if sys.platform == "win32":
+        if reveal:
+            return subprocess.run(
+                ["explorer.exe", f"/select,{os.path.normpath(value)}"],
+                check=False,
+            )
+        os.startfile(value)
+        return None
+    command = ["open"]
+    if reveal:
+        command.append("-R")
+    command.append(value)
+    return subprocess.run(command, check=False)

--- a/core/relation_audit.py
+++ b/core/relation_audit.py
@@ -6,6 +6,8 @@ import sqlite3
 import time
 from urllib.parse import quote
 
+from .config import ensure_private_file
+
 
 KNOWN_BROKEN_RELATION_REASON = (
     "关系判定失败，按新线索保守提醒: "
@@ -128,7 +130,7 @@ def repair_known_invalid_relations(db_path, *, backup_path, expected_count):
             source.backup(backup)
         finally:
             backup.close()
-        os.chmod(backup_path, 0o600)
+        ensure_private_file(backup_path)
 
         backup = sqlite3.connect(backup_path)
         try:

--- a/core/resource_backup.py
+++ b/core/resource_backup.py
@@ -8,7 +8,6 @@ it does not claim that a cloud provider has completed remote synchronization.
 from __future__ import annotations
 
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -20,6 +19,8 @@ import tempfile
 import time
 import unicodedata
 import uuid
+
+from . import file_lock as fcntl
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timezone

--- a/core/resource_capture.py
+++ b/core/resource_capture.py
@@ -9,7 +9,6 @@ string observed in the WeChat message, not an AI-produced summary.
 from __future__ import annotations
 
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -18,6 +17,8 @@ import re
 import sqlite3
 import threading
 import time
+
+from . import file_lock as fcntl
 import uuid
 from contextlib import contextmanager
 from datetime import datetime

--- a/core/review_queue.py
+++ b/core/review_queue.py
@@ -15,6 +15,7 @@ from typing import Iterable
 
 from .config import DATA_DIR, ensure_private_dir, ensure_private_file
 from .link_preview import is_wechat_record_url
+from .source_contract import local_datetime_from_timestamp
 
 QUEUE_DIR = os.path.join(DATA_DIR, "review_queue")
 PENDING_FILE = "pending.jsonl"
@@ -154,7 +155,7 @@ P2_KEYWORDS = (
 
 
 def _now_text(now_func=time.time) -> str:
-    return datetime.fromtimestamp(now_func()).isoformat(timespec="seconds")
+    return local_datetime_from_timestamp(now_func()).isoformat(timespec="seconds")
 
 
 def _clean_text(value, limit=400) -> str:

--- a/core/source_contract.py
+++ b/core/source_contract.py
@@ -1,5 +1,5 @@
 """Closed producer metadata contract for generated Markdown."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 SOURCE_APP = "we-groupchat-obsidian"
@@ -19,9 +19,14 @@ def _value(item, key, default=""):
         return default
 
 
+def local_datetime_from_timestamp(value):
+    """Convert epoch seconds without relying on the Windows pre-epoch CRT path."""
+    return datetime.fromtimestamp(float(value), timezone.utc).astimezone()
+
+
 def aware_iso_from_timestamp(value):
     """Return a seconds-precision aware ISO timestamp for a canonical row time."""
-    return datetime.fromtimestamp(float(value)).astimezone().isoformat(timespec="seconds")
+    return local_datetime_from_timestamp(value).isoformat(timespec="seconds")
 
 
 def atomic_source_lines(topic_id, generated_at):

--- a/core/taxonomy_migration.py
+++ b/core/taxonomy_migration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import ctypes
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -16,6 +15,8 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import quote
+
+from . import file_lock as fcntl
 
 from core.knowledge import KnowledgeStore
 

--- a/core/wechat_db.py
+++ b/core/wechat_db.py
@@ -18,6 +18,7 @@ from urllib.parse import quote
 import zstandard as zstd
 
 from .decryptor import WALSnapshotError, decrypt_database, decrypt_wal
+from .config import _atomic_replace, ensure_private_dir, ensure_private_file
 
 _zstd_dctx = zstd.ZstdDecompressor()
 
@@ -342,12 +343,8 @@ class WeChatDB:
             source_identity.encode("utf-8")
         ).hexdigest()
         self.cache_dir = os.path.join(self.CACHE_DIR, self.cache_namespace)
-        os.makedirs(self.cache_dir, exist_ok=True)
-        try:
-            os.chmod(self.CACHE_DIR, 0o700)
-            os.chmod(self.cache_dir, 0o700)
-        except OSError:
-            pass
+        ensure_private_dir(self.CACHE_DIR)
+        ensure_private_dir(self.cache_dir)
 
     @staticmethod
     def _file_identity(path):
@@ -442,10 +439,7 @@ class WeChatDB:
                 destination.close()
             if source is not None:
                 source.close()
-        try:
-            os.chmod(pinned, 0o600)
-        except OSError:
-            pass
+        ensure_private_file(pinned)
         self._source_snapshot_paths[rel_path] = pinned
         return pinned
 
@@ -536,12 +530,10 @@ class WeChatDB:
                     or self._file_identity(wal_path) != wal_identity
                 ):
                     continue
-                try:
-                    os.chmod(temp_path, 0o600)
-                except OSError:
-                    pass
-                os.replace(temp_path, cache_path)
+                ensure_private_file(temp_path)
+                _atomic_replace(temp_path, cache_path)
                 temp_path = ""
+                ensure_private_file(cache_path)
             except WALSnapshotError as exc:
                 raise WeChatSourceDegraded("source_snapshot_failed") from exc
             finally:

--- a/core/wechat_source_guard.py
+++ b/core/wechat_source_guard.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime, timezone
-import fcntl
 import json
 import os
 from pathlib import Path
@@ -18,6 +17,8 @@ import tempfile
 import time
 import uuid
 from typing import Callable
+
+from . import file_lock as fcntl
 
 from .key_extractor import get_cached_keys, is_wechat_running, process_lookup_available
 from .project_identity import data_dir

--- a/core/windows_console.py
+++ b/core/windows_console.py
@@ -1,0 +1,19 @@
+"""Small Windows command-line encoding boundary for user-facing scripts."""
+from __future__ import annotations
+
+import sys
+
+
+def configure_utf8_stdio() -> None:
+    """Keep redirected Windows CLI output from failing on Chinese text."""
+    if sys.platform != "win32":
+        return
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            continue

--- a/core/windows_key_extractor.py
+++ b/core/windows_key_extractor.py
@@ -1,0 +1,237 @@
+"""Windows Weixin 4.x raw-key import and per-database key derivation.
+
+The Windows and macOS clients expose different platform boundaries.  WGO does
+not bundle a third-party Windows key-extraction binary or guess at its output;
+this module accepts an explicitly supplied account raw key, derives each
+existing page key, and persists only HMAC-verified page keys in the
+repository's original ``all_keys.json`` shape.
+"""
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import json
+import os
+import re
+import tempfile
+from ctypes import wintypes
+
+from .config import _atomic_replace, ensure_private_dir, ensure_private_file
+from .decryptor import PAGE_SZ, SALT_SZ, verify_page1
+
+
+WECHAT_PROCESS_NAMES = ("Weixin.exe", "WeChat.exe")
+WINDOWS_RAW_KEY_KDF_ITERS = 256_000
+WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT = "windows-weixin-raw-key"
+_TH32CS_SNAPPROCESS = 0x00000002
+_INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+_MAX_PATH = 260
+
+
+class _ProcessEntry32W(ctypes.Structure):
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ProcessID", wintypes.DWORD),
+        ("th32DefaultHeapID", ctypes.c_size_t),
+        ("th32ModuleID", wintypes.DWORD),
+        ("cntThreads", wintypes.DWORD),
+        ("th32ParentProcessID", wintypes.DWORD),
+        ("pcPriClassBase", wintypes.LONG),
+        ("dwFlags", wintypes.DWORD),
+        ("szExeFile", wintypes.WCHAR * _MAX_PATH),
+    ]
+
+
+if os.name == "nt":
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _create_snapshot = _kernel32.CreateToolhelp32Snapshot
+    _create_snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    _create_snapshot.restype = wintypes.HANDLE
+    _process_first = _kernel32.Process32FirstW
+    _process_first.argtypes = [wintypes.HANDLE, ctypes.POINTER(_ProcessEntry32W)]
+    _process_first.restype = wintypes.BOOL
+    _process_next = _kernel32.Process32NextW
+    _process_next.argtypes = [wintypes.HANDLE, ctypes.POINTER(_ProcessEntry32W)]
+    _process_next.restype = wintypes.BOOL
+    _close_handle = _kernel32.CloseHandle
+    _close_handle.argtypes = [wintypes.HANDLE]
+    _close_handle.restype = wintypes.BOOL
+
+
+def _require_windows():
+    if os.name != "nt":
+        raise RuntimeError("windows_key_extractor_requires_windows")
+
+
+def get_wechat_processes():
+    """Return matching executable names and PIDs without command lines."""
+    _require_windows()
+    snapshot = _create_snapshot(_TH32CS_SNAPPROCESS, 0)
+    if not snapshot or snapshot == _INVALID_HANDLE_VALUE:
+        return []
+    wanted = {name.casefold() for name in WECHAT_PROCESS_NAMES}
+    found = []
+    try:
+        entry = _ProcessEntry32W()
+        entry.dwSize = ctypes.sizeof(entry)
+        ok = _process_first(snapshot, ctypes.byref(entry))
+        while ok:
+            if entry.szExeFile.casefold() in wanted:
+                found.append({
+                    "name": str(entry.szExeFile),
+                    "pid": int(entry.th32ProcessID),
+                })
+            ok = _process_next(snapshot, ctypes.byref(entry))
+    finally:
+        _close_handle(snapshot)
+    return sorted(found, key=lambda item: (item["name"].casefold(), item["pid"]))
+
+
+def get_wechat_pids(process_name=None):
+    """Return matching PIDs, optionally restricted to one executable name."""
+    processes = get_wechat_processes()
+    if process_name:
+        wanted = str(process_name).casefold()
+        processes = [
+            item for item in processes if item["name"].casefold() == wanted
+        ]
+    return [item["pid"] for item in processes]
+
+
+def is_weixin_running():
+    """Return whether the Windows Weixin 4.x executable is running."""
+    return bool(get_wechat_pids("Weixin.exe"))
+
+
+def get_weixin_app_path(environ=None):
+    """Return an installed Windows Weixin 4.x executable, if discoverable."""
+    environ = environ or os.environ
+    roots = (
+        environ.get("ProgramW6432", ""),
+        environ.get("ProgramFiles", ""),
+        environ.get("ProgramFiles(x86)", ""),
+        environ.get("LOCALAPPDATA", ""),
+    )
+    candidates = []
+    for root in roots:
+        if root:
+            candidates.extend((
+                os.path.join(root, "Tencent", "Weixin", "Weixin.exe"),
+                os.path.join(root, "Weixin", "Weixin.exe"),
+            ))
+    return next((path for path in candidates if os.path.isfile(path)), None)
+
+
+def process_lookup_available():
+    """Return whether the Win32 process snapshot API is available."""
+    try:
+        _require_windows()
+        snapshot = _create_snapshot(_TH32CS_SNAPPROCESS, 0)
+    except (OSError, RuntimeError):
+        return False
+    if not snapshot or snapshot == _INVALID_HANDLE_VALUE:
+        return False
+    _close_handle(snapshot)
+    return True
+
+
+def _iter_database_pages(db_dir):
+    root = os.path.abspath(os.path.expanduser(db_dir))
+    for current, _dirs, files in os.walk(root):
+        for filename in sorted(files):
+            if not filename.lower().endswith(".db"):
+                continue
+            path = os.path.join(current, filename)
+            try:
+                with open(path, "rb") as handle:
+                    page1 = handle.read(PAGE_SZ)
+            except OSError:
+                continue
+            if len(page1) != PAGE_SZ or page1.startswith(b"SQLite format 3\x00"):
+                continue
+            rel_path = os.path.relpath(path, root).replace("\\", "/")
+            yield rel_path, page1
+
+
+def derive_page_key(raw_key, salt, *, iterations=WINDOWS_RAW_KEY_KDF_ITERS):
+    """Derive one WCDB page key from the Windows Weixin 4.x raw key."""
+    if len(raw_key) != 32:
+        raise ValueError("raw key must be exactly 32 bytes")
+    if len(salt) != SALT_SZ:
+        raise ValueError("database salt must be exactly 16 bytes")
+    return hashlib.pbkdf2_hmac("sha512", raw_key, salt, iterations, dklen=32)
+
+
+def build_key_map_from_raw_key(raw_key_hex, db_dir):
+    """Build the repository's existing per-database page-key map in memory."""
+    raw_key_text = str(raw_key_hex or "").strip()
+    if not re.fullmatch(r"[0-9a-fA-F]{64}", raw_key_text):
+        raise ValueError("raw key must be 64 hexadecimal characters")
+    raw_key = bytes.fromhex(raw_key_text)
+
+    keys = {}
+    for rel_path, page1 in _iter_database_pages(db_dir):
+        page_key = derive_page_key(raw_key, page1[:SALT_SZ])
+        if verify_page1(page_key, page1):
+            keys[rel_path] = {"enc_key": page_key.hex()}
+    return keys
+
+
+def save_key_map(keys, keys_path):
+    """Atomically save verified keys without printing their values."""
+    if not keys:
+        return False
+    keys_path = os.path.abspath(os.path.expanduser(keys_path))
+    directory = os.path.dirname(keys_path)
+    ensure_private_dir(directory)
+    fd, temp_path = tempfile.mkstemp(prefix=".keys-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            json.dump(keys, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        _atomic_replace(temp_path, keys_path)
+        temp_path = ""
+        ensure_private_file(keys_path)
+        return True
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+
+
+def _load_existing_key_map(keys_path):
+    try:
+        with open(os.path.abspath(os.path.expanduser(keys_path)), encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(value, dict):
+        return {}
+    keys = {}
+    for rel_path, record in value.items():
+        if str(rel_path).startswith("_") or not isinstance(record, dict):
+            continue
+        enc_key = str(record.get("enc_key") or "")
+        if not re.fullmatch(r"[0-9a-fA-F]{64}", enc_key):
+            continue
+        keys[str(rel_path).replace("\\", "/")] = {"enc_key": enc_key.lower()}
+    return keys
+
+
+def extract_keys_from_raw_key(raw_key_hex, db_dir, keys_path):
+    """Explicit fallback for a user-supplied Windows Weixin raw key."""
+    derived_keys = build_key_map_from_raw_key(raw_key_hex, db_dir)
+    if not derived_keys:
+        return None
+    keys = _load_existing_key_map(keys_path)
+    keys.update(derived_keys)
+    save_key_map(keys, keys_path)
+    return keys

--- a/core/windows_permissions.py
+++ b/core/windows_permissions.py
@@ -1,0 +1,107 @@
+"""Windows ACL helpers for private local application data."""
+from __future__ import annotations
+
+import os
+
+
+def _security_modules():
+    import ntsecuritycon
+    import pywintypes
+    import win32api
+    import win32con
+    import win32security
+
+    return ntsecuritycon, pywintypes, win32api, win32con, win32security
+
+
+def _current_user_sid():
+    _, _, win32api, win32con, win32security = _security_modules()
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(),
+        win32con.TOKEN_QUERY,
+    )
+    try:
+        return win32security.GetTokenInformation(
+            token,
+            win32security.TokenUser,
+        )[0]
+    finally:
+        token.Close()
+
+
+def current_user_sid_string() -> str:
+    """Return the current token user SID without exposing account names."""
+    _, _, _, _, win32security = _security_modules()
+    return win32security.ConvertSidToStringSid(_current_user_sid())
+
+
+def restrict_path_to_current_user(path: str, *, is_directory: bool | None = None) -> bool:
+    """Protect a file or directory DACL and grant access only to this user."""
+    if os.name != "nt":
+        return False
+    try:
+        ntsecuritycon, pywintypes, _, _, win32security = _security_modules()
+    except ImportError:
+        return False
+    try:
+        sid = _current_user_sid()
+        if is_directory is None:
+            is_directory = os.path.isdir(path)
+        inheritance = 0
+        if is_directory:
+            inheritance = (
+                win32security.OBJECT_INHERIT_ACE
+                | win32security.CONTAINER_INHERIT_ACE
+            )
+        dacl = win32security.ACL()
+        dacl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION_DS,
+            inheritance,
+            ntsecuritycon.FILE_ALL_ACCESS,
+            sid,
+        )
+        win32security.SetNamedSecurityInfo(
+            os.fspath(path),
+            win32security.SE_FILE_OBJECT,
+            win32security.DACL_SECURITY_INFORMATION
+            | win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            dacl,
+            None,
+        )
+        return True
+    except (OSError, pywintypes.error):
+        return False
+
+
+def is_private_to_current_user(path: str) -> bool:
+    """Return whether the protected DACL grants access only to this user."""
+    if os.name != "nt":
+        return False
+    try:
+        _, pywintypes, _, _, win32security = _security_modules()
+    except ImportError:
+        return False
+    try:
+        current_sid = win32security.ConvertSidToStringSid(_current_user_sid())
+        descriptor = win32security.GetNamedSecurityInfo(
+            os.fspath(path),
+            win32security.SE_FILE_OBJECT,
+            win32security.DACL_SECURITY_INFORMATION,
+        )
+        control, _ = descriptor.GetSecurityDescriptorControl()
+        if not control & win32security.SE_DACL_PROTECTED:
+            return False
+        dacl = descriptor.GetSecurityDescriptorDacl()
+        if dacl is None or dacl.GetAceCount() == 0:
+            return False
+        for index in range(dacl.GetAceCount()):
+            ace = dacl.GetAce(index)
+            if ace[0][0] != win32security.ACCESS_ALLOWED_ACE_TYPE:
+                return False
+            if win32security.ConvertSidToStringSid(ace[2]) != current_sid:
+                return False
+        return True
+    except (OSError, pywintypes.error):
+        return False

--- a/core/windows_runtime.py
+++ b/core/windows_runtime.py
@@ -1,0 +1,39 @@
+"""Privacy-safe Windows source readiness inspection."""
+from __future__ import annotations
+
+import os
+
+from .config import load_config
+from .keychain import load_key
+from .key_extractor import (
+    check_new_databases,
+    get_cached_keys,
+    process_lookup_available,
+)
+from .windows_key_extractor import (
+    WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT,
+    get_weixin_app_path,
+    is_weixin_running,
+)
+
+
+def inspect_windows_runtime() -> dict:
+    config = load_config()
+    db_value = str(config.get("db_dir") or "").strip()
+    db_dir = os.path.abspath(os.path.expanduser(db_value)) if db_value else ""
+    db_available = bool(db_dir and os.path.isdir(db_dir))
+    keys = get_cached_keys() or {}
+    missing = check_new_databases(db_dir, keys) if db_available else []
+    can_lookup = process_lookup_available()
+    return {
+        "platform": "windows",
+        "wechat_installed": bool(get_weixin_app_path()),
+        "process_lookup_available": can_lookup,
+        "wechat_running": is_weixin_running() if can_lookup else None,
+        "db_configured": bool(db_dir),
+        "db_available": db_available,
+        "key_count": len(keys),
+        "raw_key_remembered": bool(load_key(WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT)),
+        "missing_required_key_count": len(missing),
+        "ready": bool(db_available and keys and not missing),
+    }

--- a/launchers/启动.ps1
+++ b/launchers/启动.ps1
@@ -1,0 +1,155 @@
+﻿$ErrorActionPreference = "Stop"
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$env:PYTHONIOENCODING = "utf-8"
+
+$ProjectDir = Split-Path -Parent $PSScriptRoot
+$VenvDir = Join-Path $ProjectDir ".venv"
+$PythonBin = Join-Path $VenvDir "Scripts\python.exe"
+$RequirementsFile = Join-Path $ProjectDir "requirements.txt"
+$RequirementsStamp = Join-Path $VenvDir ".requirements.sha256"
+$env:WE_GROUPCHAT_OBSIDIAN_DATA_DIR = Join-Path $env:USERPROFILE ".we-groupchat-obsidian"
+
+$SetupOnly = $args -contains "--setup-only"
+$HealthCheck = $args -contains "--health-check"
+$RefreshDataSource = $args -contains "--refresh-data-source"
+$InstallAutostart = $args -contains "--install-autostart"
+$UninstallAutostart = $args -contains "--uninstall-autostart"
+$AutostartStatus = $args -contains "--autostart-status"
+$Autostart = $args -contains "--autostart"
+$NoPause = $Autostart -or ($args -contains "--no-pause") -or ($env:WE_GROUPCHAT_OBSIDIAN_NO_PAUSE -eq "1")
+$AssumeYes = $args -contains "--yes"
+
+function Pause-Wgo([int] $ExitCode) {
+    if (-not $NoPause) {
+        [void](Read-Host "按回车键关闭")
+    }
+    exit $ExitCode
+}
+
+function Invoke-BasePython([string[]] $PythonArgs) {
+    $PyLauncher = Get-Command "py.exe" -ErrorAction SilentlyContinue
+    if ($null -ne $PyLauncher) {
+        & $PyLauncher.Source -3 @PythonArgs
+        return $LASTEXITCODE
+    }
+    $Python = Get-Command "python.exe" -ErrorAction SilentlyContinue
+    if ($null -eq $Python) {
+        throw "未找到 Python 3。请从 python.org 安装 Python 3.10 或更高版本。"
+    }
+    & $Python.Source @PythonArgs
+    return $LASTEXITCODE
+}
+
+function Confirm-DependencyInstall {
+    if ($AssumeYes) {
+        return $true
+    }
+    $Answer = Read-Host "创建/更新项目 .venv 并安装 requirements.txt 中的依赖？[y/N]"
+    return $Answer -eq "y" -or $Answer -eq "Y"
+}
+
+function Get-WgoSha256([string] $Path) {
+    $Stream = [System.IO.File]::OpenRead($Path)
+    $Sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $Bytes = $Sha256.ComputeHash($Stream)
+        return ([System.BitConverter]::ToString($Bytes)).Replace("-", "").ToLowerInvariant()
+    } finally {
+        $Sha256.Dispose()
+        $Stream.Dispose()
+    }
+}
+
+try {
+    Set-Location -LiteralPath $ProjectDir
+    if ($UninstallAutostart -and -not (Test-Path -LiteralPath $PythonBin)) {
+        $Code = Invoke-BasePython @((Join-Path $ProjectDir "scripts\windows_autostart.py"), "uninstall")
+        Pause-Wgo $Code
+    }
+    $CurrentHash = Get-WgoSha256 $RequirementsFile
+    $InstalledHash = ""
+    if (Test-Path -LiteralPath $RequirementsStamp) {
+        $InstalledHash = (Get-Content -Raw -LiteralPath $RequirementsStamp).Trim()
+    }
+    $NeedsInstall = (-not (Test-Path -LiteralPath $PythonBin)) -or ($CurrentHash -ne $InstalledHash)
+    if ($NeedsInstall -and $Autostart) {
+        throw "项目依赖已变化；请先手动运行 启动.cmd 完成更新，再恢复登录自启。"
+    }
+    if ($NeedsInstall -and -not (Confirm-DependencyInstall)) {
+        Write-Host "已取消依赖安装，程序不会启动。"
+        Pause-Wgo 1
+    }
+    if (-not (Test-Path -LiteralPath $PythonBin)) {
+        Write-Host "[1/3] 创建项目隔离环境..."
+        $Code = Invoke-BasePython @("-m", "venv", $VenvDir)
+        if ($Code -ne 0) {
+            throw "创建 .venv 失败。"
+        }
+    }
+    if ($CurrentHash -ne $InstalledHash) {
+        Write-Host "[2/3] 安装项目依赖（首次可能需要几分钟）..."
+        & $PythonBin -m pip install -r $RequirementsFile
+        if ($LASTEXITCODE -ne 0) {
+            throw "安装 requirements.txt 失败。"
+        }
+        Set-Content -LiteralPath $RequirementsStamp -Value $CurrentHash -Encoding ascii -NoNewline
+    } else {
+        Write-Host "[2/3] Python 依赖已就绪"
+    }
+
+    if ($InstallAutostart) {
+        Write-Host "登录自启需要自动续期数据源；raw key 将遮蔽输入并仅保存到 Windows 凭据管理器。"
+        & $PythonBin (Join-Path $ProjectDir "scripts\refresh_data_source.py") --raw-key --remember-raw-key
+        if ($LASTEXITCODE -ne 0) {
+            Pause-Wgo $LASTEXITCODE
+        }
+        & $PythonBin (Join-Path $ProjectDir "scripts\windows_autostart.py") install
+        $InstallCode = $LASTEXITCODE
+        if ($InstallCode -ne 0) {
+            & $PythonBin (Join-Path $ProjectDir "scripts\refresh_data_source.py") --forget-raw-key
+        }
+        Pause-Wgo $InstallCode
+    }
+    if ($UninstallAutostart) {
+        & $PythonBin (Join-Path $ProjectDir "scripts\windows_autostart.py") uninstall
+        Pause-Wgo $LASTEXITCODE
+    }
+    if ($AutostartStatus) {
+        & $PythonBin (Join-Path $ProjectDir "scripts\windows_autostart.py") status
+        Pause-Wgo $LASTEXITCODE
+    }
+
+    Write-Host "[3/3] 检查 Windows 微信数据源..."
+    & $PythonBin (Join-Path $ProjectDir "scripts\windows_setup.py")
+    $Readiness = $LASTEXITCODE
+
+    if ($SetupOnly -or $HealthCheck) {
+        Pause-Wgo $Readiness
+    }
+    if ($RefreshDataSource) {
+        & $PythonBin (Join-Path $ProjectDir "scripts\refresh_data_source.py") --raw-key
+        Pause-Wgo $LASTEXITCODE
+    }
+    if ($Readiness -eq 3) {
+        Pause-Wgo 3
+    }
+    if ($Readiness -eq 2) {
+        & $PythonBin (Join-Path $ProjectDir "scripts\refresh_data_source.py") --stored-raw-key
+        $RefreshCode = $LASTEXITCODE
+        if ($RefreshCode -ne 0 -and -not $Autostart) {
+            & $PythonBin (Join-Path $ProjectDir "scripts\refresh_data_source.py") --raw-key
+            $RefreshCode = $LASTEXITCODE
+        }
+        if ($RefreshCode -ne 0) {
+            Pause-Wgo $RefreshCode
+        }
+    }
+
+    Write-Host "正在启动微信总结；托盘区会出现应用图标。"
+    & $PythonBin (Join-Path $ProjectDir "app.py")
+    Pause-Wgo $LASTEXITCODE
+} catch {
+    Write-Host "❌ $($_.Exception.Message)"
+    Pause-Wgo 1
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
-rumps>=0.4.0
+rumps>=0.4.0; sys_platform == "darwin"
 pycryptodome>=3.20.0
 zstandard>=0.22.0
-pyobjc-framework-Cocoa>=10.0
+pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"
 anthropic>=0.40.0
 openai>=1.50.0
 requests>=2.31.0
-mcp[cli]>=1.0.0
+mcp[cli]>=1.0.0,<2
+pywin32>=311; sys_platform == "win32"
+pystray>=0.19.5; sys_platform == "win32"
+Pillow>=10.4.0; sys_platform == "win32"
+tzdata>=2024.1; sys_platform == "win32"

--- a/scripts/configure_monitor.py
+++ b/scripts/configure_monitor.py
@@ -20,7 +20,7 @@ from core.config import (
     update_config,
 )
 from core.key_extractor import get_cached_keys
-from core.keychain import load_key, save_key
+from core.keychain import credential_store_label, load_key, save_key
 from core.knowledge import (
     HUMAN_AI_INTIMACY_PROFILE,
     KnowledgeMetadataQueryError,
@@ -277,18 +277,20 @@ def configure(args: argparse.Namespace) -> int:
     if provider != "ollama":
         existing_key = load_key("ai-api-key")
         if existing_key:
-            if prompt_yes_no("Keychain 里已有 API key，要更新吗？", False):
+            store_label = credential_store_label()
+            if prompt_yes_no(f"{store_label}里已有 API key，要更新吗？", False):
                 key = getpass.getpass("输入新的 API key（不会显示）: ").strip()
                 if key and not save_key("ai-api-key", key):
-                    print("写入 Keychain 失败。")
+                    print(f"写入{store_label}失败。")
                     return 1
         else:
-            key = getpass.getpass("输入 API key（不会显示，会写入 macOS Keychain）: ").strip()
+            store_label = credential_store_label()
+            key = getpass.getpass(f"输入 API key（不会显示，会写入{store_label}）: ").strip()
             if not key:
                 print("没有 API key，无法启用云端模型。")
                 return 1
             if not save_key("ai-api-key", key):
-                print("写入 Keychain 失败。")
+                print(f"写入{store_label}失败。")
                 return 1
 
     print("\n关注描述")

--- a/scripts/google_drive_file_sync.py
+++ b/scripts/google_drive_file_sync.py
@@ -14,6 +14,7 @@ if str(PROJECT_DIR) not in sys.path:
 
 from core.config import load_config, update_config
 from core.google_drive_auth import GoogleDriveAuthError, GoogleDriveOAuth
+from core.keychain import credential_store_label
 from core.google_drive_client import GoogleDriveClient
 from core.google_drive_file_sync import GoogleDriveFileSync
 from core.key_extractor import get_cached_keys
@@ -115,7 +116,10 @@ def main(argv=None):
         return _print_result(GoogleDriveOAuth().status(validate=True))
     if args.command == "disconnect":
         GoogleDriveOAuth().disconnect()
-        print("Google Drive refresh token removed from Keychain. Queue and remote files were not deleted.")
+        print(
+            "Google Drive refresh token removed from "
+            f"{credential_store_label()}. Queue and remote files were not deleted."
+        )
         return 0
     if args.command == "enable":
         config = _set_config(

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -191,6 +191,10 @@ def _sensitive_log_status(delete: bool = False) -> tuple[str, bool]:
 
 
 def main(argv: list[str] | None = None) -> int:
+    if sys.platform == "win32":
+        from scripts.windows_setup import main as windows_main
+
+        return windows_main()
     parser = argparse.ArgumentParser(description="Print local we-groupchat-obsidian health status.")
     parser.add_argument(
         "--sensitive",

--- a/scripts/refresh_data_source.py
+++ b/scripts/refresh_data_source.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import argparse
+import getpass
 import os
 import sys
 from pathlib import Path
@@ -12,12 +14,15 @@ if str(PROJECT_DIR) not in sys.path:
     sys.path.insert(0, str(PROJECT_DIR))
 
 from core.config import load_config
+from core.keychain import delete_key, load_key, save_key
 from core.key_extractor import (
     check_new_databases,
     extract_keys,
     is_wechat_running,
     process_lookup_available,
 )
+from core.windows_key_extractor import WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT
+from core.windows_console import configure_utf8_stdio
 
 
 @dataclass(frozen=True)
@@ -28,20 +33,28 @@ class RefreshResult:
     message: str = ""
 
 
-def refresh_data_source() -> RefreshResult:
+def refresh_data_source(raw_key_hex: str | None = None) -> RefreshResult:
     """Extract current DB keys and report whether any encrypted DBs remain missing."""
-    if not process_lookup_available():
-        return RefreshResult(ok=False, message="当前进程无法检测 macOS process list；请在 Terminal/Finder 中运行刷新命令")
-    if not is_wechat_running():
-        return RefreshResult(ok=False, message="微信未运行，请先启动微信并登录")
+    if sys.platform != "win32":
+        if not process_lookup_available():
+            return RefreshResult(ok=False, message="当前进程无法检测 macOS process list；请在 Terminal/Finder 中运行刷新命令")
+        if not is_wechat_running():
+            return RefreshResult(ok=False, message="微信未运行，请先启动微信并登录")
+    elif raw_key_hex is None:
+        return RefreshResult(
+            ok=False,
+            message="Windows 刷新需要账户 raw key；请使用 --raw-key 安全输入（不会显示或写入命令行）",
+        )
 
     config = load_config()
     db_dir = os.path.expanduser(config.get("db_dir", ""))
     if not db_dir or not os.path.isdir(db_dir):
-        return RefreshResult(ok=False, message=f"未找到微信数据目录: {db_dir or '未配置'}")
+        return RefreshResult(ok=False, message="未找到已配置的微信数据目录")
 
-    keys = extract_keys()
+    keys = extract_keys(raw_key_hex=raw_key_hex)
     if not keys:
+        if sys.platform == "win32":
+            return RefreshResult(ok=False, message="raw key 未能验证任何加密数据库；请检查账户、版本和数据目录")
         return RefreshResult(ok=False, message="数据源刷新失败；如果微信刚更新过，请重新运行带 --allow-wechat-resign 的启动命令")
 
     missing = check_new_databases(db_dir, keys)
@@ -53,10 +66,57 @@ def refresh_data_source() -> RefreshResult:
     )
 
 
-def main() -> int:
+def main(argv=None) -> int:
+    configure_utf8_stdio()
+    parser = argparse.ArgumentParser(description="Refresh WGO WeChat database keys.")
+    parser.add_argument(
+        "--raw-key",
+        action="store_true",
+        help="Prompt privately for a Windows Weixin 4.x account raw key.",
+    )
+    parser.add_argument(
+        "--stored-raw-key",
+        action="store_true",
+        help="Use a previously remembered raw key from Windows Credential Manager.",
+    )
+    parser.add_argument(
+        "--remember-raw-key",
+        action="store_true",
+        help="After full verification, remember the prompted raw key for autostart renewal.",
+    )
+    parser.add_argument(
+        "--forget-raw-key",
+        action="store_true",
+        help="Remove the remembered Windows raw key without changing page keys.",
+    )
+    args = parser.parse_args(argv)
+    if args.raw_key and args.stored_raw_key:
+        parser.error("choose either --raw-key or --stored-raw-key")
+    if args.remember_raw_key and not args.raw_key:
+        parser.error("--remember-raw-key requires --raw-key")
+    if args.forget_raw_key:
+        if sys.platform != "win32":
+            parser.error("--forget-raw-key is supported only on Windows")
+        delete_key(WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT)
+        print("已删除 Windows 自动续期 raw key；已派生的逐库密钥未改变。")
+        return 0
+    raw_key_hex = None
+    if args.raw_key:
+        if sys.platform != "win32":
+            parser.error("--raw-key is supported only on Windows")
+        raw_key_hex = getpass.getpass(
+            "输入 Windows 微信账户 raw key（64 位十六进制，不会显示）: "
+        ).strip()
+    elif args.stored_raw_key:
+        if sys.platform != "win32":
+            parser.error("--stored-raw-key is supported only on Windows")
+        raw_key_hex = load_key(WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT)
+        if not raw_key_hex:
+            print("Windows 凭据管理器中没有自动续期 raw key。")
+            return 1
     print("微信总结 数据源刷新")
     print("")
-    result = refresh_data_source()
+    result = refresh_data_source(raw_key_hex=raw_key_hex)
     if result.message:
         print(result.message)
     if result.key_count:
@@ -68,6 +128,11 @@ def main() -> int:
             print(f"  - {rel}")
         return 2
     if result.ok:
+        if args.remember_raw_key:
+            if not save_key(WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT, raw_key_hex):
+                print("数据库密钥已刷新，但 raw key 无法写入 Windows 凭据管理器。")
+                return 1
+            print("raw key 已保存到 Windows 凭据管理器，仅用于自动数据源续期。")
         print("New encrypted DBs missing keys: 0 个")
         return 0
     return 1

--- a/scripts/windows_autostart.py
+++ b/scripts/windows_autostart.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Manage a per-user Windows logon task with bounded crash restart."""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from xml.etree import ElementTree
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+if str(PROJECT_DIR) not in sys.path:
+    sys.path.insert(0, str(PROJECT_DIR))
+
+from core.keychain import delete_key
+from core.config import ensure_private_file
+from core.windows_key_extractor import WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT
+from core.windows_console import configure_utf8_stdio
+from core.windows_permissions import current_user_sid_string
+
+TASK_NAME = r"\we-groupchat-obsidian"
+TASK_XML_NAMESPACE = "http://schemas.microsoft.com/windows/2004/02/mit/task"
+
+
+def _subelement(parent, name, text=None, **attributes):
+    element = ElementTree.SubElement(
+        parent,
+        f"{{{TASK_XML_NAMESPACE}}}{name}",
+        attributes,
+    )
+    if text is not None:
+        element.text = str(text)
+    return element
+
+
+def task_action(project_dir: Path = PROJECT_DIR, *, environ=None) -> tuple[str, str]:
+    project_dir = Path(project_dir).resolve()
+    launcher = project_dir / "launchers" / "启动.ps1"
+    if not launcher.is_file():
+        raise RuntimeError(f"Windows 启动器不存在: {launcher}")
+    environ = os.environ if environ is None else environ
+    system_root = str(environ.get("SystemRoot") or r"C:\Windows")
+    powershell = Path(system_root) / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    arguments = subprocess.list2cmdline([
+        "-NoProfile",
+        "-WindowStyle",
+        "Hidden",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(launcher),
+        "--autostart",
+        "--no-pause",
+    ])
+    return str(powershell), arguments
+
+
+def build_task_xml(
+    *,
+    project_dir: Path = PROJECT_DIR,
+    user_sid: str,
+    environ=None,
+) -> bytes:
+    """Build the Task Scheduler definition without embedding any credential."""
+    project_dir = Path(project_dir).resolve()
+    command, arguments = task_action(project_dir, environ=environ)
+    ElementTree.register_namespace("", TASK_XML_NAMESPACE)
+    task = ElementTree.Element(
+        f"{{{TASK_XML_NAMESPACE}}}Task",
+        {"version": "1.4"},
+    )
+    registration = _subelement(task, "RegistrationInfo")
+    _subelement(
+        registration,
+        "Description",
+        "Start the WGO tray app at logon and restart it after bounded failures.",
+    )
+
+    triggers = _subelement(task, "Triggers")
+    logon = _subelement(triggers, "LogonTrigger")
+    _subelement(logon, "Enabled", "true")
+    _subelement(logon, "UserId", user_sid)
+
+    principals = _subelement(task, "Principals")
+    principal = _subelement(principals, "Principal", id="Author")
+    _subelement(principal, "UserId", user_sid)
+    _subelement(principal, "LogonType", "InteractiveToken")
+    _subelement(principal, "RunLevel", "LeastPrivilege")
+
+    settings = _subelement(task, "Settings")
+    _subelement(settings, "MultipleInstancesPolicy", "IgnoreNew")
+    _subelement(settings, "DisallowStartIfOnBatteries", "false")
+    _subelement(settings, "StopIfGoingOnBatteries", "false")
+    _subelement(settings, "AllowHardTerminate", "true")
+    _subelement(settings, "StartWhenAvailable", "true")
+    _subelement(settings, "RunOnlyIfNetworkAvailable", "false")
+    idle = _subelement(settings, "IdleSettings")
+    _subelement(idle, "StopOnIdleEnd", "false")
+    _subelement(idle, "RestartOnIdle", "false")
+    _subelement(settings, "AllowStartOnDemand", "true")
+    _subelement(settings, "Enabled", "true")
+    _subelement(settings, "Hidden", "false")
+    _subelement(settings, "RunOnlyIfIdle", "false")
+    _subelement(settings, "WakeToRun", "false")
+    _subelement(settings, "ExecutionTimeLimit", "PT0S")
+    _subelement(settings, "Priority", "7")
+    restart = _subelement(settings, "RestartOnFailure")
+    _subelement(restart, "Interval", "PT1M")
+    _subelement(restart, "Count", "3")
+
+    actions = _subelement(task, "Actions", Context="Author")
+    execute = _subelement(actions, "Exec")
+    _subelement(execute, "Command", command)
+    _subelement(execute, "Arguments", arguments)
+    _subelement(execute, "WorkingDirectory", str(project_dir))
+    return ElementTree.tostring(task, encoding="utf-16", xml_declaration=True)
+
+
+def _run_schtasks(arguments, *, runner=subprocess.run):
+    return runner(
+        ["schtasks.exe", *arguments],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def _register_task_definition(task_name, xml, *, runner=subprocess.run) -> int:
+    temp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as handle:
+            temp_path = handle.name
+            handle.write(xml)
+            handle.flush()
+            os.fsync(handle.fileno())
+        ensure_private_file(temp_path)
+        result = _run_schtasks(
+            ["/Create", "/TN", task_name, "/XML", temp_path, "/F"],
+            runner=runner,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"scheduled_task_create_failed:{result.returncode}")
+        return 0
+    finally:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+
+
+def install(
+    *,
+    project_dir: Path = PROJECT_DIR,
+    user_sid: str | None = None,
+    runner=subprocess.run,
+) -> int:
+    xml = build_task_xml(
+        project_dir=project_dir,
+        user_sid=user_sid or current_user_sid_string(),
+    )
+    _register_task_definition(TASK_NAME, xml, runner=runner)
+    print("已安装微信总结 Windows 登录自启与异常保活。")
+    return 0
+
+
+def uninstall(*, runner=subprocess.run) -> int:
+    query = _run_schtasks(["/Query", "/TN", TASK_NAME], runner=runner)
+    if query.returncode == 0:
+        result = _run_schtasks(["/Delete", "/TN", TASK_NAME, "/F"], runner=runner)
+        if result.returncode != 0:
+            raise RuntimeError(f"scheduled_task_delete_failed:{result.returncode}")
+        print("已卸载微信总结 Windows 登录自启与异常保活。")
+    else:
+        print("未找到微信总结 Windows 登录自启。")
+    delete_key(WINDOWS_RAW_KEY_CREDENTIAL_ACCOUNT)
+    return 0
+
+
+def status(*, runner=subprocess.run) -> int:
+    result = _run_schtasks(["/Query", "/TN", TASK_NAME, "/FO", "LIST"], runner=runner)
+    print(f"Windows 登录自启/保活: {'已安装' if result.returncode == 0 else '未安装'}")
+    return 0 if result.returncode == 0 else 1
+
+
+def validate(*, runner=subprocess.run) -> int:
+    """Register/query/delete an inert-until-next-logon task under a random name."""
+    task_name = f"{TASK_NAME}-validation-{uuid.uuid4().hex}"
+    if not task_name.startswith(f"{TASK_NAME}-validation-"):
+        raise RuntimeError("validation_task_name_rejected")
+    xml = build_task_xml(user_sid=current_user_sid_string())
+    created = False
+    try:
+        _register_task_definition(task_name, xml, runner=runner)
+        created = True
+        query = _run_schtasks(["/Query", "/TN", task_name], runner=runner)
+        if query.returncode != 0:
+            raise RuntimeError(f"scheduled_task_query_failed:{query.returncode}")
+    finally:
+        if created:
+            deleted = _run_schtasks(["/Delete", "/TN", task_name, "/F"], runner=runner)
+            if deleted.returncode != 0:
+                raise RuntimeError(f"scheduled_task_cleanup_failed:{deleted.returncode}")
+    print("Windows 计划任务 XML 注册/查询/清理验证通过。")
+    return 0
+
+
+def main() -> int:
+    configure_utf8_stdio()
+    parser = argparse.ArgumentParser(description="Manage Windows per-user autostart.")
+    parser.add_argument("action", choices=("install", "uninstall", "status", "validate"))
+    args = parser.parse_args()
+    if args.action == "install":
+        return install()
+    if args.action == "uninstall":
+        return uninstall()
+    if args.action == "status":
+        return status()
+    return validate()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/windows_setup.py
+++ b/scripts/windows_setup.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Print a privacy-safe Windows Weixin/WGO readiness check."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+if str(PROJECT_DIR) not in sys.path:
+    sys.path.insert(0, str(PROJECT_DIR))
+
+from core.windows_runtime import inspect_windows_runtime
+from core.windows_console import configure_utf8_stdio
+
+
+def main() -> int:
+    configure_utf8_stdio()
+    status = inspect_windows_runtime()
+    print("微信总结 Windows 环境检查")
+    print("")
+    print(f"[{'OK' if status['wechat_installed'] else 'WARN'}] Windows 微信 4.x: {'已安装' if status['wechat_installed'] else '未检测到'}")
+    running = status["wechat_running"]
+    running_text = "无法检测" if running is None else "运行中" if running else "未运行"
+    print(f"[{'OK' if running else 'WARN'}] 微信进程: {running_text}")
+    print(f"[{'OK' if status['db_available'] else 'WARN'}] db_storage: {'已配置且可读' if status['db_available'] else '未检测到'}")
+    print(f"[{'OK' if status['key_count'] else 'WARN'}] 已验证数据库页密钥: {status['key_count']} 个")
+    print(f"[{'OK' if not status['missing_required_key_count'] else 'WARN'}] 必需数据库缺少密钥: {status['missing_required_key_count']} 个")
+    print(f"[INFO] 自动续期凭据: {'已保存到 Windows 凭据管理器' if status['raw_key_remembered'] else '未保存'}")
+    print("")
+    if status["ready"]:
+        print("Windows 数据源已就绪。")
+        return 0
+    if not status["db_available"]:
+        print("请安装并登录 Windows 微信 4.x，等待本地数据同步后重试。")
+        return 3
+    print("请运行 启动.cmd --refresh-data-source，安全输入当前账户 raw key。")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_resource_backup.py
+++ b/tests/test_app_resource_backup.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 import tempfile
 import threading
 import unittest
@@ -99,7 +101,7 @@ class AppResourceBackupTests(unittest.TestCase):
         ):
             menu = app._build_resource_backup_menu()
 
-        self.assertIn("📂 在 Finder 打开文件备份", set(menu.keys()))
+        self.assertIn("📂 在文件夹中显示文件备份", set(menu.keys()))
         self.assertIn(
             "已备份: 5 个文件 · 8 次出现 · 待补齐: 3 条",
             set(menu.keys()),
@@ -114,11 +116,11 @@ class AppResourceBackupTests(unittest.TestCase):
         with (
             patch("app.load_config", return_value=app.config),
             patch("app.MountedResourceBackup.from_config", return_value=backup),
-            patch("app.subprocess.run") as run,
+            patch("app.open_target") as open_path,
         ):
             app._open_resource_backup_portal(None)
 
-        run.assert_called_once_with(["open", "-R", "/tmp/portal.md"])
+        open_path.assert_called_once_with("/tmp/portal.md", reveal=True)
 
     def test_open_file_backup_entry_explains_when_no_portal_exists(self):
         app = self.make_app()
@@ -128,12 +130,12 @@ class AppResourceBackupTests(unittest.TestCase):
         with (
             patch("app.load_config", return_value=app.config),
             patch("app.MountedResourceBackup.from_config", return_value=backup),
-            patch("app.subprocess.run") as run,
+            patch("app.open_target") as open_path,
             patch("app._notify") as notify,
         ):
             app._open_resource_backup_portal(None)
 
-        run.assert_not_called()
+        open_path.assert_not_called()
         self.assertEqual(notify.call_args.args[1], "还没有可打开的文件备份入口")
 
     def test_backfill_does_not_report_success_when_projection_failed(self):
@@ -188,6 +190,41 @@ class AppResourceBackupTests(unittest.TestCase):
                     AppInstanceLock(path).acquire()
             finally:
                 first.release()
+
+    def test_app_singleton_lock_rejects_second_process(self):
+        child_code = (
+            "import sys; "
+            "from core.app_runtime import AppInstanceLock; "
+            "lock = AppInstanceLock(sys.argv[1]).acquire(); "
+            "print('ready', flush=True); "
+            "sys.stdin.read(1); "
+            "lock.release()"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "menu-app.lock")
+            child = subprocess.Popen(
+                [sys.executable, "-c", child_code, path],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+            )
+            try:
+                self.assertEqual(child.stdout.readline().strip(), "ready")
+                with self.assertRaisesRegex(
+                    AppAlreadyRunning, "menu_app_already_running"
+                ):
+                    AppInstanceLock(path).acquire()
+            finally:
+                if child.stdin:
+                    child.stdin.write("x")
+                    child.stdin.close()
+                child.wait(timeout=10)
+            stderr_text = child.stderr.read()
+            child.stdout.close()
+            child.stderr.close()
+            self.assertEqual(child.returncode, 0, stderr_text)
 
     def test_link_backfill_apply_never_calls_file_resolver(self):
         app = self.make_app(resolve_files=False)

--- a/tests/test_app_windows.py
+++ b/tests/test_app_windows.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import patch
+
+from app import WeGroupchatObsidianApp
+
+
+class AppWindowsTests(unittest.TestCase):
+    def test_remembered_raw_key_renews_missing_page_keys(self):
+        app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
+        app.config = {"db_dir": "db_storage"}
+        existing = {"contact/contact.db": {"enc_key": "old"}}
+        refreshed = {
+            "contact/contact.db": {"enc_key": "new"},
+            "session/session.db": {"enc_key": "new"},
+        }
+        with patch("app.sys.platform", "win32"), \
+             patch("app.os.path.isdir", return_value=True), \
+             patch("app.check_new_databases", return_value=["session/session.db"]), \
+             patch("app.load_key", return_value="ab" * 32), \
+             patch("app.extract_keys", return_value=refreshed) as extract:
+            result = app._refresh_windows_keys_from_credential(existing)
+
+        self.assertEqual(result, refreshed)
+        extract.assert_called_once_with(raw_key_hex="ab" * 32)
+
+    def test_no_remembered_raw_key_keeps_existing_page_keys(self):
+        app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
+        app.config = {"db_dir": "db_storage"}
+        existing = {"contact/contact.db": {"enc_key": "old"}}
+        with patch("app.sys.platform", "win32"), \
+             patch("app.os.path.isdir", return_value=True), \
+             patch("app.check_new_databases", return_value=["session/session.db"]), \
+             patch("app.load_key", return_value=None), \
+             patch("app.extract_keys") as extract:
+            result = app._refresh_windows_keys_from_credential(existing)
+
+        self.assertIs(result, existing)
+        extract.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ from core.config import (
     DEFAULT_CONFIG,
     _sanitize_config,
     active_monitor_chats,
+    auto_detect_db_dir,
     merge_monitor_chat_preferences,
     load_config,
     selected_resource_backup_chats,
@@ -28,6 +29,52 @@ def _config_patch_worker(path, field, value, start_event, iterations=1):
 
 
 class ConfigTests(unittest.TestCase):
+    def test_auto_detects_windows_weixin_db_from_utf8_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            appdata = os.path.join(tmp, "AppData", "Roaming")
+            config_dir = os.path.join(appdata, "Tencent", "xwechat", "config")
+            data_root = os.path.join(tmp, "WeixinData")
+            db_dir = os.path.join(
+                data_root, "xwechat_files", "account", "db_storage"
+            )
+            os.makedirs(os.path.join(db_dir, "contact"))
+            os.makedirs(os.path.join(db_dir, "session"))
+            os.makedirs(config_dir)
+            for rel_path in ("contact/contact.db", "session/session.db"):
+                with open(os.path.join(db_dir, *rel_path.split("/")), "wb") as handle:
+                    handle.write(b"fixture")
+            with open(os.path.join(config_dir, "storage.ini"), "w", encoding="utf-8") as handle:
+                handle.write(data_root)
+
+            detected = auto_detect_db_dir(
+                platform_name="win32",
+                environ={"APPDATA": appdata},
+                home_dir=os.path.join(tmp, "home"),
+            )
+
+            self.assertEqual(detected, db_dir)
+
+    def test_auto_detects_windows_weixin_db_from_gb18030_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            appdata = os.path.join(tmp, "AppData", "Roaming")
+            config_dir = os.path.join(appdata, "Tencent", "xwechat", "config")
+            data_root = os.path.join(tmp, "微信数据")
+            db_dir = os.path.join(
+                data_root, "xwechat_files", "account", "db_storage"
+            )
+            os.makedirs(os.path.join(db_dir, "message"))
+            os.makedirs(config_dir)
+            with open(os.path.join(config_dir, "storage.ini"), "wb") as handle:
+                handle.write(data_root.encode("gb18030"))
+
+            detected = auto_detect_db_dir(
+                platform_name="win32",
+                environ={"APPDATA": appdata},
+                home_dir=os.path.join(tmp, "home"),
+            )
+
+            self.assertEqual(detected, db_dir)
+
     def test_auto_detect_install_does_not_overwrite_concurrent_explicit_source(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "config.json")
@@ -123,8 +170,15 @@ class ConfigTests(unittest.TestCase):
             start.set()
             observed = 0
             while writer.is_alive():
-                with open(path, encoding="utf-8") as handle:
-                    value = json.load(handle)
+                try:
+                    with open(path, encoding="utf-8") as handle:
+                        value = json.load(handle)
+                except (FileNotFoundError, PermissionError):
+                    if os.name != "nt":
+                        raise
+                    # A lock-free Windows reader may briefly lose the rename
+                    # race. ConfigStore readers synchronize on the lock file.
+                    continue
                 self.assertIn(value["monitor_interval_minutes"], {1, 2})
                 observed += 1
             writer.join(10)

--- a/tests/test_daily_digest.py
+++ b/tests/test_daily_digest.py
@@ -58,6 +58,10 @@ def candidate(**overrides):
     return data
 
 
+def obsidian_relpath(*parts):
+    return "/".join(parts)
+
+
 class DailyDigestTests(unittest.TestCase):
     def test_day_bounds_follow_local_midnight_across_dst(self):
         timezone = ZoneInfo("America/New_York")
@@ -435,7 +439,7 @@ class DailyDigestTests(unittest.TestCase):
         )
         self.assertEqual(
             digest["obsidian_path"],
-            os.path.join("微信群聊", "关注推送", "Daily Digest", "2026-06-18 Daily Digest.md"),
+            obsidian_relpath("微信群聊", "关注推送", "Daily Digest", "2026-06-18 Daily Digest.md"),
         )
         with open(digest["path"], encoding="utf-8") as handle:
             self.assertIn("# WeChat Daily Digest - 2026-06-18", handle.read())
@@ -460,7 +464,7 @@ class DailyDigestTests(unittest.TestCase):
         )
         self.assertEqual(
             digest["obsidian_path"],
-            os.path.join(
+            obsidian_relpath(
                 "微信群聊",
                 "关注推送",
                 "Daily Digest",

--- a/tests/test_google_drive_auth.py
+++ b/tests/test_google_drive_auth.py
@@ -77,7 +77,12 @@ class GoogleDriveOAuthTests(unittest.TestCase):
         result = install_client_config(self.source, self.target)
 
         self.assertEqual(result, self.target)
-        self.assertEqual(stat.S_IMODE(os.stat(self.target).st_mode), 0o600)
+        if os.name == "nt":
+            from core.windows_permissions import is_private_to_current_user
+
+            self.assertTrue(is_private_to_current_user(self.target))
+        else:
+            self.assertEqual(stat.S_IMODE(os.stat(self.target).st_mode), 0o600)
         with open(self.target, encoding="utf-8") as handle:
             installed = json.load(handle)["installed"]
         self.assertEqual(

--- a/tests/test_key_extractor.py
+++ b/tests/test_key_extractor.py
@@ -21,7 +21,8 @@ class KeyExtractorTests(unittest.TestCase):
             stdout=f"{os.getpid()}\n",
             stderr="",
         )
-        with patch("core.key_extractor.subprocess.run", return_value=result) as run:
+        with patch("core.key_extractor.sys.platform", "darwin"), \
+             patch("core.key_extractor.subprocess.run", return_value=result) as run:
             self.assertTrue(process_lookup_available())
 
         run.assert_called_once_with(

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -1,4 +1,6 @@
 import unittest
+import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from core import keychain
@@ -8,6 +10,12 @@ class KeychainTests(unittest.TestCase):
     def test_new_service_name_is_primary_identity(self):
         self.assertEqual(keychain.SERVICE_NAME, "we-groupchat-obsidian")
         self.assertEqual(keychain.LEGACY_SERVICE_NAMES, ("wechat-summary",))
+
+    def test_credential_store_label_is_platform_specific(self):
+        with patch("core.keychain.sys.platform", "win32"):
+            self.assertEqual(keychain.credential_store_label(), "Windows 凭据管理器")
+        with patch("core.keychain.sys.platform", "darwin"):
+            self.assertEqual(keychain.credential_store_label(), "macOS 钥匙串")
 
     def test_load_key_falls_back_to_legacy_service(self):
         calls = []
@@ -23,11 +31,79 @@ class KeychainTests(unittest.TestCase):
 
             return Result()
 
-        with patch("core.keychain.subprocess.run", side_effect=fake_run):
+        with patch("core.keychain.sys.platform", "darwin"), \
+             patch("core.keychain.subprocess.run", side_effect=fake_run):
             self.assertEqual(keychain.load_key("ai-api-key"), "legacy-key")
 
         self.assertEqual(calls[0][calls[0].index("-s") + 1], "we-groupchat-obsidian")
         self.assertEqual(calls[1][calls[1].index("-s") + 1], "wechat-summary")
+
+    def test_windows_dispatches_to_credential_manager_backend(self):
+        with patch("core.keychain.sys.platform", "win32"), \
+             patch("core.keychain._windows_load_key", return_value="windows-key") as load:
+            self.assertEqual(keychain.load_key("ai-api-key"), "windows-key")
+
+        load.assert_called_once_with("ai-api-key")
+
+    def test_missing_windows_credential_is_not_an_error(self):
+        class CredentialError(Exception):
+            pass
+
+        fake_cred = SimpleNamespace(
+            CRED_TYPE_GENERIC=1,
+            CredRead=lambda *args: (_ for _ in ()).throw(
+                CredentialError(1168, "CredRead", "not found")
+            ),
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "pywintypes": SimpleNamespace(error=CredentialError),
+                "win32cred": fake_cred,
+            },
+        ):
+            self.assertIsNone(keychain._windows_load_key("missing-account"))
+
+    def test_windows_credential_blob_uses_unicode_api_contract(self):
+        class CredentialError(Exception):
+            pass
+
+        written = []
+        fake_cred = SimpleNamespace(
+            CRED_TYPE_GENERIC=1,
+            CRED_PERSIST_LOCAL_MACHINE=2,
+            CredWrite=lambda value, _flags: written.append(value),
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "pywintypes": SimpleNamespace(error=CredentialError),
+                "win32cred": fake_cred,
+            },
+        ):
+            self.assertTrue(keychain._windows_save_key("account", "密钥"))
+
+        self.assertEqual(written[0]["CredentialBlob"], "密钥")
+
+    def test_windows_unicode_credential_blob_decodes_utf16(self):
+        class CredentialError(Exception):
+            pass
+
+        value = "ab" * 32
+        fake_cred = SimpleNamespace(
+            CRED_TYPE_GENERIC=1,
+            CredRead=lambda *_args: {
+                "CredentialBlob": value.encode("utf-16-le"),
+            },
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "pywintypes": SimpleNamespace(error=CredentialError),
+                "win32cred": fake_cred,
+            },
+        ):
+            self.assertEqual(keychain._windows_load_key("account"), value)
 
 
 if __name__ == "__main__":

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -6,7 +6,8 @@ import sqlite3
 import tempfile
 import threading
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import core.knowledge as knowledge
@@ -32,6 +33,10 @@ def msg(ts, sender, text):
         "sender": sender,
         "text": text,
     }
+
+
+def obsidian_relpath(*parts):
+    return "/".join(parts)
 
 
 def msg_at(time_str, sender="示例成员甲", text="测试消息"):
@@ -390,7 +395,7 @@ class KnowledgeStoreTests(unittest.TestCase):
             candidate(links=[]), self.messages, self.config, {"relation": "new"}
         )
         expected_id = f"wg_topic_{result['topic_id']}"
-        expected_generated_at = datetime.fromtimestamp(1000).astimezone().isoformat(
+        expected_generated_at = datetime.fromtimestamp(1000, timezone.utc).astimezone().isoformat(
             timespec="seconds"
         )
 
@@ -506,7 +511,7 @@ class KnowledgeStoreTests(unittest.TestCase):
         result = self.store.apply_event(candidate(links=[]), self.messages, config, {"relation": "new"})
 
         self.assertIn(
-            os.path.join("关注推送", "示例稳定群名", "AI模型"),
+            obsidian_relpath("关注推送", "示例稳定群名", "AI模型"),
             result["obsidian_path"],
         )
         self.assertNotIn("示例技术群改名后", result["obsidian_path"])
@@ -892,7 +897,7 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertEqual(topics[0]["taxonomy_profile"], HUMAN_AI_INTIMACY_PROFILE)
         self.assertEqual(topics[0]["taxonomy_version"], 2)
         self.assertIn(
-            os.path.join("关注推送", "示例人机互动群", "互动实验与玩法"),
+            obsidian_relpath("关注推送", "示例人机互动群", "互动实验与玩法"),
             result["obsidian_path"],
         )
 
@@ -948,7 +953,7 @@ class KnowledgeStoreTests(unittest.TestCase):
 
         self.assertEqual(topic["category"], "资源线索")
         self.assertIn(
-            os.path.join("关注推送", "示例人机互动群", "资源线索"),
+            obsidian_relpath("关注推送", "示例人机互动群", "资源线索"),
             result["obsidian_path"],
         )
 
@@ -975,7 +980,7 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertEqual(after["category"], "互动实验与玩法")
         self.assertEqual(after["obsidian_path"], before["obsidian_path"])
         self.assertIn(
-            os.path.join("关注推送", "示例人机互动群", "互动实验与玩法"),
+            obsidian_relpath("关注推送", "示例人机互动群", "互动实验与玩法"),
             after["obsidian_path"],
         )
 
@@ -997,7 +1002,7 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertEqual(topic["category"], "待归类")
         self.assertEqual(topic["taxonomy_profile"], HUMAN_AI_INTIMACY_PROFILE)
         self.assertIn(
-            os.path.join("关注推送", "Example Interaction Lab", "待归类"),
+            obsidian_relpath("关注推送", "Example Interaction Lab", "待归类"),
             result["obsidian_path"],
         )
 
@@ -1019,7 +1024,7 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertEqual(topic["category"], "AI伴侣交互")
         self.assertEqual(topic["taxonomy_profile"], "")
         self.assertIn(
-            os.path.join("关注推送", "其他群", "AI伴侣交互"),
+            obsidian_relpath("关注推送", "其他群", "AI伴侣交互"),
             result["obsidian_path"],
         )
 
@@ -1628,8 +1633,8 @@ class KnowledgeStoreTests(unittest.TestCase):
         topics = {t["topic_key"]: t for t in self.store.list_topics()}
         self.assertEqual(topics["example-model-thinking-tips"]["category"], "技术方法")
         self.assertEqual(topics["self-app-feature"]["category"], "自建app")
-        self.assertIn(os.path.join("关注推送", "示例技术群", "技术方法"), topics["example-model-thinking-tips"]["obsidian_path"])
-        self.assertIn(os.path.join("关注推送", "示例技术群", "自建app"), topics["self-app-feature"]["obsidian_path"])
+        self.assertIn(obsidian_relpath("关注推送", "示例技术群", "技术方法"), topics["example-model-thinking-tips"]["obsidian_path"])
+        self.assertIn(obsidian_relpath("关注推送", "示例技术群", "自建app"), topics["self-app-feature"]["obsidian_path"])
         self.assertIn("Example Model 2.0 思考链提取技巧", topics["example-model-thinking-tips"]["obsidian_path"])
         self.assertIn("自建 app 新功能讨论", topics["self-app-feature"]["obsidian_path"])
         self.assertEqual(result["removed_empty_dirs"], 2)
@@ -2112,7 +2117,7 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertEqual(event["taxonomy_profile"], HUMAN_AI_INTIMACY_PROFILE)
         self.assertEqual(event["taxonomy_version"], 2)
         self.assertIn(
-            os.path.join("关注推送", "示例人机互动群", "模型与平台"),
+            obsidian_relpath("关注推送", "示例人机互动群", "模型与平台"),
             topic["obsidian_path"],
         )
 
@@ -2195,11 +2200,11 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertEqual(len(to_paths), 2)
         self.assertEqual(len(set(to_paths)), 2)
         self.assertIn(
-            os.path.join("关注推送", "示例人机互动群", "模型与平台", "同名主题.md"),
+            obsidian_relpath("关注推送", "示例人机互动群", "模型与平台", "同名主题.md"),
             to_paths,
         )
         self.assertIn(
-            os.path.join("关注推送", "示例人机互动群", "工具与方法", "同名主题.md"),
+            obsidian_relpath("关注推送", "示例人机互动群", "工具与方法", "同名主题.md"),
             to_paths,
         )
 
@@ -2380,7 +2385,7 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertIn('  - "file"', md)
         self.assertIn("### 文件", md)
         self.assertIn("test workflow.zip", md)
-        self.assertIn("file://" + file_dir.replace(" ", "%20"), md)
+        self.assertIn(Path(file_dir).resolve().as_uri(), md)
 
     def test_attachment_mention_is_registered_with_event_transaction(self):
         messages = [

--- a/tests/test_mcp_identity.py
+++ b/tests/test_mcp_identity.py
@@ -16,6 +16,16 @@ class McpIdentityTests(unittest.TestCase):
         self.assertNotIn('"wechat-summary"', desktop)
         self.assertIn("claude mcp add we-groupchat-obsidian", code)
 
+    def test_windows_claude_code_command_quotes_checkout_paths(self):
+        code = claude_code_add_command(
+            r"C:\Project Name\.venv\Scripts\python.exe",
+            r"C:\Project Name\mcp_server.py",
+            platform_name="win32",
+        )
+
+        self.assertIn(r'"C:\Project Name\.venv\Scripts\python.exe"', code)
+        self.assertIn(r'"C:\Project Name\mcp_server.py"', code)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_notification_target.py
+++ b/tests/test_notification_target.py
@@ -14,7 +14,10 @@ class NotificationTargetTests(unittest.TestCase):
     def test_notification_data_for_path_expands_to_absolute_path(self):
         data = notification_data_for_path("~/note.md")
 
-        self.assertEqual(data["open_path"], os.path.expanduser("~/note.md"))
+        self.assertEqual(
+            data["open_path"],
+            os.path.abspath(os.path.expanduser("~/note.md")),
+        )
 
     def test_target_path_from_notification_returns_existing_path_only(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -40,9 +43,10 @@ class NotificationTargetTests(unittest.TestCase):
         self.assertEqual(commands[1], ["open", path])
 
     def test_non_markdown_notification_targets_keep_default_open(self):
-        commands = notification_open_commands_for_path("/tmp/export.txt")
+        path = os.path.abspath(os.path.join(tempfile.gettempdir(), "export.txt"))
+        commands = notification_open_commands_for_path(path)
 
-        self.assertEqual(commands, [["open", "/tmp/export.txt"]])
+        self.assertEqual(commands, [["open", path]])
 
 
 if __name__ == "__main__":

--- a/tests/test_platform_clipboard.py
+++ b/tests/test_platform_clipboard.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import patch
+
+from core.platform_clipboard import copy_text
+
+
+class PlatformClipboardTests(unittest.TestCase):
+    def test_windows_uses_unicode_clipboard_adapter(self):
+        with patch("core.platform_clipboard.sys.platform", "win32"), \
+             patch("core.platform_clipboard._copy_windows") as copy_windows:
+            copy_text("中文 summary")
+
+        copy_windows.assert_called_once_with("中文 summary")
+
+    def test_macos_uses_pbcopy_stdin(self):
+        with patch("core.platform_clipboard.sys.platform", "darwin"), \
+             patch("core.platform_clipboard.subprocess.run") as run:
+            copy_text("summary")
+
+        run.assert_called_once_with(
+            ["pbcopy"],
+            input=b"summary",
+            check=True,
+            timeout=5,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_platform_open.py
+++ b/tests/test_platform_open.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch
+
+from core.platform_open import open_target
+
+
+class PlatformOpenTests(unittest.TestCase):
+    def test_macos_reveal_uses_open_r(self):
+        with patch("core.platform_open.sys.platform", "darwin"), \
+             patch("core.platform_open.subprocess.run") as run:
+            open_target("/tmp/note.md", reveal=True)
+
+        run.assert_called_once_with(["open", "-R", "/tmp/note.md"], check=False)
+
+    def test_windows_reveal_uses_explorer_without_shell(self):
+        with patch("core.platform_open.sys.platform", "win32"), \
+             patch("core.platform_open.subprocess.run") as run:
+            open_target(r"C:\Vault\note.md", reveal=True)
+
+        run.assert_called_once_with(
+            ["explorer.exe", r"/select,C:\Vault\note.md"],
+            check=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_refresh_data_source.py
+++ b/tests/test_refresh_data_source.py
@@ -1,7 +1,8 @@
+import sys
 import unittest
 from unittest.mock import patch
 
-from scripts.refresh_data_source import refresh_data_source
+from scripts.refresh_data_source import RefreshResult, main, refresh_data_source
 
 
 class RefreshDataSourceTests(unittest.TestCase):
@@ -13,13 +14,16 @@ class RefreshDataSourceTests(unittest.TestCase):
              patch("scripts.refresh_data_source.process_lookup_available", return_value=True), \
              patch("scripts.refresh_data_source.is_wechat_running", return_value=True), \
              patch("scripts.refresh_data_source.os.path.isdir", return_value=True), \
-             patch("scripts.refresh_data_source.extract_keys", return_value=keys), \
+             patch("scripts.refresh_data_source.extract_keys", return_value=keys) as extract, \
              patch("scripts.refresh_data_source.check_new_databases", return_value=[]):
-            result = refresh_data_source()
+            result = refresh_data_source(raw_key_hex="ab" * 32 if sys.platform == "win32" else None)
 
         self.assertTrue(result.ok)
         self.assertEqual(result.key_count, 1)
         self.assertEqual(result.missing_databases, [])
+        extract.assert_called_once_with(
+            raw_key_hex="ab" * 32 if sys.platform == "win32" else None
+        )
 
     def test_reports_missing_database_keys_after_refresh(self):
         config = {"db_dir": "/tmp/db_storage"}
@@ -31,18 +35,52 @@ class RefreshDataSourceTests(unittest.TestCase):
              patch("scripts.refresh_data_source.os.path.isdir", return_value=True), \
              patch("scripts.refresh_data_source.extract_keys", return_value=keys), \
              patch("scripts.refresh_data_source.check_new_databases", return_value=["message/weclaw.db"]):
-            result = refresh_data_source()
+            result = refresh_data_source(raw_key_hex="ab" * 32 if sys.platform == "win32" else None)
 
         self.assertFalse(result.ok)
         self.assertEqual(result.key_count, 1)
         self.assertEqual(result.missing_databases, ["message/weclaw.db"])
 
     def test_reports_when_process_list_cannot_be_checked(self):
-        with patch("scripts.refresh_data_source.process_lookup_available", return_value=False):
+        with patch("scripts.refresh_data_source.sys.platform", "darwin"), \
+             patch("scripts.refresh_data_source.process_lookup_available", return_value=False):
             result = refresh_data_source()
 
         self.assertFalse(result.ok)
         self.assertIn("无法检测", result.message)
+
+    def test_windows_requires_explicit_private_raw_key_input(self):
+        with patch("scripts.refresh_data_source.sys.platform", "win32"):
+            result = refresh_data_source()
+
+        self.assertFalse(result.ok)
+        self.assertIn("--raw-key", result.message)
+
+    def test_remembered_raw_key_is_loaded_without_command_line_secret(self):
+        with patch("scripts.refresh_data_source.sys.platform", "win32"), \
+             patch("scripts.refresh_data_source.load_key", return_value="ab" * 32) as load, \
+             patch(
+                 "scripts.refresh_data_source.refresh_data_source",
+                 return_value=RefreshResult(ok=True, key_count=2, missing_databases=[]),
+             ) as refresh:
+            result = main(["--stored-raw-key"])
+
+        self.assertEqual(result, 0)
+        load.assert_called_once()
+        refresh.assert_called_once_with(raw_key_hex="ab" * 32)
+
+    def test_prompted_raw_key_is_remembered_only_after_full_verification(self):
+        with patch("scripts.refresh_data_source.sys.platform", "win32"), \
+             patch("scripts.refresh_data_source.getpass.getpass", return_value="cd" * 32), \
+             patch(
+                 "scripts.refresh_data_source.refresh_data_source",
+                 return_value=RefreshResult(ok=True, key_count=2, missing_databases=[]),
+             ), \
+             patch("scripts.refresh_data_source.save_key", return_value=True) as save:
+            result = main(["--raw-key", "--remember-raw-key"])
+
+        self.assertEqual(result, 0)
+        save.assert_called_once_with("windows-weixin-raw-key", "cd" * 32)
 
 
 if __name__ == "__main__":

--- a/tests/test_relation_audit.py
+++ b/tests/test_relation_audit.py
@@ -180,7 +180,12 @@ class RelationAuditTests(unittest.TestCase):
         self.assertEqual(result["fts_before"], result["fts_after"])
         self.assertEqual(result["integrity_before"], "ok")
         self.assertEqual(result["integrity_after"], "ok")
-        self.assertEqual(os.stat(backup_path).st_mode & 0o777, 0o600)
+        if os.name == "nt":
+            from core.windows_permissions import is_private_to_current_user
+
+            self.assertTrue(is_private_to_current_user(backup_path))
+        else:
+            self.assertEqual(os.stat(backup_path).st_mode & 0o777, 0o600)
 
         backup_audit = audit_relations(backup_path)
         source_audit = audit_relations(self.db_path)

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -44,6 +44,8 @@ class RepositoryLayoutTests(unittest.TestCase):
         }
 
         self.assertEqual(root_launchers, {"启动.command"})
+        self.assertTrue((REPO_ROOT / "启动.cmd").is_file())
+        self.assertTrue((REPO_ROOT / "launchers" / "启动.ps1").is_file())
         self.assertEqual(canonical_launchers, expected)
         self.assertTrue(all(
             os.access(REPO_ROOT / "launchers" / name, os.X_OK)

--- a/tests/test_resource_backup.py
+++ b/tests/test_resource_backup.py
@@ -1,4 +1,4 @@
-import fcntl
+from core import file_lock as fcntl
 import hashlib
 import io
 import json

--- a/tests/test_taxonomy_migration.py
+++ b/tests/test_taxonomy_migration.py
@@ -3,7 +3,7 @@ import io
 import json
 import os
 import errno
-import fcntl
+from core import file_lock as fcntl
 import shutil
 import sqlite3
 import stat

--- a/tests/test_windows_autostart.py
+++ b/tests/test_windows_autostart.py
@@ -1,0 +1,105 @@
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+from xml.etree import ElementTree
+
+from scripts.windows_autostart import (
+    TASK_NAME,
+    TASK_XML_NAMESPACE,
+    build_task_xml,
+    install,
+    uninstall,
+    validate,
+)
+
+
+class WindowsAutostartTests(unittest.TestCase):
+    def make_project(self, root: Path) -> Path:
+        project = root / "Project Name"
+        launcher = project / "launchers" / "启动.ps1"
+        launcher.parent.mkdir(parents=True)
+        launcher.write_text("", encoding="utf-8")
+        return project
+
+    def test_task_is_per_user_keepalive_without_embedded_secrets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = self.make_project(Path(tmp))
+
+            xml = build_task_xml(
+                project_dir=project,
+                user_sid="S-1-5-21-fixture",
+                environ={"SystemRoot": r"C:\Windows"},
+            )
+
+        root = ElementTree.fromstring(xml)
+        ns = {"task": TASK_XML_NAMESPACE}
+        self.assertEqual(
+            root.findtext("task:Principals/task:Principal/task:LogonType", namespaces=ns),
+            "InteractiveToken",
+        )
+        self.assertEqual(
+            root.findtext("task:Settings/task:RestartOnFailure/task:Count", namespaces=ns),
+            "3",
+        )
+        self.assertEqual(
+            root.findtext("task:Settings/task:RestartOnFailure/task:Interval", namespaces=ns),
+            "PT1M",
+        )
+        arguments = root.findtext("task:Actions/task:Exec/task:Arguments", namespaces=ns)
+        self.assertIn("--autostart", arguments)
+        self.assertIn("--no-pause", arguments)
+        self.assertNotIn("raw-key", arguments)
+
+    def test_install_registers_generated_task_definition(self):
+        runner = Mock(return_value=SimpleNamespace(returncode=0))
+        with tempfile.TemporaryDirectory() as tmp:
+            project = self.make_project(Path(tmp))
+
+            result = install(
+                project_dir=project,
+                user_sid="S-1-5-21-fixture",
+                runner=runner,
+            )
+
+        self.assertEqual(result, 0)
+        command = runner.call_args.args[0]
+        self.assertEqual(command[:5], ["schtasks.exe", "/Create", "/TN", TASK_NAME, "/XML"])
+        self.assertEqual(command[-1], "/F")
+
+    def test_uninstall_is_idempotent_and_forgets_remembered_raw_key(self):
+        runner = Mock(return_value=SimpleNamespace(returncode=1))
+        with patch("scripts.windows_autostart.delete_key") as delete_key:
+            result = uninstall(runner=runner)
+
+        self.assertEqual(result, 0)
+        runner.assert_called_once_with(
+            ["schtasks.exe", "/Query", "/TN", TASK_NAME],
+            stdout=-3,
+            stderr=-3,
+            check=False,
+        )
+        delete_key.assert_called_once()
+
+    def test_validate_registers_queries_and_cleans_random_task(self):
+        runner = Mock(side_effect=[
+            SimpleNamespace(returncode=0),
+            SimpleNamespace(returncode=0),
+            SimpleNamespace(returncode=0),
+        ])
+        with patch("scripts.windows_autostart.current_user_sid_string", return_value="S-1-5-21-fixture"):
+            result = validate(runner=runner)
+
+        self.assertEqual(result, 0)
+        calls = [call.args[0] for call in runner.call_args_list]
+        task_names = [arguments[3] for arguments in calls]
+        self.assertTrue(task_names[0].startswith(f"{TASK_NAME}-validation-"))
+        self.assertEqual(task_names, [task_names[0]] * 3)
+        self.assertEqual(calls[0][1], "/Create")
+        self.assertEqual(calls[1][1], "/Query")
+        self.assertEqual(calls[2][1], "/Delete")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_console.py
+++ b/tests/test_windows_console.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from core.windows_console import configure_utf8_stdio
+
+
+class WindowsConsoleTests(unittest.TestCase):
+    def test_windows_stdio_is_reconfigured_for_utf8(self):
+        stdout = Mock()
+        stderr = Mock()
+        with patch("core.windows_console.sys.platform", "win32"), \
+             patch("core.windows_console.sys.stdout", stdout), \
+             patch("core.windows_console.sys.stderr", stderr):
+            configure_utf8_stdio()
+
+        stdout.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+        stderr.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+
+    def test_non_windows_stdio_is_unchanged(self):
+        stdout = Mock()
+        with patch("core.windows_console.sys.platform", "darwin"), \
+             patch("core.windows_console.sys.stdout", stdout):
+            configure_utf8_stdio()
+
+        stdout.reconfigure.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_key_extractor.py
+++ b/tests/test_windows_key_extractor.py
@@ -1,0 +1,167 @@
+import hashlib
+import hmac
+import json
+import os
+import struct
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from Crypto.Cipher import AES
+
+from core.decryptor import (
+    HMAC_SZ,
+    PAGE_SZ,
+    RESERVE_SZ,
+    SQLITE_HDR,
+    decrypt_database,
+    derive_mac_key,
+)
+from core.windows_key_extractor import (
+    build_key_map_from_raw_key,
+    derive_page_key,
+    extract_keys_from_raw_key,
+    get_weixin_app_path,
+)
+
+
+def _encrypted_page1(page_key, salt):
+    page = bytearray(hashlib.sha512(b"page-fixture").digest() * 64)
+    page[:16] = salt
+    mac_key = derive_mac_key(page_key, salt)
+    signed = page[16 : PAGE_SZ - RESERVE_SZ + 16]
+    digest = hmac.new(mac_key, signed, hashlib.sha512)
+    digest.update(struct.pack("<I", 1))
+    page[PAGE_SZ - HMAC_SZ :] = digest.digest()
+    return bytes(page)
+
+
+class WindowsKeyExtractorTests(unittest.TestCase):
+    def test_weixin_install_detection_does_not_accept_classic_wechat(self):
+        with patch("core.windows_key_extractor.os.path.isfile") as isfile:
+            isfile.side_effect = lambda path: path.endswith(
+                os.path.join("Tencent", "Weixin", "Weixin.exe")
+            )
+
+            path = get_weixin_app_path({"ProgramFiles": r"C:\Program Files"})
+
+        self.assertEqual(
+            path,
+            os.path.join(r"C:\Program Files", "Tencent", "Weixin", "Weixin.exe"),
+        )
+
+    def test_raw_key_derives_existing_page_key_map_shape(self):
+        raw_key = bytes(range(32))
+        salt = bytes(range(16, 32))
+        page_key = derive_page_key(raw_key, salt)
+        with tempfile.TemporaryDirectory() as tmp:
+            message_dir = os.path.join(tmp, "message")
+            os.makedirs(message_dir)
+            db_path = os.path.join(message_dir, "message_0.db")
+            with open(db_path, "wb") as handle:
+                handle.write(_encrypted_page1(page_key, salt))
+
+            keys = build_key_map_from_raw_key(raw_key.hex(), tmp)
+
+        self.assertEqual(
+            keys,
+            {"message/message_0.db": {"enc_key": page_key.hex()}},
+        )
+
+    def test_wrong_raw_key_is_not_persistable_as_page_key(self):
+        raw_key = bytes(range(32))
+        salt = bytes(range(16, 32))
+        page_key = derive_page_key(raw_key, salt)
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "contact.db"), "wb") as handle:
+                handle.write(_encrypted_page1(page_key, salt))
+
+            keys = build_key_map_from_raw_key((b"x" * 32).hex(), tmp)
+
+        self.assertEqual(keys, {})
+
+    def test_refresh_preserves_existing_page_keys(self):
+        raw_key = bytes(range(32))
+        salt = bytes(range(16, 32))
+        page_key = derive_page_key(raw_key, salt)
+        existing_key = "ab" * 32
+        with tempfile.TemporaryDirectory() as tmp:
+            message_dir = os.path.join(tmp, "message")
+            os.makedirs(message_dir)
+            with open(os.path.join(message_dir, "message_0.db"), "wb") as handle:
+                handle.write(_encrypted_page1(page_key, salt))
+            keys_path = os.path.join(tmp, "all_keys.json")
+            with open(keys_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {"contact/contact.db": {"enc_key": existing_key}},
+                    handle,
+                )
+
+            keys = extract_keys_from_raw_key(raw_key.hex(), tmp, keys_path)
+            with open(keys_path, encoding="utf-8") as handle:
+                persisted = json.load(handle)
+
+        self.assertEqual(keys["contact/contact.db"]["enc_key"], existing_key)
+        self.assertEqual(
+            keys["message/message_0.db"]["enc_key"],
+            page_key.hex(),
+        )
+        self.assertEqual(persisted, keys)
+
+    def test_wrong_raw_key_leaves_existing_key_file_unchanged(self):
+        raw_key = bytes(range(32))
+        salt = bytes(range(16, 32))
+        page_key = derive_page_key(raw_key, salt)
+        original = '{"contact/contact.db":{"enc_key":"' + ("ab" * 32) + '"}}'
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "contact.db"), "wb") as handle:
+                handle.write(_encrypted_page1(page_key, salt))
+            keys_path = os.path.join(tmp, "all_keys.json")
+            with open(keys_path, "w", encoding="utf-8") as handle:
+                handle.write(original)
+
+            keys = extract_keys_from_raw_key((b"x" * 32).hex(), tmp, keys_path)
+            with open(keys_path, encoding="utf-8") as handle:
+                after = handle.read()
+
+        self.assertIsNone(keys)
+        self.assertEqual(after, original)
+
+    def test_raw_key_map_drives_original_database_decryptor(self):
+        raw_key = bytes(range(32))
+        salt = bytes(range(16))
+        page_key = derive_page_key(raw_key, salt)
+        iv = bytes(range(32, 48))
+        body = bytes(index % 251 for index in range(4000))
+        encrypted = AES.new(page_key, AES.MODE_CBC, iv).encrypt(body)
+        page1 = bytearray(salt + encrypted + iv + bytes(HMAC_SZ))
+        mac_key = derive_mac_key(page_key, salt)
+        digest = hmac.new(
+            mac_key,
+            page1[16 : PAGE_SZ - RESERVE_SZ + 16],
+            hashlib.sha512,
+        )
+        digest.update(struct.pack("<I", 1))
+        page1[PAGE_SZ - HMAC_SZ :] = digest.digest()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "session.db")
+            output = os.path.join(tmp, "plain", "session.db")
+            with open(db_path, "wb") as handle:
+                handle.write(page1)
+            keys = build_key_map_from_raw_key(raw_key.hex(), tmp)
+            pages = decrypt_database(
+                db_path,
+                output,
+                keys["session.db"]["enc_key"],
+            )
+            with open(output, "rb") as handle:
+                plaintext = handle.read()
+
+        self.assertEqual(pages, 1)
+        self.assertEqual(plaintext[:16], SQLITE_HDR)
+        self.assertEqual(plaintext[16:4016], body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_launcher.py
+++ b/tests/test_windows_launcher.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import unittest
+
+from tests.paths import REPO_ROOT
+
+
+class WindowsLauncherTests(unittest.TestCase):
+    def test_double_click_stub_delegates_to_canonical_powershell_launcher(self):
+        stub_path = REPO_ROOT / "启动.cmd"
+        stub = stub_path.read_text(encoding="utf-8")
+
+        self.assertIn("launchers\\启动.ps1", stub)
+        self.assertNotIn("pip install", stub)
+        self.assertIn(b"\r\n", stub_path.read_bytes())
+
+    def test_launcher_requires_consent_before_dependency_install(self):
+        launcher_path = REPO_ROOT / "launchers" / "启动.ps1"
+        launcher = launcher_path.read_text(encoding="utf-8-sig")
+
+        self.assertIn("Confirm-DependencyInstall", launcher)
+        self.assertIn("Get-WgoSha256", launcher)
+        self.assertNotIn("Get-FileHash", launcher)
+        self.assertIn("--refresh-data-source", launcher)
+        self.assertIn("scripts\\refresh_data_source.py", launcher)
+        self.assertIn("--install-autostart", launcher)
+        self.assertIn("--remember-raw-key", launcher)
+        self.assertIn("--stored-raw-key", launcher)
+        self.assertIn("$Autostart", launcher)
+        self.assertIn("scripts\\windows_autostart.py", launcher)
+        self.assertNotIn("raw_key_hex", launcher)
+        self.assertTrue(launcher_path.read_bytes().startswith(b"\xef\xbb\xbf"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_permissions.py
+++ b/tests/test_windows_permissions.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+import unittest
+
+from core.windows_permissions import (
+    is_private_to_current_user,
+    restrict_path_to_current_user,
+)
+
+
+@unittest.skipUnless(os.name == "nt", "Windows ACL behavior")
+class WindowsPermissionsTests(unittest.TestCase):
+    def test_restricts_file_and_directory_to_current_user(self):
+        with tempfile.TemporaryDirectory() as root:
+            path = os.path.join(root, "private.json")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("{}")
+
+            self.assertTrue(restrict_path_to_current_user(root, is_directory=True))
+            self.assertTrue(restrict_path_to_current_user(path, is_directory=False))
+            self.assertTrue(is_private_to_current_user(root))
+            self.assertTrue(is_private_to_current_user(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_rumps.py
+++ b/tests/test_windows_rumps.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from ui import windows_rumps as rumps
+
+
+class WindowsRumpsTests(unittest.TestCase):
+    def test_menu_supports_existing_app_mutation_contract(self):
+        menu = rumps.Menu([
+            rumps.MenuItem("first"),
+            rumps.separator,
+            rumps.MenuItem("last"),
+        ])
+
+        menu.insert_after("first", rumps.MenuItem("middle"))
+        menu.insert_before("last", rumps.MenuItem("before-last"))
+        del menu["middle"]
+
+        self.assertEqual(menu.keys(), ["first", "before-last", "last"])
+
+    def test_menu_item_keeps_nested_titles_and_callbacks(self):
+        callback = Mock()
+        parent = rumps.MenuItem("parent")
+        child = rumps.MenuItem("child", callback=callback)
+        parent.add(child)
+
+        self.assertEqual(parent.keys(), ["child"])
+        self.assertIs(parent["child"].callback, callback)
+
+    def test_timer_stop_is_idempotent(self):
+        timer = rumps.Timer(lambda _timer: None, 1)
+
+        timer.stop()
+        timer.stop()
+
+    def test_secure_window_records_masked_input_contract(self):
+        window = rumps.Window("message", secure=True)
+
+        self.assertTrue(window.secure)
+
+    def test_notification_before_tray_start_is_queued(self):
+        before = len(rumps._pending_notifications)
+
+        rumps.notification("title", "subtitle", "message")
+
+        self.assertEqual(len(rumps._pending_notifications), before + 1)
+        rumps._pending_notifications.pop()
+
+    def test_native_pystray_menu_builds_from_nested_rumps_shape(self):
+        app = rumps.App("WGO", quit_button="退出")
+        parent = rumps.MenuItem("parent")
+        parent.add(rumps.MenuItem("child", callback=lambda _item: None))
+        app.menu = [parent, rumps.separator, rumps.MenuItem("info")]
+
+        native = app._build_native_menu()
+
+        self.assertGreaterEqual(len(native.items), 5)
+
+    def test_run_constructs_windows_tray_backend(self):
+        app = rumps.App("WGO")
+        app.menu = [rumps.MenuItem("action", callback=lambda _item: None)]
+
+        with patch("pystray.Icon.run") as run:
+            app.run()
+
+        run.assert_called_once()
+        self.assertTrue(callable(run.call_args.kwargs["setup"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_runtime.py
+++ b/tests/test_windows_runtime.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+
+from core.windows_runtime import inspect_windows_runtime
+
+
+class WindowsRuntimeTests(unittest.TestCase):
+    def test_ready_requires_database_verified_keys_and_no_missing_required_key(self):
+        with patch("core.windows_runtime.load_config", return_value={"db_dir": "db"}), \
+             patch("core.windows_runtime.os.path.isdir", return_value=True), \
+             patch("core.windows_runtime.get_cached_keys", return_value={"contact/contact.db": {"enc_key": "x"}}), \
+             patch("core.windows_runtime.load_key", return_value="raw"), \
+             patch("core.windows_runtime.check_new_databases", return_value=[]), \
+             patch("core.windows_runtime.get_weixin_app_path", return_value="Weixin.exe"), \
+             patch("core.windows_runtime.process_lookup_available", return_value=True), \
+             patch("core.windows_runtime.is_weixin_running", return_value=True):
+            status = inspect_windows_runtime()
+
+        self.assertTrue(status["ready"])
+        self.assertEqual(status["key_count"], 1)
+        self.assertTrue(status["raw_key_remembered"])
+
+    def test_missing_required_key_is_not_ready(self):
+        with patch("core.windows_runtime.load_config", return_value={"db_dir": "db"}), \
+             patch("core.windows_runtime.os.path.isdir", return_value=True), \
+             patch("core.windows_runtime.get_cached_keys", return_value={"contact/contact.db": {"enc_key": "x"}}), \
+             patch("core.windows_runtime.load_key", return_value=None), \
+             patch("core.windows_runtime.check_new_databases", return_value=["session/session.db"]), \
+             patch("core.windows_runtime.get_weixin_app_path", return_value="Weixin.exe"), \
+             patch("core.windows_runtime.process_lookup_available", return_value=True), \
+             patch("core.windows_runtime.is_weixin_running", return_value=True):
+            status = inspect_windows_runtime()
+
+        self.assertFalse(status["ready"])
+        self.assertEqual(status["missing_required_key_count"], 1)
+
+    def test_empty_database_setting_does_not_treat_checkout_as_source(self):
+        with patch("core.windows_runtime.load_config", return_value={"db_dir": ""}), \
+             patch("core.windows_runtime.get_cached_keys", return_value=None), \
+             patch("core.windows_runtime.load_key", return_value=None), \
+             patch("core.windows_runtime.get_weixin_app_path", return_value=None), \
+             patch("core.windows_runtime.process_lookup_available", return_value=False):
+            status = inspect_windows_runtime()
+
+        self.assertFalse(status["db_configured"])
+        self.assertFalse(status["db_available"])
+        self.assertFalse(status["ready"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/windows_rumps.py
+++ b/ui/windows_rumps.py
@@ -1,0 +1,332 @@
+"""Small rumps-compatible Windows tray adapter used by the canonical app.
+
+The application keeps its existing menu construction and callbacks.  This
+module only translates that UI surface to pystray/tkinter on Windows.
+"""
+from __future__ import annotations
+
+import threading
+import traceback
+from types import SimpleNamespace
+
+
+class _Separator:
+    pass
+
+
+separator = _Separator()
+_active_app = None
+_notification_handler = None
+_pending_notifications = []
+_notification_lock = threading.Lock()
+
+
+class Menu:
+    def __init__(self, items=None, *, owner=None):
+        self._items = []
+        self._owner = owner
+        for item in items or []:
+            self.add(item, notify=False)
+
+    def _set_owner(self, owner):
+        self._owner = owner
+        for item in self._items:
+            if isinstance(item, MenuItem):
+                item._menu._set_owner(owner)
+
+    def _changed(self):
+        if self._owner is not None:
+            self._owner._menu_changed()
+
+    @staticmethod
+    def _title(item):
+        return item.title if isinstance(item, MenuItem) else None
+
+    def _index(self, title):
+        for index, item in enumerate(self._items):
+            if self._title(item) == title:
+                return index
+        raise KeyError(title)
+
+    def add(self, item, *, notify=True):
+        if item is not separator and not isinstance(item, MenuItem):
+            item = MenuItem(str(item))
+        if isinstance(item, MenuItem):
+            item._menu._set_owner(self._owner)
+        self._items.append(item)
+        if notify:
+            self._changed()
+        return item
+
+    def insert_before(self, title, item):
+        index = self._index(title)
+        if item is not separator and not isinstance(item, MenuItem):
+            item = MenuItem(str(item))
+        if isinstance(item, MenuItem):
+            item._menu._set_owner(self._owner)
+        self._items.insert(index, item)
+        self._changed()
+
+    def insert_after(self, title, item):
+        index = self._index(title) + 1
+        if item is not separator and not isinstance(item, MenuItem):
+            item = MenuItem(str(item))
+        if isinstance(item, MenuItem):
+            item._menu._set_owner(self._owner)
+        self._items.insert(index, item)
+        self._changed()
+
+    def keys(self):
+        return [
+            item.title for item in self._items if isinstance(item, MenuItem)
+        ]
+
+    def __contains__(self, title):
+        return title in self.keys()
+
+    def __getitem__(self, title):
+        return self._items[self._index(title)]
+
+    def __delitem__(self, title):
+        del self._items[self._index(title)]
+        self._changed()
+
+    def __iter__(self):
+        return iter(self._items)
+
+
+class MenuItem:
+    def __init__(self, title, callback=None, **_kwargs):
+        self.title = str(title)
+        self.callback = callback
+        self._menu = Menu()
+
+    def add(self, item):
+        return self._menu.add(item)
+
+    def keys(self):
+        return self._menu.keys()
+
+    def __contains__(self, title):
+        return title in self._menu
+
+    def __getitem__(self, title):
+        return self._menu[title]
+
+    def __delitem__(self, title):
+        del self._menu[title]
+
+
+class Timer:
+    def __init__(self, callback, interval):
+        self.callback = callback
+        self.interval = max(0.01, float(interval))
+        self._stop = threading.Event()
+        self._thread = None
+
+    def start(self):
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        while not self._stop.wait(self.interval):
+            try:
+                self.callback(self)
+            except Exception:
+                traceback.print_exc()
+
+    def stop(self):
+        self._stop.set()
+
+
+class Window:
+    def __init__(
+        self,
+        message="",
+        title="",
+        default_text="",
+        ok="OK",
+        cancel="Cancel",
+        dimensions=(300, 24),
+        secure=False,
+        **_kwargs,
+    ):
+        self.message = str(message)
+        self.title = str(title)
+        self.default_text = str(default_text)
+        self.ok = str(ok)
+        self.cancel = str(cancel)
+        self.dimensions = dimensions
+        self.secure = bool(secure)
+
+    def run(self):
+        import tkinter as tk
+        from tkinter import messagebox, simpledialog
+
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes("-topmost", True)
+        try:
+            if tuple(self.dimensions) == (0, 0):
+                clicked = messagebox.askokcancel(
+                    self.title,
+                    self.message,
+                    parent=root,
+                )
+                return SimpleNamespace(clicked=bool(clicked), text="")
+            options = {
+                "initialvalue": self.default_text,
+                "parent": root,
+            }
+            if self.secure:
+                options["show"] = "*"
+            value = simpledialog.askstring(self.title, self.message, **options)
+            return SimpleNamespace(clicked=value is not None, text=value or "")
+        finally:
+            root.destroy()
+
+
+def clicked(_title):
+    def decorate(function):
+        return function
+
+    return decorate
+
+
+def notifications(function):
+    global _notification_handler
+    _notification_handler = function
+    return function
+
+
+def notification(title, subtitle, message, data=None):
+    del data  # pystray notifications do not expose a portable click payload.
+    body = f"{subtitle}\n{message}" if subtitle else str(message)
+    if (
+        _active_app is None
+        or _active_app._icon is None
+        or not _active_app._notification_ready.is_set()
+    ):
+        with _notification_lock:
+            _pending_notifications.append((str(title), body))
+            del _pending_notifications[:-20]
+        return
+    _active_app._icon.notify(body, str(title))
+
+
+class App:
+    def __init__(
+        self,
+        name,
+        title=None,
+        icon=None,
+        template=False,
+        quit_button="Quit",
+        **_kwargs,
+    ):
+        del template
+        self.name = str(name)
+        self.title = str(title or name)
+        self.icon = icon
+        self.quit_button = str(quit_button or "Quit")
+        self._menu = Menu(owner=self)
+        self._icon = None
+        self._menu_lock = threading.RLock()
+        self._notification_ready = threading.Event()
+
+    @property
+    def menu(self):
+        return self._menu
+
+    @menu.setter
+    def menu(self, items):
+        menu = items if isinstance(items, Menu) else Menu(items)
+        menu._set_owner(self)
+        self._menu = menu
+        self._menu_changed()
+
+    def _menu_changed(self):
+        with self._menu_lock:
+            if self._icon is not None:
+                try:
+                    self._icon.menu = self._build_native_menu()
+                    self._icon.update_menu()
+                except Exception:
+                    traceback.print_exc()
+
+    def _native_callback(self, item):
+        def invoke(_icon, _native_item):
+            try:
+                if callable(item.callback):
+                    item.callback(item)
+            except Exception:
+                traceback.print_exc()
+            finally:
+                self._menu_changed()
+
+        return invoke
+
+    def _native_item(self, pystray, item):
+        if item is separator:
+            return pystray.Menu.SEPARATOR
+        submenu = None
+        if item._menu._items:
+            submenu = pystray.Menu(*[
+                self._native_item(pystray, child) for child in item._menu
+            ])
+        action = submenu if submenu is not None else self._native_callback(item)
+        return pystray.MenuItem(item.title, action, enabled=bool(submenu or item.callback))
+
+    def _build_native_menu(self):
+        import pystray
+
+        native = [self._native_item(pystray, item) for item in self._menu]
+        native.extend((
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(self.quit_button, lambda icon, _item: icon.stop()),
+        ))
+        return pystray.Menu(*native)
+
+    def run(self):
+        global _active_app
+        import pystray
+        from PIL import Image
+
+        image_path = self.icon
+        if not image_path:
+            from pathlib import Path
+
+            image_path = str(
+                Path(__file__).resolve().parents[1] / "resources" / "app_icon.png"
+            )
+        with Image.open(image_path) as source_image:
+            image = source_image.copy()
+        self._icon = pystray.Icon(
+            "we-groupchat-obsidian",
+            image,
+            self.title,
+            self._build_native_menu(),
+        )
+        _active_app = self
+        self._notification_ready.clear()
+
+        def setup(icon):
+            icon.visible = True
+            self._notification_ready.set()
+            with _notification_lock:
+                pending = list(_pending_notifications)
+                _pending_notifications.clear()
+            for title, body in pending:
+                try:
+                    icon.notify(body, title)
+                except Exception:
+                    traceback.print_exc()
+        try:
+            self._icon.run(setup=setup)
+        finally:
+            self._notification_ready.clear()
+            _active_app = None
+            self._icon = None

--- a/使用说明.txt
+++ b/使用说明.txt
@@ -7,13 +7,41 @@
 
   https://github.com/IndelibleVivi/we-groupchat-obsidian/blob/main/README.zh-CN.md
 
-这个项目是 source-distributed macOS menu-bar app。公开 repo 是正式分发入口；
-目前不提供已签名 installer、.dmg 或 bundled Python runtime。
+这个项目是 source-distributed macOS menu-bar / Windows tray app。公开 repo 是
+正式分发入口；目前不提供已签名 installer、.dmg 或 bundled Python runtime。
 
 
 ============================================
     第一次运行
 ============================================
+
+Windows 微信 4.x：
+
+1. 从公开 repo clone：
+
+     git clone https://github.com/IndelibleVivi/we-groupchat-obsidian.git
+     cd we-groupchat-obsidian
+     .\启动.cmd
+
+2. 启动器会先征求依赖安装同意，自动发现 db_storage。首次没有数据库密钥时，
+   按提示遮蔽输入当前账户 64 位十六进制 raw key。也可以单独运行：
+
+     .\启动.cmd --refresh-data-source
+
+   WGO 不捆绑/下载第三方 key extractor。raw key 不进命令行、config、log 或计划任务
+   参数；普通刷新只在内存中派生逐库密钥，且只保存通过原 page HMAC 验证的结果。
+
+3. Windows 登录自启不会默认安装。需要时显式运行：
+
+     .\启动.cmd --install-autostart
+
+   该命令会重新遮蔽输入并验证 raw key，再把它保存到 Windows 凭据管理器；计划任务
+   负责登录启动、拒绝重复实例和异常退出后一分钟间隔最多三次重启。发现新增必需数据库
+   时会自动重新派生/验证逐库密钥。它不会扫描内存或猜测已轮换的 raw key；如果
+   账户 raw key 变了，重新运行 `--install-autostart` 遮蔽输入一次。卸载自启会同时
+   删除计划任务和记住的 raw key。
+
+macOS：
 
 1. 从公开 repo clone：
 
@@ -33,10 +61,11 @@
 4. 菜单栏出现 💬 图标后，在“设置”里选择 AI provider 并填写 API Key。
 
 支持通义千问（新安装默认）、DeepSeek、Claude、OpenAI、Ollama 和自定义
-OpenAI-compatible endpoint。API Key 存在 macOS Keychain，不写入 repo。
+OpenAI-compatible endpoint。API Key 存在 macOS 钥匙串或 Windows 凭据管理器，
+不写入 repo。
 云端 provider 会收到你要求总结/判断的聊天文本；需要本地 AI 时使用 Ollama。
 
-macOS 可能在菜单 app 启动后询问一次 WeChat App Data 访问。source guard、
+macOS 可能在菜单 app 启动后询问一次 WeChat App Data 访问。macOS source guard、
 monitor 与 mounted-resource timer 都由这只长驻 app 负责，不会靠每几分钟启动
 短命 worker 来反复索取授权。附件 bytes 解析还需要单独开启，授权只在当前
 app process/session 内存里有效，重启后自动关闭。
@@ -57,8 +86,21 @@ app process/session 内存里有效，重启后自动关闭。
 
      ./启动.command
 
-前台启动时关闭该 Terminal 或按 Ctrl+C 会结束这次 app process。需要登录自启时，
-请使用下面的安装入口；不要自己复制或改写 LaunchAgent plist。
+启动 Windows 托盘 app：
+
+     .\启动.cmd
+
+Windows 常用维护入口：
+
+     .\启动.cmd --setup-only
+     .\启动.cmd --health-check
+     .\启动.cmd --refresh-data-source
+     .\启动.cmd --install-autostart
+     .\启动.cmd --uninstall-autostart
+
+前台启动时关闭该 Terminal 或按 Ctrl+C 会结束这次 app process。Windows 请用
+`--install-autostart` 管理计划任务；macOS 请用下面的安装入口，不要自己复制或改写
+LaunchAgent plist。
 
 常用 Finder/Terminal helper：
 
@@ -106,7 +148,7 @@ archive；Obsidian note 可以链接到私有归档 object，但附件 bytes 不
   source guard 和 MCP 真实发送；不要因为看到命令存在就把它们当成已经启用。
 - Mounted target 只证明目标 filesystem bytes/readback，不证明云端 provider 已上传。
 - 每轮 mounted backup 会维护 wgo-resource-backup/00-打开微信资源备份.md；也可从菜单
-  “在 Finder 打开文件备份”直接进入。入口分成“文件备份”“待补齐附件”“资源索引”：
+  “在文件夹中显示文件备份”直接进入。入口分成“文件备份”“待补齐附件”“资源索引”：
   文件备份只列真正已交付的去重文件，并显示群聊出现次数；待补齐页按真实状态分组且没有
   target link。看到“本地缓存暂未找到”时，先在微信里重新打开或下载附件，再点立即更新。
   “已备份”只表示 mounted target 已交付并即时校验，不表示 provider 云端同步已经完成。
@@ -129,6 +171,11 @@ docs/resource-capture-and-mounted-backup-spec.md 为准。
 
      git pull --ff-only
      ./启动.command
+
+Windows 更新后运行：
+
+     git pull --ff-only
+     .\启动.cmd
 
 分享给别人时只发送公开 repo 或中文版 README 链接：
 

--- a/功能说明.txt
+++ b/功能说明.txt
@@ -2,11 +2,29 @@
     we-groupchat-obsidian - 简明功能索引
 ============================================
 
-这份 .txt 方便在 Finder 或离线源码里快速浏览当前能力，不承担完整 contract。
+这份 .txt 方便在文件管理器或离线源码里快速浏览当前能力，不承担完整 contract。
 用户与 operator authority 是 README.zh-CN.md；可靠性和资源流的 formal contract 是：
 
   docs/source-reliability.zh-CN.md
   docs/resource-capture-and-mounted-backup-spec.md
+
+
+============================================
+    平台支持边界
+============================================
+
+- macOS 是完整支持平台；Windows 微信 4.x 当前是 source-distributed 适配预览。
+- Windows 继续走原有 WeChatDB 解密、总结、搜索、monitor、Obsidian 与 MCP read 主链；
+  新增层只负责 db_storage discovery、raw key 逐库派生/验证、ACL、凭据管理器、托盘、
+  Unicode 剪贴板、PowerShell 启动器和当前用户登录自启。
+- Windows raw key 只通过遮蔽输入，不写 config/log/命令行/计划任务参数；普通刷新只进
+  内存。显式安装自启时可保存到 Windows 凭据管理器，用于新增 DB 自动续期；仓库不
+  捆绑或下载第三方 extractor，只持久化通过原 page HMAC 验证的逐库密钥 map。
+- Windows 自启使用当前用户计划任务，拒绝重复实例，并在异常退出后按一分钟间隔最多
+  重启三次；卸载时删除任务和记住的 raw key，不删除已派生逐库密钥。
+- 自动续期只会用已记住的 raw key 补齐新 DB 分片，不扫描内存或猜测已轮换的 raw key。
+- source guard、通知点击跳转、MCP 真实 UI 发送、py2app 与高级附件/mounted-backup
+  链在 Windows 上尚不宣称支持；默认关闭的 advanced lane 不因入口存在而视为可用。
 
 
 ============================================
@@ -80,7 +98,7 @@ monitor checkpoint 倒退成“没处理过”。
   sync_delegated 只证明目标 bytes/readback，不证明 provider-side upload。
 - 输出包括 immutable CAS object、privacy-bounded catalog snapshot、Markdown resource
   indexes 和 receipts；GC 只删除 manifest-owned generated paths。
-- Mounted 根部的 00-打开微信资源备份.md 是人类入口；菜单也可以直接在 Finder reveal。
+- Mounted 根部的 00-打开微信资源备份.md 是人类入口；菜单也可以直接在系统文件管理器中 reveal。
   入口下有文件备份、待补齐附件和资源总索引三套平行 view。文件备份按群聊/月列已交付
   digest，每个 object 一行并显示 occurrence 次数；待补齐页按 queued、cache unavailable、retry、
   local-space、attention、awaiting-handoff 与 unknown 分组，不生成 target link。三套 view 共用
@@ -105,7 +123,7 @@ monitor checkpoint 倒退成“没处理过”。
   namespace，避免不同账号/数据根互相碰撞。
 - 可选 source guard 运行在长驻菜单 app 内，受 grace、pause、restart budget、
   exponential backoff 和 content-free receipts 约束。
-- Source guard 只请求 macOS 正常打开微信；不会 kill、re-sign、登录或操作微信 UI，
+- Source guard 是 macOS-only，只请求系统正常打开微信；不会 kill、re-sign、登录或操作微信 UI，
   也不会把 process lookup unknown 猜成“微信没运行”。
 
 
@@ -123,7 +141,7 @@ MCP 可以让 Claude Desktop、Claude Code、Cursor、OpenClaw 等 client 查询
 - enabled 仍然拒绝空目标。
 - allowlist/enabled 必须先 prepare_send_message，给人核对 exact target/text，再以
   未过期 nonce 调 confirm_send_message；compatibility send_message 不会绕过确认。
-- 真实发送还需要 macOS Accessibility permission，并在写入后做数据库 readback。
+- 真实发送仍是 macOS-only，需要 Accessibility permission，并在写入后做数据库 readback。
 
 
 ============================================
@@ -137,6 +155,12 @@ MCP 可以让 Claude Desktop、Claude Code、Cursor、OpenClaw 等 client 查询
   ownership locks；worker_busy 或 unknown 不是 success。
 
 常用入口：
+
+  .\启动.cmd
+  .\启动.cmd --health-check
+  .\启动.cmd --refresh-data-source
+  .\启动.cmd --install-autostart
+  .\启动.cmd --uninstall-autostart
 
   ./启动.command
   ./launchers/配置关注推送.command

--- a/启动.cmd
+++ b/启动.cmd
@@ -1,0 +1,4 @@
+@echo off
+chcp 65001 >nul
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0launchers\启动.ps1" %*
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

- Preserve WGO's original database verification/decryption pipeline and add a Windows Weixin 4.x adapter that discovers db_storage, derives per-database page keys from an explicitly supplied account raw key, verifies every key against page 1, and writes the existing all_keys.json shape.
- Add Windows-safe credential storage/ACL handling, cross-process file locking, local-path handling, clipboard/open adapters, and a pystray/Tk tray compatibility layer while keeping the canonical app workflow in app.py.
- Add a Windows PowerShell launcher plus a current-user Task Scheduler logon task with duplicate-instance suppression and bounded crash restart. Autostart can remember a fully verified raw key in Windows Credential Manager and renew keys for newly created database shards.
- Document the supported Windows preview surface and the macOS-only/macOS-validated boundaries.

## Security and privacy

- Raw keys are entered with masked input and are not accepted as command-line values or written to config, logs, task arguments, fixtures, or the repository.
- Ordinary refresh keeps the raw key in memory only. Remembering it is an explicit autostart action and stores it in Windows Credential Manager; uninstalling autostart removes that credential while retaining already verified page keys.
- Wrong raw keys never replace the existing page-key map.
- WGO does not bundle, download, or execute a third-party key extractor. No third-party implementation was copied; the Windows adapter feeds published format/KDF facts into WGO's existing verifier and decryptor.

## Verification

- 320/320 affected shared-path and Windows tests pass.
- python -m compileall -q app.py core scripts ui tests passes.
- git diff --check passes.
- A synthetic encrypted SQLCipher page was taken through raw-key derivation and WGO's original decryptor to a valid SQLite database.
- Live Windows Credential Manager write/read/delete validation passed, and the temporary random credential was deleted.
- Live Task Scheduler XML register/query/delete validation passed, and the temporary random task was deleted.
- The root 启动.cmd launcher runs under Windows PowerShell 5.1-compatible encoding/path rules and returns the expected readiness code when the operator raw key is absent.
- Full Windows-hosted repository discovery currently reports 897 tests: 588 pass, 43 skip, 89 fail, and 177 error. The remaining failures/errors are macOS/POSIX contracts on this host (LaunchAgent, Unix directory-fd/inode/mode/symlink/hardlink, and setitimer behavior); they were not skipped or weakened for this PR.

## Preview limits

- Real-account source acceptance still requires the account owner to enter their raw key privately on Windows; no private key or chat data was available to this PR.
- Automatic renewal means deriving and verifying keys for new database shards from an explicitly remembered raw key. It does not scan process memory or guess a rotated raw key.
- Windows notification clicks, real MCP message sending, macOS WeChat re-signing/source guard, py2app packaging, and the advanced attachment/mounted-backup lanes are not claimed as Windows-validated.