### PR TITLE
Add W0.1 Windows portability foundation

### DIFF
--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -1,0 +1,67 @@
+name: Portability
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  windows-import:
+    name: Windows x64 / Python 3.11 import boundary
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          architecture: x64
+          cache: pip
+      - name: Install base and Windows-safe dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Verify W0.1 Windows inventory and public boundary
+        run: >-
+          python -m unittest
+          tests.windows
+          tests.test_repository_layout
+      - name: Compile Windows-owned source surfaces
+        run: >-
+          python -m compileall -q
+          mcp_server.py ai core ui scripts tests
+
+  macos-regression:
+    name: macOS / Python ${{ matrix.python-version }} regression
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install macOS dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Run full macOS regression suite
+        run: >-
+          python -m unittest discover
+          -s tests -t . -p 'test_*.py'
+      - name: Compile all source surfaces
+        run: >-
+          python -m compileall -q
+          app.py mcp_server.py setup.py ai core ui scripts tests
+      - name: Parse macOS launchers
+        run: |
+          for launcher in 启动.command launchers/*.command; do
+            bash -n "$launcher"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,23 @@
 - `tests/` is an importable unittest package. New tests belong there and use
   `tests.<module>` for focused invocation.
 
+## Windows port staging
+
+- Windows work follows `WGO-WIN-SPEC-1`. The current authorized phase is
+  `PR-W0.1` only: portability mapping, platform contracts/factory, dependency
+  markers, Windows import/compile CI and documentation.
+- `app.py` remains the macOS shell. W0.1 must not add Windows source reads, key
+  acquisition, monitor activation, attachment/backup behavior, tray UI,
+  autostart, packaging or message sending.
+- `core/platform/` owns behavior-free platform contracts and fail-closed
+  provider selection. Concrete lock/path/private-storage adapters begin in
+  W0.2; secrets/open/notification adapters begin in W0.3; source adapters begin
+  in W1.
+- `docs/WINDOWS-PORT-MAP.md` is the W0.1 module inventory. Every root,
+  `core/`, `ui/` and `scripts/` Python module must remain classified, and only
+  modules marked `windows-import-safe` enter the Windows import gate. Import
+  success is not evidence of Windows feature support.
+
 ## Durable and generated boundaries
 
 - SQLite/CAS ledgers are authoritative for durable derived state. Markdown,
@@ -76,6 +93,16 @@ shared code, packaging, public-boundary or runtime changes. Source completion,
 private/public publication, app-bundle rebuild, LaunchAgent reload and live
 acceptance are separate gates. Do not mutate live config/data or reload a live
 agent merely because source tests pass.
+
+For W0.1 on Windows, also run:
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest tests.windows tests.test_repository_layout
+.\.venv\Scripts\python.exe -m compileall -q mcp_server.py ai core ui scripts tests
+```
+
+The portability workflow is the macOS regression authority; a Windows host
+cannot waive or simulate that gate.
 
 ## Review ref resolution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,11 @@
 
 ## Windows port staging
 
-- Windows work follows `WGO-WIN-SPEC-1`. The current authorized phase is
-  `PR-W0.1` only: portability mapping, platform contracts/factory, dependency
-  markers, Windows import/compile CI and documentation.
+- The full Windows programme contract, `WGO-WIN-SPEC-1`, is owner-authorized
+  external material. For `PR-W0.1`, `docs/WINDOWS-PORT-MAP.md` is the sole
+  in-repository executable authority: portability mapping, platform
+  contracts/factory, dependency markers, Windows import/compile CI and
+  documentation only.
 - `app.py` remains the macOS shell. W0.1 must not add Windows source reads, key
   acquisition, monitor activation, attachment/backup behavior, tray UI,
   autostart, packaging or message sending.
@@ -44,9 +46,9 @@
   W0.2; secrets/open/notification adapters begin in W0.3; source adapters begin
   in W1.
 - `docs/WINDOWS-PORT-MAP.md` is the W0.1 module inventory. Every root,
-  `core/`, `ui/` and `scripts/` Python module must remain classified, and only
-  modules marked `windows-import-safe` enter the Windows import gate. Import
-  success is not evidence of Windows feature support.
+  `ai/`, `core/`, `ui/` and `scripts/` Python module must remain classified,
+  and only modules marked `windows-import-safe` enter the Windows import gate.
+  Import success is not evidence of Windows feature support.
 
 ## Durable and generated boundaries
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ full regression suite; review the data-flow and account-safety notes before
 using it on real chat data. A bundled Python runtime or signed installer is not
 currently distributed.
 
-Windows port status: **W0 portability foundation only**. The repository now
-tracks an explicit module/import boundary and Windows CI, but W0 does not
+Windows port status: **W0.1 module inventory and import-boundary stage**. The
+complete W0 portability foundation is not yet finished. The repository now
+tracks an explicit module/import boundary and Windows CI, but W0.1 does not
 support Windows WeChat discovery, keys, database reads, monitoring, tray UI,
 backup, autostart, packaging, or sending. See
 [`docs/WINDOWS-PORT-MAP.md`](docs/WINDOWS-PORT-MAP.md) for the staged contract.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ full regression suite; review the data-flow and account-safety notes before
 using it on real chat data. A bundled Python runtime or signed installer is not
 currently distributed.
 
+Windows port status: **W0 portability foundation only**. The repository now
+tracks an explicit module/import boundary and Windows CI, but W0 does not
+support Windows WeChat discovery, keys, database reads, monitoring, tray UI,
+backup, autostart, packaging, or sending. See
+[`docs/WINDOWS-PORT-MAP.md`](docs/WINDOWS-PORT-MAP.md) for the staged contract.
+
 A local-first macOS tool for reading your own WeChat desktop database, summarizing group chats, searching messages, and turning high-value group-chat updates into an Obsidian-friendly Markdown knowledge base.
 
 This is not official WeChat/Tencent software, not a WeChat bot, not employee-monitoring software, and not fully offline when you enable cloud AI, remote link preview, or MCP sending. It does not use a WeChat API, does not run a remote service, and does not send your chat history to this project. The app reads local database files on your Mac and calls the AI provider you configure.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,9 +7,9 @@ operator CLI、持久化本地状态、recovery/backup workers 和完整 regress
 数据流和账号安全边界，再在真实聊天数据上使用。当前不分发 bundled Python runtime
 或已签名 installer。
 
-Windows 迁移当前只到 **W0 可移植性基础阶段**：仓库建立了明确的模块/import 边界和
-Windows CI，但 W0 不支持 Windows 微信发现、密钥、数据库读取、monitor、托盘、
-backup、自启、打包或发送。分阶段契约见
+Windows 迁移当前处于 **W0.1 模块清单与 import 边界阶段**；完整的 W0 可移植性基础
+尚未完成。仓库建立了明确的模块/import 边界和 Windows CI，但 W0.1 不支持 Windows
+微信发现、密钥、数据库读取、monitor、托盘、backup、自启、打包或发送。分阶段契约见
 [`docs/WINDOWS-PORT-MAP.md`](docs/WINDOWS-PORT-MAP.md)。
 
 一个本地优先的 macOS 微信群聊总结工具。它读取你电脑上的微信本地数据库，生成群聊摘要、关键词搜索结果，并把值得关注的新消息整理成 Obsidian-friendly Markdown 笔记。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,11 @@ operator CLI、持久化本地状态、recovery/backup workers 和完整 regress
 数据流和账号安全边界，再在真实聊天数据上使用。当前不分发 bundled Python runtime
 或已签名 installer。
 
+Windows 迁移当前只到 **W0 可移植性基础阶段**：仓库建立了明确的模块/import 边界和
+Windows CI，但 W0 不支持 Windows 微信发现、密钥、数据库读取、monitor、托盘、
+backup、自启、打包或发送。分阶段契约见
+[`docs/WINDOWS-PORT-MAP.md`](docs/WINDOWS-PORT-MAP.md)。
+
 一个本地优先的 macOS 微信群聊总结工具。它读取你电脑上的微信本地数据库，生成群聊摘要、关键词搜索结果，并把值得关注的新消息整理成 Obsidian-friendly Markdown 笔记。
 
 它不是微信/Tencent 官方软件，不是微信机器人，不是员工监控工具；当你启用云端 AI、远程链接预览或 MCP 发送时，它也不是完全离线工具。它不接入微信官方/非官方接口，也不会替你把聊天记录上传到项目作者的服务器。所有运行状态、数据库 key、知识库和导出文件默认都保存在你自己的 Mac 上。

--- a/core/platform/__init__.py
+++ b/core/platform/__init__.py
@@ -1,0 +1,53 @@
+"""Platform contracts and factory seams for staged portability work."""
+
+from .contracts import (
+    AutostartService,
+    AutostartStatus,
+    FileLock,
+    LockBusy,
+    LockHandle,
+    LockMode,
+    NotificationService,
+    OpenTargetService,
+    PathIdentity,
+    PathService,
+    PlatformCapabilityUnavailable,
+    PlatformName,
+    PlatformServices,
+    PrivateStorage,
+    ProcessIdentity,
+    ProcessService,
+    SecretStore,
+)
+from .factory import (
+    PlatformFactoryMismatch,
+    PlatformServicesUnavailable,
+    create_platform_services,
+    detect_platform,
+    register_platform_services,
+)
+
+__all__ = [
+    "AutostartService",
+    "AutostartStatus",
+    "FileLock",
+    "LockBusy",
+    "LockHandle",
+    "LockMode",
+    "NotificationService",
+    "OpenTargetService",
+    "PathIdentity",
+    "PathService",
+    "PlatformCapabilityUnavailable",
+    "PlatformFactoryMismatch",
+    "PlatformName",
+    "PlatformServices",
+    "PlatformServicesUnavailable",
+    "PrivateStorage",
+    "ProcessIdentity",
+    "ProcessService",
+    "SecretStore",
+    "create_platform_services",
+    "detect_platform",
+    "register_platform_services",
+]

--- a/core/platform/__init__.py
+++ b/core/platform/__init__.py
@@ -20,6 +20,7 @@ from .contracts import (
     SecretStore,
 )
 from .factory import (
+    InvalidPlatformServicesProviderResult,
     PlatformFactoryMismatch,
     PlatformServicesUnavailable,
     create_platform_services,
@@ -34,6 +35,7 @@ __all__ = [
     "LockBusy",
     "LockHandle",
     "LockMode",
+    "InvalidPlatformServicesProviderResult",
     "NotificationService",
     "OpenTargetService",
     "PathIdentity",

--- a/core/platform/contracts.py
+++ b/core/platform/contracts.py
@@ -1,0 +1,171 @@
+"""Behavioral contracts for platform-owned services.
+
+W0.1 defines the ownership seam only.  Concrete macOS and Windows adapters are
+introduced in their scheduled PRs and are not registered by this module.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from os import PathLike
+from typing import Protocol, Sequence
+
+
+_PLATFORM_SERVICE_NAMES = (
+    "locks",
+    "paths",
+    "private_storage",
+    "secrets",
+    "processes",
+    "notifications",
+    "open_targets",
+    "autostart",
+)
+
+
+class PlatformName(str, Enum):
+    MACOS = "macos"
+    WINDOWS = "windows"
+    UNSUPPORTED = "unsupported"
+
+
+class LockMode(str, Enum):
+    SHARED = "shared"
+    EXCLUSIVE = "exclusive"
+
+
+class LockBusy(RuntimeError):
+    """Stable non-blocking lock conflict."""
+
+    code = "worker_busy"
+
+
+class PlatformCapabilityUnavailable(RuntimeError):
+    code = "platform_capability_unavailable"
+
+    def __init__(self, platform_name: PlatformName, capability: str):
+        self.platform_name = platform_name
+        self.capability = capability
+        super().__init__(f"{self.code}:{platform_name.value}:{capability}")
+
+
+class LockHandle(Protocol):
+    """A retained operating-system lock handle."""
+
+    def close(self) -> None: ...
+
+    def __enter__(self) -> "LockHandle": ...
+
+    def __exit__(self, exc_type, exc, traceback) -> None: ...
+
+
+class FileLock(Protocol):
+    def acquire(
+        self,
+        path: str | PathLike[str],
+        *,
+        mode: LockMode,
+        blocking: bool,
+    ) -> LockHandle: ...
+
+
+@dataclass(frozen=True)
+class PathIdentity:
+    display_path: str
+    operational_path: str
+    identity_key: str
+    source_relative_path: str = ""
+
+
+class PathService(Protocol):
+    def describe(
+        self,
+        path: str | PathLike[str],
+        *,
+        source_root: str | PathLike[str] | None = None,
+    ) -> PathIdentity: ...
+
+
+class PrivateStorage(Protocol):
+    def ensure_directory(self, path: str | PathLike[str]) -> None: ...
+
+    def ensure_file(self, path: str | PathLike[str]) -> None: ...
+
+    def verify(self, path: str | PathLike[str]) -> bool: ...
+
+
+class SecretStore(Protocol):
+    def save(self, account: str, secret: str) -> None: ...
+
+    def load(self, account: str) -> str | None: ...
+
+    def delete(self, account: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    process_id: int
+    created_at: str
+    executable_path: str
+    executable_sha256: str
+
+
+class ProcessService(Protocol):
+    def find_desktop_clients(self) -> Sequence[ProcessIdentity]: ...
+
+
+class NotificationService(Protocol):
+    def notify(
+        self,
+        *,
+        title: str,
+        body: str,
+        open_target: str = "",
+    ) -> None: ...
+
+
+class OpenTargetService(Protocol):
+    def open_target(self, target: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class AutostartStatus:
+    installed: bool
+    enabled: bool
+    state: str
+
+
+class AutostartService(Protocol):
+    def install(self) -> None: ...
+
+    def uninstall(self) -> None: ...
+
+    def status(self) -> AutostartStatus: ...
+
+
+@dataclass(frozen=True)
+class PlatformServices:
+    platform: PlatformName
+    locks: FileLock | None = None
+    paths: PathService | None = None
+    private_storage: PrivateStorage | None = None
+    secrets: SecretStore | None = None
+    processes: ProcessService | None = None
+    notifications: NotificationService | None = None
+    open_targets: OpenTargetService | None = None
+    autostart: AutostartService | None = None
+
+    def available_capabilities(self) -> frozenset[str]:
+        return frozenset(
+            name
+            for name in _PLATFORM_SERVICE_NAMES
+            if getattr(self, name) is not None
+        )
+
+    def require(self, capability: str):
+        if capability not in _PLATFORM_SERVICE_NAMES:
+            raise ValueError(f"unknown platform capability: {capability}")
+        service = getattr(self, capability)
+        if service is None:
+            raise PlatformCapabilityUnavailable(self.platform, capability)
+        return service

--- a/core/platform/factory.py
+++ b/core/platform/factory.py
@@ -27,6 +27,14 @@ class PlatformFactoryMismatch(RuntimeError):
         super().__init__(f"{self.code}:{expected.value}:{actual.value}")
 
 
+class InvalidPlatformServicesProviderResult(RuntimeError):
+    code = "invalid_platform_services_provider_result"
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(f"{self.code}:{reason}")
+
+
 def detect_platform(system_name: str | None = None) -> PlatformName:
     normalized = str(system_name or runtime_platform.system()).strip().casefold()
     if normalized == "darwin":
@@ -59,6 +67,10 @@ def create_platform_services(
     if provider is None:
         raise PlatformServicesUnavailable(selected)
     services = provider()
+    if not isinstance(services, PlatformServices):
+        raise InvalidPlatformServicesProviderResult("provider_result_type")
+    if not isinstance(services.platform, PlatformName):
+        raise InvalidPlatformServicesProviderResult("platform_type")
     if services.platform is not selected:
         raise PlatformFactoryMismatch(selected, services.platform)
     return services

--- a/core/platform/factory.py
+++ b/core/platform/factory.py
@@ -1,0 +1,64 @@
+"""Fail-closed registry for platform-service providers."""
+from __future__ import annotations
+
+import platform as runtime_platform
+from collections.abc import Callable
+
+from .contracts import PlatformName, PlatformServices
+
+PlatformServicesProvider = Callable[[], PlatformServices]
+_PLATFORM_FACTORIES: dict[PlatformName, PlatformServicesProvider] = {}
+
+
+class PlatformServicesUnavailable(RuntimeError):
+    code = "platform_services_unavailable"
+
+    def __init__(self, platform_name: PlatformName):
+        self.platform_name = platform_name
+        super().__init__(f"{self.code}:{platform_name.value}")
+
+
+class PlatformFactoryMismatch(RuntimeError):
+    code = "platform_factory_mismatch"
+
+    def __init__(self, expected: PlatformName, actual: PlatformName):
+        self.expected = expected
+        self.actual = actual
+        super().__init__(f"{self.code}:{expected.value}:{actual.value}")
+
+
+def detect_platform(system_name: str | None = None) -> PlatformName:
+    normalized = str(system_name or runtime_platform.system()).strip().casefold()
+    if normalized == "darwin":
+        return PlatformName.MACOS
+    if normalized == "windows":
+        return PlatformName.WINDOWS
+    return PlatformName.UNSUPPORTED
+
+
+def register_platform_services(
+    platform_name: PlatformName,
+    provider: PlatformServicesProvider,
+    *,
+    replace: bool = False,
+) -> None:
+    if platform_name is PlatformName.UNSUPPORTED:
+        raise ValueError("unsupported platform cannot register services")
+    if not callable(provider):
+        raise TypeError("platform services provider must be callable")
+    if platform_name in _PLATFORM_FACTORIES and not replace:
+        raise ValueError(f"platform services already registered: {platform_name.value}")
+    _PLATFORM_FACTORIES[platform_name] = provider
+
+
+def create_platform_services(
+    platform_name: PlatformName | None = None,
+) -> PlatformServices:
+    selected = platform_name or detect_platform()
+    provider = _PLATFORM_FACTORIES.get(selected)
+    if provider is None:
+        raise PlatformServicesUnavailable(selected)
+    services = provider()
+    if services.platform is not selected:
+        raise PlatformFactoryMismatch(selected, services.platform)
+    return services

--- a/docs/WINDOWS-PORT-MAP.md
+++ b/docs/WINDOWS-PORT-MAP.md
@@ -1,0 +1,120 @@
+# Windows portability map (W0.1)
+
+This document is the module-by-module import boundary for
+`WGO-WIN-SPEC-1`, phase `PR-W0.1`.
+
+```text
+repository: IndelibleVivi/we-groupchat-obsidian
+requested_ref: main
+resolved_source_sha: a25af75468588cad6f32fef1a3358b40b9036917
+default_branch_sha_at_mapping: a25af75468588cad6f32fef1a3358b40b9036917
+merge_base: a25af75468588cad6f32fef1a3358b40b9036917
+applies_to: PR-W0.1 portability foundation
+release_tier_affected: W0 only
+```
+
+W0.1 does not enable Windows source discovery, key acquisition, database
+reads, monitor writes, attachments, backup, tray UI, autostart, packaging, or
+message sending. Existing macOS entrypoints and behavior remain authoritative.
+
+## Classification
+
+- `windows-import-safe`: imports in a fresh Windows Python 3.11 process. This
+  is an import claim only, not a Windows behavior or release-tier claim.
+- `deferred-w0.2`: blocked by direct or transitive POSIX lock, path, atomic
+  publication, or private-storage ownership. W0.2 migrates these modules.
+- `deferred-w1+`: import work is possible, but source/product activation is
+  owned by W1 or a later phase.
+- `macos-only`: current macOS shell, packaging, or adapter. It is intentionally
+  excluded from the Windows import gate until its owning platform PR.
+- `operator-deferred`: thin operator entrypoint whose dependencies or behavior
+  are not authorized on Windows in W0.1.
+
+`tests.windows.test_portability_inventory` enforces exact coverage of every
+root, `core/`, `ui/`, and `scripts/` Python module and imports every
+`windows-import-safe` module in a fresh process on Windows.
+
+## Module inventory
+
+| Path | Classification | Current boundary and next owner |
+|---|---|---|
+| `app.py` | `macos-only` | rumps/AppKit/objc menu shell; reusable controllers are extracted in later staged PRs. |
+| `mcp_server.py` | `deferred-w0.2` | Imports `core.config`; Windows source factory activation belongs to W1.1/W2. |
+| `setup.py` | `macos-only` | py2app packaging entrypoint; Windows packaging is W6. |
+| `core/__init__.py` | `windows-import-safe` | Empty shared package boundary. |
+| `core/api_errors.py` | `windows-import-safe` | Provider-independent error normalization. |
+| `core/app_runtime.py` | `deferred-w0.2` | Direct `fcntl` singleton; central lock backend is W0.2. |
+| `core/attachment_archive.py` | `deferred-w0.2` | Direct `fcntl` plus path/private-storage semantics; Windows bytes remain W5. |
+| `core/attachment_backup.py` | `deferred-w0.2` | Transitively imports attachment/config storage. |
+| `core/background_jobs.py` | `windows-import-safe` | Shared process-lifetime job coordination; behavior activation remains gated. |
+| `core/bookmark.py` | `deferred-w0.2` | Transitively imports ConfigStore/private storage. |
+| `core/chat_groups.py` | `deferred-w0.2` | Transitively imports ConfigStore/private storage. |
+| `core/config.py` | `deferred-w0.2` | Direct `fcntl`, POSIX path parsing, atomic/private-storage migration. |
+| `core/daily_digest.py` | `deferred-w0.2` | Transitively imports config/knowledge storage; Windows activation is W3. |
+| `core/decryptor.py` | `windows-import-safe` | Shared crypto/WAL implementation; synthetic behavior fixtures expand in W1. |
+| `core/google_drive_auth.py` | `deferred-w0.2` | Config/private storage plus macOS Keychain; secret adapter is W0.3. |
+| `core/google_drive_client.py` | `deferred-w0.2` | Transitively imports the current auth adapter. |
+| `core/google_drive_file_sync.py` | `deferred-w0.2` | Direct `fcntl` and attachment/config dependencies; Windows activation is later. |
+| `core/image_decoder.py` | `windows-import-safe` | Platform-neutral byte decoding. |
+| `core/key_extractor.py` | `macos-only` | macOS process scanner, codesign, sudo, and osascript source adapter. |
+| `core/keychain.py` | `macos-only` | macOS `security` adapter; shared secret contract is defined for W0.3 wiring. |
+| `core/knowledge.py` | `deferred-w0.2` | Transitively imports ConfigStore/path/private storage; Windows activation is W3. |
+| `core/launch_agent.py` | `macos-only` | macOS LaunchAgent adapter; Windows autostart is W6. |
+| `core/link_preview.py` | `windows-import-safe` | Platform-neutral URL extraction and preview logic. |
+| `core/mcp_config.py` | `windows-import-safe` | Pure configuration rendering; Windows command emission is activated later. |
+| `core/mcp_send_confirmation.py` | `windows-import-safe` | Shared confirmation state; Windows send remains forbidden through W6. |
+| `core/mcp_send_policy.py` | `windows-import-safe` | Shared send policy; no Windows sender is registered. |
+| `core/monitor.py` | `deferred-w0.2` | Transitively imports config/knowledge/review storage; Windows activation is W3. |
+| `core/notification_identity.py` | `macos-only` | Foundation/app-bundle notification identity diagnostics. |
+| `core/notification_target.py` | `macos-only` | Emits the macOS `open` command; target-opening adapter is W0.3. |
+| `core/platform/__init__.py` | `windows-import-safe` | Exposes contracts/factory only; registers no concrete service. |
+| `core/platform/contracts.py` | `windows-import-safe` | Shared lock/path/storage/secret/process/notification/open/autostart protocols. |
+| `core/platform/factory.py` | `windows-import-safe` | Fail-closed service registry with no W0.1 adapters. |
+| `core/project_identity.py` | `windows-import-safe` | Shared public project identifiers. |
+| `core/relation_audit.py` | `windows-import-safe` | Imports without platform services; filesystem behavior remains unclaimed. |
+| `core/relation_markdown_cleanup.py` | `deferred-w0.2` | Transitively imports knowledge/config storage. |
+| `core/resource_backup_launch_agent.py` | `macos-only` | Retired/current LaunchAgent compatibility surface. |
+| `core/resource_backup.py` | `deferred-w0.2` | Direct `fcntl`, path identity, target lock, and atomic semantics; Windows is W5. |
+| `core/resource_capture.py` | `deferred-w0.2` | Direct `fcntl` and source/config dependencies; Windows is W4. |
+| `core/review_queue.py` | `deferred-w0.2` | Transitively imports ConfigStore/private storage; Windows activation is W3. |
+| `core/sender.py` | `macos-only` | Quartz and AppleScript UI sender; Windows send is separately authorized after W6. |
+| `core/source_contract.py` | `windows-import-safe` | Existing shared source-metadata helpers; canonical WeChatSource extraction is W1.1. |
+| `core/source_metadata_plan.py` | `deferred-w0.2` | Transitively imports digest/knowledge/config storage. |
+| `core/taxonomy_assignment.py` | `windows-import-safe` | Platform-neutral taxonomy resolution. |
+| `core/taxonomy_migration.py` | `deferred-w0.2` | Direct `fcntl` and knowledge storage. |
+| `core/wechat_db.py` | `windows-import-safe` | Existing shared crypto/query import surface; schema/source adapters are W1.1+. |
+| `core/wechat_source_guard.py` | `macos-only` | `fcntl`, macOS key/process adapter, and osascript notification behavior. |
+| `ui/__init__.py` | `windows-import-safe` | Empty reusable UI package boundary; Windows tray is W6. |
+| `scripts/__init__.py` | `windows-import-safe` | Empty operator package boundary. |
+| `scripts/attachment_archive.py` | `operator-deferred` | Depends on W0.2 storage and W5 attachment authorization. |
+| `scripts/attachment_backup.py` | `operator-deferred` | Depends on W0.2 storage and later backup activation. |
+| `scripts/autostart.py` | `macos-only` | macOS LaunchAgent installer. |
+| `scripts/backfill_history.py` | `operator-deferred` | Source/knowledge operation; Windows historical behavior is not authorized in W0.1. |
+| `scripts/build_share_package.py` | `operator-deferred` | POSIX mode/symlink publication semantics require a later filesystem audit. |
+| `scripts/catch_up_monitor.py` | `macos-only` | LaunchAgent control plus monitor/source operations. |
+| `scripts/configure_monitor.py` | `operator-deferred` | Depends on config, source, keychain, and knowledge activation. |
+| `scripts/daily_digest.py` | `operator-deferred` | Depends on W0.2 storage and W3 activation. |
+| `scripts/google_drive_file_sync.py` | `operator-deferred` | Depends on current auth/config/source adapters. |
+| `scripts/health_check.py` | `macos-only` | Reports LaunchAgent, notification identity, and macOS source state. |
+| `scripts/migrate_taxonomy.py` | `operator-deferred` | Depends on W0.2 config/knowledge storage. |
+| `scripts/organize_obsidian.py` | `operator-deferred` | Depends on W0.2 path/storage and W3 projection activation. |
+| `scripts/refresh_data_source.py` | `macos-only` | Invokes the current macOS key/process adapter. |
+| `scripts/repair_relation_markdown.py` | `operator-deferred` | Depends on knowledge/config storage. |
+| `scripts/repair_relations.py` | `operator-deferred` | Depends on configured private relation state. |
+| `scripts/resource_backup.py` | `macos-only` | Current LaunchAgent/source/backup operator surface; Windows backup is W5. |
+| `scripts/review_queue.py` | `operator-deferred` | Depends on W0.2 storage and W3 activation. |
+| `scripts/wechat_source_guard.py` | `macos-only` | Current LaunchAgent and macOS source-guard operator. |
+
+## Staged cutover
+
+1. **W0.2:** implement central lock, path identity, atomic publication, and
+   private-storage adapters; migrate only the modules marked `deferred-w0.2`.
+2. **W0.3:** adapt secrets, notifications, and target opening behind the
+   contracts defined here.
+3. **W1.1–W1.3:** extract the canonical WeChat source contract, add one
+   exact-build Windows probe/schema profile, and add a verified key provider.
+4. **W2–W6:** enable read-only source, knowledge, resources, backup, then tray,
+   packaging, and logon startup only after their separate live gates.
+
+No module changes classification merely because it imports. The owning phase
+must supply its behavioral tests and acceptance evidence first.

--- a/docs/WINDOWS-PORT-MAP.md
+++ b/docs/WINDOWS-PORT-MAP.md
@@ -1,7 +1,9 @@
 # Windows portability map (W0.1)
 
-This document is the module-by-module import boundary for
-`WGO-WIN-SPEC-1`, phase `PR-W0.1`.
+The full Windows programme contract, `WGO-WIN-SPEC-1`, is owner-authorized
+external material and is not distributed with this repository. This document
+is the sole in-repository executable authority for its `PR-W0.1`
+module-by-module import boundary.
 
 ```text
 repository: IndelibleVivi/we-groupchat-obsidian
@@ -31,7 +33,7 @@ message sending. Existing macOS entrypoints and behavior remain authoritative.
   are not authorized on Windows in W0.1.
 
 `tests.windows.test_portability_inventory` enforces exact coverage of every
-root, `core/`, `ui/`, and `scripts/` Python module and imports every
+root, `ai/`, `core/`, `ui/`, and `scripts/` Python module and imports every
 `windows-import-safe` module in a fresh process on Windows.
 
 ## Module inventory
@@ -41,6 +43,12 @@ root, `core/`, `ui/`, and `scripts/` Python module and imports every
 | `app.py` | `macos-only` | rumps/AppKit/objc menu shell; reusable controllers are extracted in later staged PRs. |
 | `mcp_server.py` | `deferred-w0.2` | Imports `core.config`; Windows source factory activation belongs to W1.1/W2. |
 | `setup.py` | `macos-only` | py2app packaging entrypoint; Windows packaging is W6. |
+| `ai/__init__.py` | `windows-import-safe` | Empty shared provider package boundary. |
+| `ai/base.py` | `windows-import-safe` | Platform-neutral provider interface. |
+| `ai/claude_provider.py` | `windows-import-safe` | Provider adapter imports cleanly; credentials remain behind the W0.3 secret boundary. |
+| `ai/factory.py` | `windows-import-safe` | Imports cleanly on Windows; provider creation still reaches the macOS keychain and is not activated before W0.3. |
+| `ai/ollama_provider.py` | `windows-import-safe` | Platform-neutral HTTP provider adapter; runtime behavior is not a W0.1 claim. |
+| `ai/openai_provider.py` | `windows-import-safe` | Provider adapter imports cleanly; credentials remain behind the W0.3 secret boundary. |
 | `core/__init__.py` | `windows-import-safe` | Empty shared package boundary. |
 | `core/api_errors.py` | `windows-import-safe` | Provider-independent error normalization. |
 | `core/app_runtime.py` | `deferred-w0.2` | Direct `fcntl` singleton; central lock backend is W0.2. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-rumps>=0.4.0
+rumps>=0.4.0; sys_platform == "darwin"
 pycryptodome>=3.20.0
 zstandard>=0.22.0
-pyobjc-framework-Cocoa>=10.0
+pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"
 anthropic>=0.40.0
 openai>=1.50.0
 requests>=2.31.0
-mcp[cli]>=1.0.0
+mcp[cli]>=1.0.0,<2

--- a/tests/windows/__init__.py
+++ b/tests/windows/__init__.py
@@ -1,0 +1,12 @@
+"""Windows portability tests for the staged port."""
+from pathlib import Path
+
+
+def load_tests(loader, standard_tests, pattern):
+    tests_dir = Path(__file__).resolve().parent
+    repository_root = tests_dir.parents[1]
+    return loader.discover(
+        str(tests_dir),
+        pattern=pattern or "test_*.py",
+        top_level_dir=str(repository_root),
+    )

--- a/tests/windows/test_platform_contracts.py
+++ b/tests/windows/test_platform_contracts.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import patch
+
+from core.platform.contracts import (
+    PlatformCapabilityUnavailable,
+    PlatformName,
+    PlatformServices,
+)
+from core.platform.factory import (
+    PlatformFactoryMismatch,
+    PlatformServicesUnavailable,
+    _PLATFORM_FACTORIES,
+    create_platform_services,
+    detect_platform,
+    register_platform_services,
+)
+
+
+class _Services:
+    def __init__(self, platform_name):
+        self.platform = platform_name
+
+
+class PlatformFactoryTests(unittest.TestCase):
+    def test_detect_platform_uses_closed_vocabulary(self):
+        self.assertIs(detect_platform("Darwin"), PlatformName.MACOS)
+        self.assertIs(detect_platform("WINDOWS"), PlatformName.WINDOWS)
+        self.assertIs(detect_platform("Linux"), PlatformName.UNSUPPORTED)
+
+    def test_unregistered_platform_fails_closed(self):
+        with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
+            with self.assertRaises(PlatformServicesUnavailable) as raised:
+                create_platform_services(PlatformName.WINDOWS)
+        self.assertEqual(raised.exception.code, "platform_services_unavailable")
+
+    def test_registered_provider_is_selected(self):
+        expected = _Services(PlatformName.WINDOWS)
+        with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
+            register_platform_services(PlatformName.WINDOWS, lambda: expected)
+            self.assertIs(create_platform_services(PlatformName.WINDOWS), expected)
+
+    def test_duplicate_registration_requires_explicit_replacement(self):
+        first = _Services(PlatformName.WINDOWS)
+        second = _Services(PlatformName.WINDOWS)
+        with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
+            register_platform_services(PlatformName.WINDOWS, lambda: first)
+            with self.assertRaises(ValueError):
+                register_platform_services(PlatformName.WINDOWS, lambda: second)
+            register_platform_services(
+                PlatformName.WINDOWS,
+                lambda: second,
+                replace=True,
+            )
+            self.assertIs(create_platform_services(PlatformName.WINDOWS), second)
+
+    def test_provider_platform_mismatch_is_rejected(self):
+        with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
+            register_platform_services(
+                PlatformName.WINDOWS,
+                lambda: _Services(PlatformName.MACOS),
+            )
+            with self.assertRaises(PlatformFactoryMismatch) as raised:
+                create_platform_services(PlatformName.WINDOWS)
+        self.assertEqual(raised.exception.code, "platform_factory_mismatch")
+
+    def test_partial_service_bundle_reports_capabilities_and_fails_closed(self):
+        lock_service = object()
+        services = PlatformServices(
+            platform=PlatformName.WINDOWS,
+            locks=lock_service,
+        )
+        self.assertEqual(services.available_capabilities(), frozenset({"locks"}))
+        self.assertIs(services.require("locks"), lock_service)
+        with self.assertRaises(PlatformCapabilityUnavailable) as raised:
+            services.require("secrets")
+        self.assertEqual(raised.exception.code, "platform_capability_unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/windows/test_platform_contracts.py
+++ b/tests/windows/test_platform_contracts.py
@@ -7,6 +7,7 @@ from core.platform.contracts import (
     PlatformServices,
 )
 from core.platform.factory import (
+    InvalidPlatformServicesProviderResult,
     PlatformFactoryMismatch,
     PlatformServicesUnavailable,
     _PLATFORM_FACTORIES,
@@ -14,11 +15,6 @@ from core.platform.factory import (
     detect_platform,
     register_platform_services,
 )
-
-
-class _Services:
-    def __init__(self, platform_name):
-        self.platform = platform_name
 
 
 class PlatformFactoryTests(unittest.TestCase):
@@ -34,14 +30,14 @@ class PlatformFactoryTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "platform_services_unavailable")
 
     def test_registered_provider_is_selected(self):
-        expected = _Services(PlatformName.WINDOWS)
+        expected = PlatformServices(platform=PlatformName.WINDOWS)
         with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
             register_platform_services(PlatformName.WINDOWS, lambda: expected)
             self.assertIs(create_platform_services(PlatformName.WINDOWS), expected)
 
     def test_duplicate_registration_requires_explicit_replacement(self):
-        first = _Services(PlatformName.WINDOWS)
-        second = _Services(PlatformName.WINDOWS)
+        first = PlatformServices(platform=PlatformName.WINDOWS)
+        second = PlatformServices(platform=PlatformName.WINDOWS)
         with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
             register_platform_services(PlatformName.WINDOWS, lambda: first)
             with self.assertRaises(ValueError):
@@ -57,11 +53,38 @@ class PlatformFactoryTests(unittest.TestCase):
         with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
             register_platform_services(
                 PlatformName.WINDOWS,
-                lambda: _Services(PlatformName.MACOS),
+                lambda: PlatformServices(platform=PlatformName.MACOS),
             )
             with self.assertRaises(PlatformFactoryMismatch) as raised:
                 create_platform_services(PlatformName.WINDOWS)
         self.assertEqual(raised.exception.code, "platform_factory_mismatch")
+
+    def test_unrelated_provider_result_is_rejected_with_stable_error(self):
+        with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
+            register_platform_services(PlatformName.WINDOWS, object)
+            with self.assertRaises(
+                InvalidPlatformServicesProviderResult
+            ) as raised:
+                create_platform_services(PlatformName.WINDOWS)
+        self.assertEqual(
+            raised.exception.code,
+            "invalid_platform_services_provider_result",
+        )
+        self.assertEqual(raised.exception.reason, "provider_result_type")
+
+    def test_malformed_platform_is_rejected_with_stable_error(self):
+        malformed = PlatformServices(platform="windows")
+        with patch.dict(_PLATFORM_FACTORIES, {}, clear=True):
+            register_platform_services(PlatformName.WINDOWS, lambda: malformed)
+            with self.assertRaises(
+                InvalidPlatformServicesProviderResult
+            ) as raised:
+                create_platform_services(PlatformName.WINDOWS)
+        self.assertEqual(
+            raised.exception.code,
+            "invalid_platform_services_provider_result",
+        )
+        self.assertEqual(raised.exception.reason, "platform_type")
 
     def test_partial_service_bundle_reports_capabilities_and_fails_closed(self):
         lock_service = object()

--- a/tests/windows/test_portability_inventory.py
+++ b/tests/windows/test_portability_inventory.py
@@ -36,7 +36,7 @@ def python_inventory() -> set[str]:
         path.relative_to(REPOSITORY_ROOT).as_posix()
         for path in REPOSITORY_ROOT.glob("*.py")
     }
-    for directory in ("core", "ui", "scripts"):
+    for directory in ("ai", "core", "ui", "scripts"):
         files.update(
             path.relative_to(REPOSITORY_ROOT).as_posix()
             for path in (REPOSITORY_ROOT / directory).rglob("*.py")

--- a/tests/windows/test_portability_inventory.py
+++ b/tests/windows/test_portability_inventory.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+PORT_MAP = REPOSITORY_ROOT / "docs" / "WINDOWS-PORT-MAP.md"
+ROW_RE = re.compile(
+    r"^\| `(?P<path>[^`]+\.py)` \| `(?P<classification>[^`]+)` \|",
+    re.MULTILINE,
+)
+ALLOWED_CLASSIFICATIONS = {
+    "windows-import-safe",
+    "deferred-w0.2",
+    "deferred-w1+",
+    "macos-only",
+    "operator-deferred",
+}
+FORBIDDEN_IMPORT_ROOTS = {
+    "AppKit",
+    "Foundation",
+    "Quartz",
+    "fcntl",
+    "objc",
+    "rumps",
+}
+
+
+def python_inventory() -> set[str]:
+    files = {
+        path.relative_to(REPOSITORY_ROOT).as_posix()
+        for path in REPOSITORY_ROOT.glob("*.py")
+    }
+    for directory in ("core", "ui", "scripts"):
+        files.update(
+            path.relative_to(REPOSITORY_ROOT).as_posix()
+            for path in (REPOSITORY_ROOT / directory).rglob("*.py")
+            if "__pycache__" not in path.parts
+        )
+    return files
+
+
+def port_map_inventory() -> dict[str, str]:
+    text = PORT_MAP.read_text(encoding="utf-8")
+    rows = ROW_RE.findall(text)
+    inventory = dict(rows)
+    if len(rows) != len(inventory):
+        raise AssertionError("duplicate Python path in WINDOWS-PORT-MAP.md")
+    return inventory
+
+
+def module_name(path: str) -> str:
+    module = path[:-3].replace("/", ".")
+    if module.endswith(".__init__"):
+        module = module[: -len(".__init__")]
+    return module
+
+
+class WindowsPortabilityInventoryTests(unittest.TestCase):
+    def test_every_owned_python_module_is_classified_once(self):
+        mapped = port_map_inventory()
+        self.assertEqual(set(mapped), python_inventory())
+        self.assertEqual(set(mapped.values()) - ALLOWED_CLASSIFICATIONS, set())
+
+    def test_import_safe_modules_have_no_direct_platform_imports(self):
+        mapped = port_map_inventory()
+        for path, classification in mapped.items():
+            if classification != "windows-import-safe":
+                continue
+            with self.subTest(path=path):
+                tree = ast.parse(
+                    (REPOSITORY_ROOT / path).read_text(encoding="utf-8"),
+                    filename=path,
+                )
+                imported_roots = set()
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Import):
+                        imported_roots.update(
+                            alias.name.partition(".")[0] for alias in node.names
+                        )
+                    elif isinstance(node, ast.ImportFrom) and node.module:
+                        imported_roots.add(node.module.partition(".")[0])
+                self.assertEqual(imported_roots & FORBIDDEN_IMPORT_ROOTS, set())
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows import gate")
+    def test_windows_import_safe_modules_import_in_fresh_processes(self):
+        mapped = port_map_inventory()
+        import_safe = sorted(
+            module_name(path)
+            for path, classification in mapped.items()
+            if classification == "windows-import-safe"
+        )
+        for module in import_safe:
+            with self.subTest(module=module):
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        "import importlib,sys; importlib.import_module(sys.argv[1])",
+                        module,
+                    ],
+                    cwd=REPOSITORY_ROOT,
+                    capture_output=True,
+                    text=True,
+                    timeout=20,
+                )
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    msg=(result.stderr or result.stdout).strip(),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the complete W0.1 module portability map for the exact `origin/main@a25af75468588cad6f32fef1a3358b40b9036917` baseline
- define behavior-free, fail-closed platform contracts and provider selection without registering Windows adapters
- mark macOS-only dependencies so the base dependency set installs on Windows
- add Windows x64/Python 3.11 import CI and macOS Python 3.10-3.14 regression CI

This PR intentionally stops at W0.1. It does **not** implement Windows WeChat discovery, key acquisition, database reads, monitoring, tray UI, backup, autostart, packaging, or sending.

## Review identity

```text
repository: IndelibleVivi/we-groupchat-obsidian
requested_ref: main
resolved_sha: 27c46226d21e540518a868c0ff55498b9f55bb3e
default_branch_sha: a25af75468588cad6f32fef1a3358b40b9036917
merge_base: a25af75468588cad6f32fef1a3358b40b9036917
applies_to: axinjjj:feat/windows-port-w0-1@27c46226d21e540518a868c0ff55498b9f55bb3e
release tier affected: W0 only
platform capabilities changed: none; import/dependency/CI boundary only
source or client versions touched: none
durable schemas touched: none
privacy boundary changed: no
macOS behavioral delta: none intended; full matrix is enforced in CI
Windows behavioral delta: base dependencies install and the declared import-safe surface is checked
live acceptance: not applicable to W0.1
unsupported edges: all W1-W6 runtime behavior remains unsupported
```

## Verification

- `python -m unittest tests.windows tests.test_repository_layout -v` — 15 passed on Windows
- `python -m compileall -q mcp_server.py ai core ui scripts tests` — passed
- fresh Windows dependency install — passed; `rumps` and `pyobjc` were not installed
- portability map — 72 owned Python modules, 72 classified rows
- `git diff --check` — passed
- staged privacy scan — no local paths, account identifiers, chat data, database material, or secrets

The macOS regression matrix and the Windows 3.11 runner are the authoritative remote gates for this PR.

## Security and data scope

The workflow has read-only repository permissions. This change neither reads nor mutates WeChat data, keys, user configuration, databases, launch services, scheduled tasks, or external accounts.

Supersedes the earlier all-in-one prototype in #5, which crossed multiple spec phases.