### PR TITLE
Complete privacy-safe reliability health and release closure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,16 @@
   Monitor/catch-up may read only a complete inventory. Resource and Direct
   Drive scanners may consume present generations while reporting
   `source_degraded`; they must never relabel that partial observation complete.
+- `scripts/health_check.py` is the canonical operator health matrix. Its
+  default output is path-free and content-free: no chat identity/body,
+  source-relative path, local absolute path, API endpoint, or token. It must
+  distinguish monitor healthy/missing/corrupt/conflict, source inventory
+  completeness/counts, raw cursor progress, mounted handoff with provider sync
+  unknown, separate Direct Drive verification, disabled link preview, legacy
+  read-only/send-retired MCP, and the Windows W0.1 import-only boundary.
+  Health inspection must not scan source, initialize/migrate the source
+  inventory, open CAS payload objects, or promote mounted evidence to remote
+  verification. Local details require explicit `--sensitive`.
 - `setup.py` is the py2app packaging entrypoint. These are the only Python
   files that belong at repository root.
 - `core/` owns domain behavior, durable state, privacy boundaries, recovery,

--- a/README.md
+++ b/README.md
@@ -331,6 +331,22 @@ Equivalent CLI flags:
 ./启动.command --uninstall-autostart
 ```
 
+The default health output is content-free and path-free. It now separates the
+operational facts that were previously easy to collapse:
+
+| Health line | What it proves |
+| --- | --- |
+| `Monitor state` | Per-chat state files are valid, missing, corrupt, or the last runtime result observed a revision conflict. Corrupt state blocks progress; it is never reset to now. |
+| `Monitor raw cursor progress` | Counts of checkpointed chats and generation-bound shard cursors; no chat or cursor value is printed. |
+| `Source inventory` | Complete versus degraded/uninitialized inventory plus present, missing, cache-only, key-missing, and unreadable counts. “Complete” requires a complete expected-shard inventory, stable current generations, and successful reads. |
+| `Mounted resource handoff` | Existing destination binding and latest snapshot handoff evidence. `provider_side_sync=unknown` and `remote_verified=False` remain explicit even after `sync_delegated`. |
+| `Google Drive API remote verification` | Count of objects verified through the optional Direct Drive API ledger. It is separate from source completeness and mounted-folder delivery. |
+| `Link preview` / `MCP compatibility` / `Windows` | Preview is disabled with zero requests; MCP is legacy read-only and send-retired; W0.1 is only an import/dependency boundary, not Windows product support. |
+
+`--sensitive` may show local paths, chat names, topic titles, source-relative
+paths, and opaque shard IDs for deliberate on-device debugging. Default output
+never prints those values, message text, API endpoints, or token material.
+
 Monitor maintenance helpers:
 
 ```bash
@@ -587,7 +603,7 @@ If WeChat or the provider was unavailable and the monitor has a checkpointed bac
 ./launchers/补跑遗漏笔记.command --apply  # pause, back up, drain, rebuild, validate, restore
 ```
 
-Write mode requires the explicit `--apply` flag. It refuses chats without recoverable state and uses the normal paginated `TopicMonitor` path. Monitor state is a locked, revisioned atomic file: only a truly absent file initializes to now; corrupt JSON, symlinks, and non-regular files fail closed. Canonical progress is `source_cursors` per chat and logical-shard generation, using opaque raw-row tokens; `last_checked_ts` remains only a derived compatibility/diagnostic value. Each bounded batch reads every shard under one complete inventory, merges raw envelopes by `create_time` then `source_message_id`, and advances only rows actually consumed. Filtered/system rows advance the source cursor but never enter the AI prompt; `source_advanced_no_visible` is therefore progress, while `no_messages` means verified raw EOF. AI failure, source-generation change, or stale state revision commits no cursor. If a Knowledge event commits before a state CAS conflict, the retry reuses its source-batch identity instead of inserting a duplicate canonical event. Catch-up stops the managed LaunchAgent, then must acquire the same menu-app singleton lock before any backup, state, database, or projection write. `menu_app_active` means a manually started app still owns that lock, so catch-up writes no canonical data. With ownership established, it stores a private partial-recovery backup under `~/.we-groupchat-obsidian/backups/monitor-catch-up/`, drains to verified raw EOF under an unchanged complete inventory, rebuilds affected source-date indexes and historical Daily Digests, validates SQLite/FTS/hash parity, writes the reconciliation receipt while still holding the lock, releases ownership, and only then restores a previously loaded LaunchAgent.
+Write mode requires the explicit `--apply` flag. It refuses chats without recoverable state and uses the normal paginated `TopicMonitor` path. Monitor state is a locked, revisioned atomic file: only a truly absent file initializes to now; corrupt JSON, symlinks, and non-regular files fail closed. Canonical progress is `source_cursors` per chat and logical-shard generation, using opaque raw-row tokens; `last_checked_ts` remains only a derived compatibility/diagnostic value. Each bounded batch reads every shard under one complete inventory, merges raw envelopes by `create_time` then `source_message_id`, and advances only rows actually consumed. Here “complete source” means the expected logical-shard inventory is complete, every generation remains the one bound to the batch, and all required reads succeed. Filtered/system rows advance the source cursor but never enter the AI prompt; `source_advanced_no_visible` is therefore progress, while `no_messages` means verified raw EOF. AI failure, source-generation change, or stale state revision commits no cursor. If a Knowledge event commits before a state CAS conflict, the retry reuses its source-batch identity instead of inserting a duplicate canonical event. Catch-up stops the managed LaunchAgent, then must acquire the same menu-app singleton lock before any backup, state, database, or projection write. `menu_app_active` means a manually started app still owns that lock, so catch-up writes no canonical data. With ownership established, it stores a private partial-recovery backup under `~/.we-groupchat-obsidian/backups/monitor-catch-up/`, drains to verified raw EOF under an unchanged complete inventory, rebuilds affected source-date indexes and historical Daily Digests, validates SQLite/FTS/hash parity, writes the reconciliation receipt while still holding the lock, releases ownership, and only then restores a previously loaded LaunchAgent.
 
 The catch-up backup currently contains only canonical SQLite plus per-chat checkpoints. It is useful for recovery evidence, but it is not a complete rollback bundle: Review Queue JSONL and Obsidian Markdown/index/Digest projections are not copied. A failed run may therefore retain successfully committed pages before the LaunchAgent resumes. Do not describe this backup as full rollback until a separate recovery policy covers every managed surface.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,6 +287,20 @@ source install 与 LaunchAgent 继续使用。
 ./启动.command --uninstall-autostart
 ```
 
+默认 health output 保持 content-free、path-free，并把过去容易混成一团的状态拆开：
+
+| Health line | 它能证明什么 |
+| --- | --- |
+| `Monitor state` | 每个 selected chat 的 state 是 healthy、missing、corrupt，或最近 runtime 观察到 revision conflict。Corrupt state 会阻断推进，绝不会自动 reset to now。 |
+| `Monitor raw cursor progress` | 只输出 checkpointed chat 数和 generation-bound shard cursor 数，不输出 chat/cursor value。 |
+| `Source inventory` | 区分 complete、degraded 与 uninitialized，并分别统计 present、missing、cache-only、key-missing、unreadable。只有 expected inventory 完整、current generations 稳定且 required reads 全部成功，才能叫 source complete。 |
+| `Mounted resource handoff` | 只读检查现有 destination binding 与 latest snapshot handoff；即使是 `sync_delegated`，也明确保留 `provider_side_sync=unknown`、`remote_verified=False`。 |
+| `Google Drive API remote verification` | 可选 Direct Drive API ledger 中经过 remote verification 的 object 数；它与 source completeness、mounted delivery 都是不同事实。 |
+| `Link preview` / `MCP compatibility` / `Windows` | Preview 停用且零请求；MCP 为 legacy read-only、send retired；W0.1 只是 import/dependency boundary，不是 Windows 产品支持。 |
+
+只有显式 `--sensitive` 才可能显示本机 paths、chat names、topic titles、source-relative
+paths 与 opaque shard IDs。默认输出不打印这些值，也不打印 message text、API endpoint 或 token material。
+
 面向 monitor 的维护脚本：
 
 ```bash

--- a/core/monitor_state.py
+++ b/core/monitor_state.py
@@ -216,6 +216,16 @@ class MonitorStateStore:
         finally:
             self._unlock(fd)
 
+    def inspect(self) -> MonitorStateSnapshot:
+        """Read atomic state without creating a directory or lock file.
+
+        State publication uses ``os.replace``, so an observation sees either
+        the complete old file or the complete new file.  Writers still use the
+        locked ``read``/``commit`` surfaces; this method exists for health and
+        other strictly read-only diagnostics.
+        """
+        return self._read_locked()
+
     def initialize_if_absent(self, initial_state: dict) -> MonitorStateSnapshot:
         fd = self._lock(exclusive=True)
         try:

--- a/core/resource_backup.py
+++ b/core/resource_backup.py
@@ -27,7 +27,11 @@ from urllib.parse import quote
 
 from .attachment_archive import ArchiveError
 from .config import DATA_DIR
-from .resource_capture import ResourceCaptureError, SelectedResourceCapture
+from .resource_capture import (
+    ResourceCaptureError,
+    SelectedResourceCapture,
+    resource_capture_db_path,
+)
 from .url_safety import redact_url_for_display, redact_urls_in_text
 
 
@@ -2792,28 +2796,7 @@ class MountedResourceBackup:
         directory = self._snapshot_dir(snapshot_id)
         if not directory:
             return None
-        try:
-            with open(os.path.join(directory, "COMPLETE"), "rb") as handle:
-                complete_bytes = handle.read()
-            with open(os.path.join(directory, "manifest.json"), "rb") as handle:
-                manifest_bytes = handle.read()
-            with open(os.path.join(directory, "resources.jsonl"), "rb") as handle:
-                resources_bytes = handle.read()
-            complete = json.loads(complete_bytes.decode("utf-8"))
-            manifest = json.loads(manifest_bytes.decode("utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-            return None
-        if (
-            complete.get("schema") != BACKUP_SCHEMA
-            or complete.get("state") != "complete"
-            or manifest.get("schema") != BACKUP_SCHEMA
-            or complete.get("snapshot_id") != manifest.get("snapshot_id")
-            or complete.get("manifest_sha256") != hashlib.sha256(manifest_bytes).hexdigest()
-            or complete.get("resources_sha256") != hashlib.sha256(resources_bytes).hexdigest()
-            or manifest.get("resources_sha256") != hashlib.sha256(resources_bytes).hexdigest()
-        ):
-            return None
-        return {"directory": directory, "manifest": manifest}
+        return _read_complete_snapshot_directory(directory)
 
     def verify(self, snapshot_id=""):
         try:
@@ -2912,3 +2895,240 @@ class MountedResourceBackup:
             "remote_verified": False,
             "link_export_mode": self.link_export_mode,
         }
+
+
+def _read_complete_snapshot_directory(directory):
+    """Read and hash-bind one existing mounted snapshot without mutation."""
+    try:
+        complete_bytes = MountedResourceBackup._read_regular_bytes(
+            os.path.join(directory, "COMPLETE"),
+            error_code="snapshot_unavailable",
+        )
+        manifest_bytes = MountedResourceBackup._read_regular_bytes(
+            os.path.join(directory, "manifest.json"),
+            error_code="snapshot_unavailable",
+        )
+        resources_bytes = MountedResourceBackup._read_regular_bytes(
+            os.path.join(directory, "resources.jsonl"),
+            error_code="snapshot_unavailable",
+        )
+        complete = json.loads(complete_bytes.decode("utf-8"))
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (
+        ResourceBackupError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        OSError,
+    ):
+        return None
+    if (
+        complete.get("schema") != BACKUP_SCHEMA
+        or complete.get("state") != "complete"
+        or manifest.get("schema") != BACKUP_SCHEMA
+        or complete.get("snapshot_id") != manifest.get("snapshot_id")
+        or complete.get("manifest_sha256")
+        != hashlib.sha256(manifest_bytes).hexdigest()
+        or complete.get("resources_sha256")
+        != hashlib.sha256(resources_bytes).hexdigest()
+        or manifest.get("resources_sha256")
+        != hashlib.sha256(resources_bytes).hexdigest()
+    ):
+        return None
+    return {"directory": directory, "manifest": manifest}
+
+
+def _read_snapshot_metadata_directory(directory):
+    """Validate snapshot control files without opening the resource catalog."""
+    try:
+        complete_bytes = MountedResourceBackup._read_regular_bytes(
+            os.path.join(directory, "COMPLETE"),
+            error_code="snapshot_unavailable",
+        )
+        manifest_bytes = MountedResourceBackup._read_regular_bytes(
+            os.path.join(directory, "manifest.json"),
+            error_code="snapshot_unavailable",
+        )
+        complete = json.loads(complete_bytes.decode("utf-8"))
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (
+        ResourceBackupError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        OSError,
+    ):
+        return None
+    if (
+        complete.get("schema") != BACKUP_SCHEMA
+        or complete.get("state") != "complete"
+        or manifest.get("schema") != BACKUP_SCHEMA
+        or complete.get("snapshot_id") != manifest.get("snapshot_id")
+        or complete.get("manifest_sha256")
+        != hashlib.sha256(manifest_bytes).hexdigest()
+        or complete.get("resources_sha256") != manifest.get("resources_sha256")
+    ):
+        return None
+    return {"directory": directory, "manifest": manifest}
+
+
+def inspect_mounted_resource_backup(config, *, settings_path=SETTINGS_FILE):
+    """Inspect mounted handoff evidence without creating or migrating state.
+
+    The result is path-free and provider-neutral.  It validates the existing
+    destination binding and latest hash-bound snapshot, but never claims that
+    a desktop sync provider uploaded those bytes to its remote service.
+    """
+    config = dict(config or {})
+    settings = _read_resource_backup_settings_unlocked(settings_path)
+    configured_target = str(
+        config.get("resource_backup_target") or settings.get("target") or ""
+    ).strip()
+    target = (
+        os.path.abspath(os.path.expanduser(configured_target))
+        if configured_target else ""
+    )
+    enabled = bool(config.get("resource_backup_enabled", False))
+    result = {
+        "state": "disabled" if not enabled else "target_not_configured",
+        "enabled": enabled,
+        "target_configured": bool(target),
+        "handoff_semantics": "target_not_configured",
+        "provider_side_sync": "unknown",
+        "remote_verified": False,
+        "latest_snapshot": False,
+        "source_complete": False,
+        "delivery_counts": {},
+        "link_export_mode": _normalized_link_export_mode(
+            settings.get("link_export_mode")
+        ),
+        "last_error_code": "",
+    }
+    if not target:
+        return result
+    if not os.path.isdir(target):
+        result.update({
+            "state": "destination_unavailable",
+            "handoff_semantics": "destination_unavailable",
+            "last_error_code": "destination_unavailable",
+        })
+        return result
+
+    marker_path = os.path.join(
+        target,
+        "wgo-resource-backup",
+        DESTINATION_MARKER_NAME,
+    )
+    try:
+        marker = json.loads(MountedResourceBackup._read_regular_bytes(
+            marker_path,
+            error_code="destination_identity_missing",
+        ).decode("utf-8"))
+        destination_id = str(uuid.UUID(str(marker.get("destination_uuid") or "")))
+        if marker.get("schema") != DESTINATION_MARKER_SCHEMA:
+            raise ValueError("destination identity schema")
+    except (
+        ResourceBackupError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+    ):
+        result.update({
+            "state": "destination_identity_missing",
+            "handoff_semantics": "destination_identity_missing",
+            "last_error_code": "destination_identity_missing",
+        })
+        return result
+
+    db_path = resource_capture_db_path(config)
+    if not os.path.isfile(db_path):
+        result.update({
+            "state": "ledger_missing",
+            "handoff_semantics": "pending",
+            "last_error_code": "resource_ledger_missing",
+        })
+        return result
+
+    conn = None
+    try:
+        uri = "file:" + quote(db_path, safe="/") + "?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        conn.row_factory = sqlite3.Row
+        archive_row = conn.execute(
+            "SELECT value FROM resource_meta WHERE key = 'archive_id'"
+        ).fetchone()
+        archive_id = str(archive_row["value"] or "") if archive_row else ""
+        if not archive_id or str(marker.get("archive_id") or "") != archive_id:
+            result.update({
+                "state": "destination_archive_mismatch",
+                "handoff_semantics": "destination_archive_mismatch",
+                "last_error_code": "destination_archive_mismatch",
+            })
+            return result
+        state_row = conn.execute(
+            "SELECT snapshot_id FROM resource_backup_state WHERE destination_id = ?",
+            (destination_id,),
+        ).fetchone()
+        result["delivery_counts"] = {
+            str(row["status"]): int(row["count"])
+            for row in conn.execute(
+                "SELECT status, COUNT(*) AS count FROM resource_deliveries "
+                "WHERE destination_id = ? GROUP BY status",
+                (destination_id,),
+            )
+        }
+    except (OSError, sqlite3.Error, TypeError, ValueError):
+        result.update({
+            "state": "ledger_unreadable",
+            "handoff_semantics": "unknown",
+            "last_error_code": "resource_ledger_unreadable",
+        })
+        return result
+    finally:
+        if conn is not None:
+            conn.close()
+
+    if not state_row or not str(state_row["snapshot_id"] or ""):
+        result.update({
+            "state": "disabled" if not enabled else "ready",
+            "handoff_semantics": "pending",
+        })
+        return result
+    snapshot_id = str(state_row["snapshot_id"])
+    if os.path.basename(snapshot_id) != snapshot_id:
+        snapshot = None
+    else:
+        snapshot = _read_snapshot_metadata_directory(os.path.join(
+            target,
+            "wgo-resource-backup",
+            "v3",
+            "snapshots",
+            snapshot_id,
+        ))
+    if snapshot is None:
+        result.update({
+            "state": "snapshot_unavailable",
+            "handoff_semantics": "pending",
+            "last_error_code": "snapshot_unavailable",
+        })
+        return result
+    manifest = snapshot["manifest"]
+    if (
+        str(manifest.get("archive_id") or "") != archive_id
+        or str(manifest.get("snapshot_id") or "") != snapshot_id
+    ):
+        result.update({
+            "state": "snapshot_unavailable",
+            "handoff_semantics": "pending",
+            "last_error_code": "snapshot_unavailable",
+        })
+        return result
+    result.update({
+        "state": "disabled" if not enabled else "ready",
+        "handoff_semantics": str(
+            manifest.get("handoff_semantics") or "unknown"
+        ),
+        "latest_snapshot": True,
+        "source_complete": bool(
+            (manifest.get("source_observation") or {}).get("complete")
+        ),
+    })
+    return result

--- a/core/resource_capture.py
+++ b/core/resource_capture.py
@@ -61,6 +61,11 @@ def _capture_db_path(config):
     return os.path.abspath(os.path.expanduser(value))
 
 
+def resource_capture_db_path(config):
+    """Return the canonical capture-ledger path without opening it."""
+    return _capture_db_path(config)
+
+
 @contextmanager
 def resource_capture_operation_lock(config):
     """Serialize capture operations and selected-chat config mutations.

--- a/core/source_inventory.py
+++ b/core/source_inventory.py
@@ -88,6 +88,37 @@ def logical_shard_id(source_namespace: str, relative_path: str) -> str:
     ).hexdigest()[:32]
 
 
+def source_namespaces_for_root(path: str | os.PathLike[str]) -> tuple[str, str]:
+    """Return the cache and durable source namespaces for one configured root.
+
+    This is intentionally observation-only.  It does not create a cache,
+    inventory ledger, lock file, or source directory.
+    """
+    source_root = os.path.realpath(os.path.expanduser(os.fspath(path or "")))
+    try:
+        source_stat = os.stat(source_root)
+        cache_identity = (
+            f"{source_root}\0{source_stat.st_dev}\0{source_stat.st_ino}"
+        )
+        namespace_identity = (
+            f"{source_root}\0{source_stat.st_dev}:{source_stat.st_ino}"
+        )
+    except OSError:
+        cache_identity = f"{source_root}\0missing"
+        cache_namespace = hashlib.sha256(
+            cache_identity.encode("utf-8")
+        ).hexdigest()
+        namespace_identity = cache_namespace
+    else:
+        cache_namespace = hashlib.sha256(
+            cache_identity.encode("utf-8")
+        ).hexdigest()
+    source_namespace = hashlib.sha256(
+        f"wechat-source-namespace-v1\0{namespace_identity}".encode("utf-8")
+    ).hexdigest()[:32]
+    return cache_namespace, source_namespace
+
+
 @dataclass(frozen=True)
 class SourceInventorySnapshot:
     source_namespace: str

--- a/core/wechat_db.py
+++ b/core/wechat_db.py
@@ -18,7 +18,12 @@ from urllib.parse import quote
 import zstandard as zstd
 
 from .decryptor import WALSnapshotError, decrypt_database, decrypt_wal
-from .source_inventory import COMPLETE_STATES, SourceInventoryError, SourceInventoryStore
+from .source_inventory import (
+    COMPLETE_STATES,
+    SourceInventoryError,
+    SourceInventoryStore,
+    source_namespaces_for_root,
+)
 
 _zstd_dctx = zstd.ZstdDecompressor()
 
@@ -337,27 +342,9 @@ class WeChatDB:
             else SourceInventoryStore(path=None)
         )
         self._inventory_specs_by_generation = {}
-        source_root = os.path.realpath(self.db_dir)
-        source_stat = None
-        try:
-            source_stat = os.stat(source_root)
-            source_identity = (
-                f"{source_root}\0{source_stat.st_dev}\0{source_stat.st_ino}"
-            )
-        except OSError:
-            source_identity = f"{source_root}\0missing"
-        self.cache_namespace = hashlib.sha256(
-            source_identity.encode("utf-8")
-        ).hexdigest()
-        if source_stat is not None:
-            namespace_identity = (
-                f"{source_root}\0{source_stat.st_dev}:{source_stat.st_ino}"
-            )
-        else:
-            namespace_identity = self.cache_namespace
-        self.source_namespace = hashlib.sha256(
-            f"wechat-source-namespace-v1\0{namespace_identity}".encode("utf-8")
-        ).hexdigest()[:32]
+        self.cache_namespace, self.source_namespace = source_namespaces_for_root(
+            self.db_dir
+        )
         self.cache_dir = os.path.join(self.CACHE_DIR, self.cache_namespace)
         os.makedirs(self.cache_dir, exist_ok=True)
         try:

--- a/docs/WINDOWS-PORT-MAP.md
+++ b/docs/WINDOWS-PORT-MAP.md
@@ -106,7 +106,7 @@ root, `ai/`, `core/`, `ui/`, and `scripts/` Python module and imports every
 | `scripts/configure_monitor.py` | `operator-deferred` | Depends on config, source, keychain, and knowledge activation. |
 | `scripts/daily_digest.py` | `operator-deferred` | Depends on W0.2 storage and W3 activation. |
 | `scripts/google_drive_file_sync.py` | `operator-deferred` | Depends on current auth/config/source adapters. |
-| `scripts/health_check.py` | `macos-only` | Reports LaunchAgent, notification identity, and macOS source state. |
+| `scripts/health_check.py` | `macos-only` | Privacy-safe reliability matrix plus LaunchAgent/notification/macOS source diagnostics; its Windows line reports the W0.1 import boundary only. |
 | `scripts/migrate_taxonomy.py` | `operator-deferred` | Depends on W0.2 config/knowledge storage. |
 | `scripts/organize_obsidian.py` | `operator-deferred` | Depends on W0.2 path/storage and W3 projection activation. |
 | `scripts/refresh_data_source.py` | `macos-only` | Invokes the current macOS key/process adapter. |

--- a/docs/resource-capture-and-mounted-backup-spec.md
+++ b/docs/resource-capture-and-mounted-backup-spec.md
@@ -456,6 +456,13 @@ the backup root and passes metadata-only `lstat`: regular, non-symlink, matching
 size. Ordinary classification, rendering, `plan`, and `status` do not hash target
 bytes or open the source CAS. Explicit `verify` retains full target hashing.
 
+The general redacted health check uses a stricter read-only inspection path: it
+does not create/migrate the capture ledger, does not open CAS payload objects,
+and reports only destination/snapshot control evidence plus delivery counts.
+Its mounted line always says `provider_side_sync=unknown` and
+`remote_verified=False`. Direct Drive API verification is a separate health
+line and never upgrades mounted handoff evidence.
+
 App/CLI reporting keeps the existing strict `completed` and CLI exit contract for
 compatibility, and adds `operational_success`, `coverage_complete`, and `coverage`.
 `operational_success` accepts a healthy capture/scan/resolution/projection cycle

--- a/docs/source-reliability.md
+++ b/docs/source-reliability.md
@@ -752,15 +752,50 @@ tranche deliberately provides no automatic restore or deletion.
 
 ## 7. Health and safe rollout
 
-The redacted health check reports source-guard effective state, last result,
-remaining restart budget, source freshness, attachment catalog counts/object
-count, optional attachment snapshots, and privacy-safe optional direct-Drive
-state. Mounted resource backup currently has its own explicit status surface:
+The redacted health check now gives one privacy-safe reliability matrix. It
+distinguishes monitor state `healthy|missing|corrupt|conflict`, counts
+generation-bound raw cursors, reads the configured source inventory without
+scanning or creating it, and reports complete/degraded plus present, missing,
+cache-only, key-missing, and unreadable counts. Source completeness means the
+expected logical-shard inventory is complete, the current generation set stays
+stable, and the required reads succeeded; it does not mean merely that one
+enumeration returned rows.
+
+The same health surface reports the existing mounted destination/snapshot
+handoff without opening CAS payload objects. Mounted `sync_delegated` remains
+`provider_side_sync=unknown` and `remote_verified=False`. A separate Direct
+Drive line reports the number of ledger objects that passed Drive API
+verification; that remote evidence is independent from source completeness.
+It also states the fixed product boundaries: remote link preview is
+`link_preview_disabled` with zero requests, MCP is legacy read-only with send
+retired, and Windows W0.1 is an import/dependency boundary only.
 
 ```bash
 .venv/bin/python scripts/health_check.py
 .venv/bin/python scripts/resource_backup.py status
 ```
+
+Default output contains no absolute paths, chat names/usernames, message text,
+source-relative paths, API endpoints, or token material. `--sensitive` is an
+explicit local-debug disclosure gate for paths, titles, and source-shard
+details.
+
+### Upgrade and migration behavior
+
+- A valid unversioned monitor state remains readable and is upgraded only by a
+  later successful locked write. Corrupt/non-regular state never migrates or
+  resets to now.
+- A legacy timestamp checkpoint seeds missing per-generation raw cursors only
+  under one complete inventory. Generation changes never inherit an old token.
+- Source-inventory health inspection never creates or migrates the ledger;
+  initialization happens only during an actual source scan.
+- Legacy `monitor_fetch_links=true` loads as disabled, and legacy mounted
+  `link_export_mode=full` loads as `redacted`. Neither value restores the
+  retired network/export behavior.
+- Legacy MCP send keys remain parseable but inert; every old send tool returns
+  `mcp_send_retired`.
+- Windows W0.1 adds no source, monitor, backup, tray, autostart, packaging, or
+  sending activation. Later Windows phases remain separate migrations.
 
 A safe first mounted-backup rollout is:
 

--- a/docs/source-reliability.zh-CN.md
+++ b/docs/source-reliability.zh-CN.md
@@ -610,13 +610,39 @@ DB/catalog 缺失时仍能工作。这一 tranche 故意没有 automatic restore
 
 ## 7. Health 与安全 rollout
 
-Redacted health check 会报告 source guard、source freshness、attachment catalog、optional attachment
-snapshot 与 privacy-safe optional direct-Drive state。Mounted resource backup 当前有独立 status surface：
+Redacted health check 现在提供一份 privacy-safe reliability matrix：明确区分 monitor state
+`healthy|missing|corrupt|conflict`，统计 generation-bound raw cursors；对 configured source inventory
+只读 inspect，不做 source scan、也不创建 ledger，并分别报告 complete/degraded、present、missing、
+cache-only、key-missing 与 unreadable。只有 expected logical-shard inventory 完整、current generation set
+保持稳定且 required reads 全部成功，才能叫 source complete；一次 enumeration 有 rows 不够。
+
+同一个 health surface 会只读报告现有 mounted destination/snapshot handoff，且不打开 CAS payload
+objects。Mounted `sync_delegated` 始终保留 `provider_side_sync=unknown` 与
+`remote_verified=False`。独立 Direct Drive 行只统计通过 Drive API verification 的 ledger objects；
+这份 remote evidence 与 source completeness 互不替代。Health 还直接写明三个固定产品边界：remote
+link preview 是 `link_preview_disabled` 且零请求；MCP 是 legacy read-only、send retired；Windows
+W0.1 只是一条 import/dependency boundary。
 
 ```bash
 .venv/bin/python scripts/health_check.py
 .venv/bin/python scripts/resource_backup.py status
 ```
+
+默认输出不含 absolute path、chat name/username、message text、source-relative path、API endpoint
+或 token material。只有显式 `--sensitive` 才会为本机 debug 披露 path、title 与 source-shard details。
+
+### Upgrade 与 migration 行为
+
+- 合法的 unversioned monitor state 仍可读取，只在之后一次成功的 locked write 中升级；corrupt 或
+  non-regular state 绝不 migrate，也绝不 reset to now。
+- Legacy timestamp checkpoint 只有在 complete inventory 下才用于 seed 缺失的 per-generation raw
+  cursors；generation change 绝不继承旧 token。
+- Source-inventory health inspection 不创建、不迁移 ledger；只有 actual source scan 才初始化。
+- 旧 `monitor_fetch_links=true` 加载后仍为 disabled；旧 mounted `link_export_mode=full` 加载为
+  `redacted`，两者都不能恢复已经退休的 network/export 行为。
+- Legacy MCP send keys 仍可解析但完全 inert；所有旧 send tool 固定返回 `mcp_send_retired`。
+- Windows W0.1 不激活 source、monitor、backup、tray、autostart、packaging 或 sending；后续 Windows
+  phase 是独立 migration。
 
 第一次安全启用 mounted backup 建议按下面顺序：
 

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -19,6 +19,7 @@ from core.attachment_backup import AttachmentBackup
 from core.google_drive_auth import GoogleDriveOAuth
 from core.google_drive_file_sync import GoogleDriveFileSync
 from core.knowledge import TAXONOMY_PROFILES
+from core.link_preview import LINK_PREVIEW_STATE
 from core.key_extractor import (
     EXTRACT_LOG,
     check_new_databases,
@@ -38,11 +39,38 @@ from core.launch_agent import (
 )
 from core.notification_identity import notification_identity_status_for_launch_agent
 from core.project_identity import SOURCE_GUARD_LAUNCH_AGENT_LABEL
+from core.monitor import STATE_DIR as MONITOR_STATE_DIR, state_file_for_chat
+from core.monitor_state import MonitorStateError, MonitorStateStore
+from core.resource_backup import inspect_mounted_resource_backup
+from core.source_inventory import (
+    SOURCE_STATES,
+    SourceInventoryError,
+    SourceInventoryStore,
+    source_namespaces_for_root,
+)
 from core.taxonomy_assignment import taxonomy_assignment_summary
 from core.wechat_source_guard import source_guard_status
 
 AUTOSTART_ERR_LOG = Path(DATA_DIR) / "logs" / "autostart.err.log"
 AUTOSTART_OUT_LOG = Path(DATA_DIR) / "logs" / "autostart.out.log"
+
+_MONITOR_RUNTIME_STATES = frozenset({
+    "ai_backoff",
+    "cooldown",
+    "duplicate",
+    "initialized",
+    "missing_topic",
+    "monitor_source_cursors_corrupt",
+    "monitor_state_conflict",
+    "monitor_state_corrupt",
+    "monitor_state_missing_checkpoint",
+    "no_match",
+    "no_messages",
+    "notified",
+    "source_advanced_no_visible",
+    "source_generation_changed",
+    "source_inventory_incomplete",
+})
 
 
 def ok(value: bool) -> str:
@@ -190,6 +218,161 @@ def _sensitive_log_status(delete: bool = False) -> tuple[str, bool]:
     return "present", True
 
 
+def latest_monitor_runtime_result(
+    path: str | os.PathLike[str] = AUTOSTART_OUT_LOG,
+) -> str:
+    """Return the last content-free monitor result code from the app log."""
+    try:
+        lines = Path(path).read_text(
+            encoding="utf-8", errors="replace"
+        ).splitlines()
+    except OSError:
+        return "unknown"
+    for line in reversed(lines):
+        text = line.strip()
+        if text.startswith("[monitor] 命中["):
+            return "notified"
+        match = re.match(r"^\[monitor\]\s+([a-z][a-z0-9_]*)(?::|$)", text)
+        if match and match.group(1) in _MONITOR_RUNTIME_STATES:
+            return match.group(1)
+    return "unknown"
+
+
+def _monitor_cursor_progress(data) -> tuple[dict, bool]:
+    cursors = (data or {}).get("source_cursors")
+    progress = {
+        "shard_cursors": 0,
+        "generation_bound": 0,
+        "inventory_bound": bool((data or {}).get("source_inventory_digest")),
+        "legacy_checkpoint_only": False,
+    }
+    if cursors is None:
+        progress["legacy_checkpoint_only"] = bool(
+            (data or {}).get("last_checked_ts")
+        )
+        return progress, True
+    if not isinstance(cursors, dict):
+        return progress, False
+    progress["shard_cursors"] = len(cursors)
+    for shard_id, item in cursors.items():
+        if (
+            not isinstance(shard_id, str)
+            or not isinstance(item, dict)
+            or not isinstance(item.get("generation_id"), str)
+            or not item.get("generation_id")
+            or not isinstance(item.get("cursor_token"), str)
+        ):
+            return progress, False
+        progress["generation_bound"] += 1
+    return progress, True
+
+
+def monitor_state_health(
+    config,
+    *,
+    state_dir: str | os.PathLike[str] = MONITOR_STATE_DIR,
+    runtime_log: str | os.PathLike[str] = AUTOSTART_OUT_LOG,
+) -> dict:
+    """Inspect per-chat monitor state without printing chat identity or paths."""
+    chats = active_monitor_chats(config or {})
+    counts = {"healthy": 0, "missing": 0, "corrupt": 0}
+    cursor_chats = 0
+    shard_cursors = 0
+    generation_bound = 0
+    inventory_bound = 0
+    legacy_states = 0
+    for chat in chats:
+        path = state_file_for_chat(chat.get("username", ""), state_dir=state_dir)
+        try:
+            snapshot = MonitorStateStore(path).inspect()
+        except MonitorStateError:
+            counts["corrupt"] += 1
+            continue
+        if not snapshot.existed:
+            counts["missing"] += 1
+            continue
+        progress, valid = _monitor_cursor_progress(snapshot.data)
+        if not valid:
+            counts["corrupt"] += 1
+            continue
+        if not snapshot.data.get("last_checked_ts") and not progress["shard_cursors"]:
+            counts["missing"] += 1
+            continue
+        counts["healthy"] += 1
+        if snapshot.revision == 0:
+            legacy_states += 1
+        if progress["shard_cursors"]:
+            cursor_chats += 1
+        shard_cursors += int(progress["shard_cursors"])
+        generation_bound += int(progress["generation_bound"])
+        inventory_bound += int(progress["inventory_bound"])
+
+    runtime_result = latest_monitor_runtime_result(runtime_log)
+    if runtime_result == "monitor_state_conflict":
+        state = "conflict"
+    elif counts["corrupt"]:
+        state = "corrupt"
+    elif counts["missing"] or not chats:
+        state = "missing"
+    else:
+        state = "healthy"
+    return {
+        "state": state,
+        "chat_count": len(chats),
+        "counts": counts,
+        "runtime_result": runtime_result,
+        "cursor_chats": cursor_chats,
+        "shard_cursors": shard_cursors,
+        "generation_bound": generation_bound,
+        "inventory_bound_chats": inventory_bound,
+        "legacy_states": legacy_states,
+    }
+
+
+def source_inventory_health(
+    config,
+    *,
+    store=None,
+    sensitive: bool = False,
+) -> dict:
+    """Inspect the configured source inventory without scanning or mutation."""
+    db_dir = str((config or {}).get("db_dir") or "").strip()
+    empty_counts = {state: 0 for state in sorted(SOURCE_STATES)}
+    if not db_dir:
+        return {
+            "state": "unconfigured",
+            "complete": False,
+            "counts": empty_counts,
+            "error_codes": ["source_not_configured"],
+            "shards": [],
+        }
+    _cache_namespace, source_namespace = source_namespaces_for_root(db_dir)
+    try:
+        snapshot = (store or SourceInventoryStore()).inspect(source_namespace)
+    except SourceInventoryError as exc:
+        return {
+            "state": "degraded",
+            "complete": False,
+            "counts": empty_counts,
+            "error_codes": [exc.code],
+            "shards": [],
+        }
+    if "source_inventory_uninitialized" in snapshot.error_codes:
+        state = "uninitialized"
+    else:
+        state = "complete" if snapshot.complete else "degraded"
+    return {
+        "state": state,
+        "complete": bool(snapshot.complete),
+        "counts": dict(snapshot.counts),
+        "error_codes": list(snapshot.error_codes),
+        "shards": (
+            snapshot.as_dict(sensitive=True).get("shards", [])
+            if sensitive else []
+        ),
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Print local we-groupchat-obsidian health status.")
     parser.add_argument(
@@ -240,6 +423,12 @@ def main(argv: list[str] | None = None) -> int:
         config,
         oauth=GoogleDriveOAuth(),
     )
+    monitor_state = monitor_state_health(config)
+    source_inventory = source_inventory_health(
+        config,
+        sensitive=args.sensitive,
+    )
+    mounted_backup = inspect_mounted_resource_backup(config)
 
     print("微信总结 health check")
     print("")
@@ -281,6 +470,71 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     print(f"[{ok(bool(config.get('monitor_topic')))}] Monitor topic: {'已设置' if config.get('monitor_topic') else '未设置'}")
+    monitor_counts = monitor_state["counts"]
+    monitor_enabled = bool(config.get("monitor_enabled", False))
+    monitor_ok = monitor_state["state"] == "healthy" or (
+        not monitor_enabled and monitor_state["state"] == "missing"
+    )
+    print(
+        f"[{ok(monitor_ok)}] Monitor state: {monitor_state['state']}; "
+        f"healthy={monitor_counts['healthy']}; missing={monitor_counts['missing']}; "
+        f"corrupt={monitor_counts['corrupt']}; "
+        f"last_runtime={monitor_state['runtime_result']}; "
+        f"legacy={monitor_state['legacy_states']}"
+    )
+    print(
+        f"[{ok(monitor_ok)}] Monitor raw cursor progress: "
+        f"checkpointed_chats={monitor_counts['healthy']}/{monitor_state['chat_count']}; "
+        f"cursor_chats={monitor_state['cursor_chats']}; "
+        f"shard_cursors={monitor_state['shard_cursors']}; "
+        f"generation_bound={monitor_state['generation_bound']}; "
+        f"inventory_bound_chats={monitor_state['inventory_bound_chats']}"
+    )
+    inventory_counts = source_inventory["counts"]
+    inventory_ok = source_inventory["state"] == "complete" or (
+        not monitor_enabled and source_inventory["state"] == "unconfigured"
+    )
+    print(
+        f"[{ok(inventory_ok)}] Source inventory: {source_inventory['state']}; "
+        f"present={inventory_counts.get('present', 0)}; "
+        f"generation_changed={inventory_counts.get('generation_changed', 0)}; "
+        f"missing={inventory_counts.get('missing_file', 0)}; "
+        f"cache_only={inventory_counts.get('cache_only', 0)}; "
+        f"key_missing={inventory_counts.get('key_missing', 0)}; "
+        f"unreadable={inventory_counts.get('unreadable', 0)}; "
+        f"errors={len(source_inventory['error_codes'])}"
+    )
+    if args.sensitive:
+        for shard in source_inventory.get("shards") or []:
+            print(
+                "  - Source shard: "
+                f"{shard.get('relative_path', '-')}; "
+                f"logical={shard.get('logical_shard_id', '-')}; "
+                f"generation={shard.get('generation_id', '-')}; "
+                f"state={shard.get('state', 'unknown')}"
+            )
+    mounted_state = mounted_backup.get("state") or "unknown"
+    mounted_ok = (
+        not mounted_backup.get("enabled")
+        or mounted_state == "ready"
+    )
+    delivery_counts = mounted_backup.get("delivery_counts") or {}
+    print(
+        f"[{ok(mounted_ok)}] Mounted resource handoff: "
+        f"runtime={mounted_state}; "
+        f"handoff={mounted_backup.get('handoff_semantics') or 'unknown'}; "
+        f"target={'configured' if mounted_backup.get('target_configured') else 'not_configured'}; "
+        f"delegated_objects={int(delivery_counts.get('sync_delegated') or 0)}; "
+        "provider_side_sync=unknown; remote_verified=False"
+    )
+    print(
+        f"[OK] Link preview: state={LINK_PREVIEW_STATE}; network_requests=0"
+    )
+    print("[OK] MCP compatibility: legacy_read_only; send=mcp_send_retired")
+    print(
+        "[OK] Windows: W0.1 import/dependency boundary only; "
+        "product_support=not_claimed"
+    )
     print("")
     obsidian_label = obsidian_root if args.sensitive else _path_status(obsidian_root)
     print(f"[{ok(os.path.isdir(obsidian_root))}] Obsidian output: {obsidian_label}")
@@ -381,6 +635,19 @@ def main(argv: list[str] | None = None) -> int:
         f"root={drive_root}; objects={int(drive_sync.get('uploaded_unique_objects') or 0)}; "
         f"shortcuts={int(drive_sync.get('shortcut_placements') or 0)}; "
         f"last_error={drive_sync.get('last_error_code') or '-'}"
+    )
+    verified_objects = int(drive_sync.get("uploaded_unique_objects") or 0)
+    if drive_sync.get("last_error_code") == "local_ledger_unreadable":
+        drive_remote_state = "unknown"
+    elif verified_objects:
+        drive_remote_state = "verified_ledger_objects"
+    else:
+        drive_remote_state = "not_yet_verified"
+    print(
+        f"[{ok(drive_remote_state != 'unknown')}] Google Drive API remote verification: "
+        f"{drive_remote_state}; verified_objects={verified_objects}; "
+        f"last_verified={float(drive_sync.get('last_verified_upload_at') or 0):.0f}; "
+        "separate_from_source_inventory=True"
     )
     print("")
     plist_label = agent_record.plist_path if args.sensitive else ("present" if agent_record.plist_path.exists() else "missing")

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,5 +1,6 @@
 import os
 import plistlib
+import json
 import sqlite3
 import tempfile
 import unittest
@@ -11,14 +12,166 @@ from unittest.mock import patch
 import scripts.health_check as health_check
 from scripts.health_check import (
     launch_agent_report,
+    latest_monitor_runtime_result,
     latest_notification_backend_status,
+    monitor_state_health,
     parse_launch_agent_status,
     review_queue_pending_count,
+    source_inventory_health,
 )
+from core.monitor import state_file_for_chat
+from core.monitor_state import MonitorStateStore
 from core.review_queue import ReviewQueue
+from core.source_inventory import SourceInventoryStore, source_namespaces_for_root
 
 
 class HealthCheckTests(unittest.TestCase):
+    def test_monitor_state_inspect_does_not_create_parent_or_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / "absent" / "monitor-state.json"
+
+            snapshot = MonitorStateStore(state_path).inspect()
+
+            self.assertFalse(snapshot.existed)
+            self.assertFalse(state_path.exists())
+            self.assertFalse(state_path.parent.exists())
+            self.assertFalse(Path(str(state_path) + ".lock").exists())
+
+    def test_monitor_state_health_distinguishes_all_operator_states(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_dir = root / "states"
+            runtime_log = root / "autostart.out.log"
+            config = {
+                "monitor_chats": [
+                    {"username": "one@chatroom", "name": "Private One"},
+                ]
+            }
+            state_path = state_file_for_chat(
+                "one@chatroom", state_dir=str(state_dir)
+            )
+            MonitorStateStore(state_path).initialize_if_absent({
+                "last_checked_ts": 100,
+                "source_inventory_digest": "opaque-digest",
+                "source_cursors": {
+                    "opaque-shard": {
+                        "generation_id": "opaque-generation",
+                        "cursor_token": "100:9",
+                    }
+                },
+            })
+            runtime_log.write_text(
+                "[monitor] no_messages: no_messages\n", encoding="utf-8"
+            )
+
+            report = monitor_state_health(
+                config,
+                state_dir=str(state_dir),
+                runtime_log=runtime_log,
+            )
+            self.assertEqual(report["state"], "healthy")
+            self.assertEqual(report["counts"], {
+                "healthy": 1, "missing": 0, "corrupt": 0,
+            })
+            self.assertEqual(report["shard_cursors"], 1)
+            self.assertEqual(report["generation_bound"], 1)
+            self.assertEqual(report["inventory_bound_chats"], 1)
+            self.assertNotIn("one@chatroom", str(report))
+            self.assertNotIn(str(state_dir), str(report))
+
+            runtime_log.write_text(
+                "[monitor] monitor_state_conflict: monitor_state_conflict\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                monitor_state_health(
+                    config,
+                    state_dir=str(state_dir),
+                    runtime_log=runtime_log,
+                )["state"],
+                "conflict",
+            )
+
+            missing = monitor_state_health(
+                {"monitor_chats": [{"username": "missing@chatroom"}]},
+                state_dir=str(state_dir),
+                runtime_log=root / "missing.log",
+            )
+            self.assertEqual(missing["state"], "missing")
+
+            corrupt_path = state_file_for_chat(
+                "corrupt@chatroom", state_dir=str(state_dir)
+            )
+            Path(corrupt_path).write_text("{broken", encoding="utf-8")
+            corrupt = monitor_state_health(
+                {"monitor_chats": [{"username": "corrupt@chatroom"}]},
+                state_dir=str(state_dir),
+                runtime_log=root / "missing.log",
+            )
+            self.assertEqual(corrupt["state"], "corrupt")
+
+    def test_latest_monitor_runtime_result_resets_old_conflict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "out.log"
+            log.write_text(
+                "[monitor] monitor_state_conflict: monitor_state_conflict\n"
+                "[monitor] 命中[notification-muted]: redacted\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(latest_monitor_runtime_result(log), "notified")
+
+    def test_source_inventory_health_is_read_only_and_counts_degradation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_root = root / "db_storage"
+            source_root.mkdir()
+            config = {"db_dir": str(source_root)}
+            inventory_path = root / "source_inventory.json"
+            store = SourceInventoryStore(path=inventory_path)
+            _cache_namespace, namespace = source_namespaces_for_root(source_root)
+            store.reconcile(namespace, [
+                {
+                    "relative_path": "message/message_0.db",
+                    "generation_id": "generation-0",
+                    "state": "present",
+                },
+                {
+                    "relative_path": "message/message_1.db",
+                    "generation_id": "generation-1",
+                    "state": "present",
+                },
+            ])
+            store.reconcile(namespace, [
+                {
+                    "relative_path": "message/message_0.db",
+                    "generation_id": "generation-0",
+                    "state": "present",
+                },
+                {
+                    "relative_path": "message/message_2.db",
+                    "generation_id": "generation-2",
+                    "state": "cache_only",
+                },
+            ])
+
+            report = source_inventory_health(config, store=store)
+            self.assertEqual(report["state"], "degraded")
+            self.assertEqual(report["counts"]["present"], 1)
+            self.assertEqual(report["counts"]["missing_file"], 1)
+            self.assertEqual(report["counts"]["cache_only"], 1)
+            self.assertEqual(report["shards"], [])
+            self.assertNotIn(str(source_root), str(report))
+            self.assertNotIn("message/message_0.db", str(report))
+
+            absent_path = root / "absent-inventory.json"
+            absent = source_inventory_health(
+                config,
+                store=SourceInventoryStore(path=absent_path),
+            )
+            self.assertEqual(absent["state"], "uninitialized")
+            self.assertFalse(absent_path.exists())
+            self.assertFalse(Path(str(absent_path) + ".lock").exists())
+
     def test_health_check_reports_v1_singleton_as_one_active_chat(self):
         config = {
             "monitor_chat_username": "room@chatroom",
@@ -350,6 +503,7 @@ gui/501/com.example.wechat-summary = {
                 "db_dir": str(db_dir),
                 "ai_provider": "qwen",
                 "ai_model": "model-private",
+                "ai_base_url": "https://api.private.invalid/v1?token=TOPSECRET",
                 "monitor_enabled": True,
                 "monitor_interval_minutes": 3,
                 "monitor_chats": [
@@ -410,6 +564,71 @@ gui/501/com.example.wechat-summary = {
                      },
                      create=True,
                  ), \
+                 patch(
+                     "scripts.health_check.monitor_state_health",
+                     return_value={
+                         "state": "conflict",
+                         "chat_count": 2,
+                         "counts": {"healthy": 2, "missing": 0, "corrupt": 0},
+                         "runtime_result": "monitor_state_conflict",
+                         "cursor_chats": 2,
+                         "shard_cursors": 6,
+                         "generation_bound": 6,
+                         "inventory_bound_chats": 2,
+                         "legacy_states": 0,
+                     },
+                 ), \
+                 patch(
+                     "scripts.health_check.source_inventory_health",
+                     return_value={
+                         "state": "degraded",
+                         "complete": False,
+                         "counts": {
+                             "present": 2,
+                             "generation_changed": 0,
+                             "missing_file": 1,
+                             "cache_only": 1,
+                             "key_missing": 0,
+                             "unreadable": 0,
+                         },
+                         "error_codes": ["source_missing_file", "source_cache_only"],
+                         "shards": [{
+                             "relative_path": "private/account/message_0.db",
+                             "logical_shard_id": "opaque",
+                             "generation_id": "opaque-generation",
+                             "state": "present",
+                         }],
+                     },
+                 ), \
+                 patch(
+                     "scripts.health_check.inspect_mounted_resource_backup",
+                     return_value={
+                         "state": "ready",
+                         "enabled": True,
+                         "target_configured": True,
+                         "handoff_semantics": "sync_delegated",
+                         "delivery_counts": {"sync_delegated": 7},
+                         "provider_side_sync": "unknown",
+                         "remote_verified": False,
+                     },
+                 ), \
+                 patch(
+                     "scripts.health_check.GoogleDriveFileSync.inspect_status",
+                     return_value={
+                         "state": "enabled",
+                         "auth": "connected",
+                         "selected_chat_count": 2,
+                         "queue_counts": {},
+                         "last_scan_at": 10,
+                         "last_verified_upload_at": 9,
+                         "next_retry_at": 0,
+                         "root_state": "ready",
+                         "root_web_view_link": "https://drive.invalid/?token=TOPSECRET",
+                         "uploaded_unique_objects": 3,
+                         "shortcut_placements": 4,
+                         "last_error_code": "",
+                     },
+                 ), \
                  patch("scripts.health_check.check_new_databases", return_value=[]), \
                  patch("scripts.health_check.EXTRACT_LOG", str(key_log)):
                 output = StringIO()
@@ -428,6 +647,36 @@ gui/501/com.example.wechat-summary = {
             self.assertIn("expected io.github.indeliblevivi.we-groupchat-obsidian", text)
             self.assertNotIn("/private/runtime/Python.app", text)
             self.assertIn("Sensitive key extraction log: present", text)
+            self.assertIn("Monitor state: conflict", text)
+            self.assertIn(
+                "Source inventory: degraded; present=2; generation_changed=0; "
+                "missing=1; cache_only=1",
+                text,
+            )
+            self.assertIn(
+                "Mounted resource handoff: runtime=ready; "
+                "handoff=sync_delegated; target=configured; delegated_objects=7; "
+                "provider_side_sync=unknown; remote_verified=False",
+                text,
+            )
+            self.assertIn(
+                "Link preview: state=link_preview_disabled; network_requests=0",
+                text,
+            )
+            self.assertIn(
+                "MCP compatibility: legacy_read_only; send=mcp_send_retired",
+                text,
+            )
+            self.assertIn(
+                "Windows: W0.1 import/dependency boundary only; "
+                "product_support=not_claimed",
+                text,
+            )
+            self.assertIn(
+                "Google Drive API remote verification: "
+                "verified_ledger_objects; verified_objects=3",
+                text,
+            )
             self.assertNotIn(str(db_dir), text)
             self.assertNotIn(str(obsidian_root), text)
             self.assertNotIn("secret-one@chatroom", text)
@@ -438,6 +687,10 @@ gui/501/com.example.wechat-summary = {
             self.assertNotIn("secret-title.md", text)
             self.assertNotIn("/private/raw stderr", text)
             self.assertNotIn("com.private.label", text)
+            self.assertNotIn("private/account/message_0.db", text)
+            self.assertNotIn("api.private.invalid", text)
+            self.assertNotIn("drive.invalid", text)
+            self.assertNotIn("TOPSECRET", text)
 
     def test_health_check_sensitive_mode_reveals_paths_chats_topics_and_logs(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -503,6 +756,47 @@ gui/501/com.example.wechat-summary = {
                      },
                      create=True,
                  ), \
+                 patch(
+                     "scripts.health_check.monitor_state_health",
+                     return_value={
+                         "state": "healthy",
+                         "chat_count": 1,
+                         "counts": {"healthy": 1, "missing": 0, "corrupt": 0},
+                         "runtime_result": "no_messages",
+                         "cursor_chats": 1,
+                         "shard_cursors": 1,
+                         "generation_bound": 1,
+                         "inventory_bound_chats": 1,
+                         "legacy_states": 0,
+                     },
+                 ), \
+                 patch(
+                     "scripts.health_check.source_inventory_health",
+                     return_value={
+                         "state": "complete",
+                         "complete": True,
+                         "counts": {"present": 1},
+                         "error_codes": [],
+                         "shards": [{
+                             "relative_path": "message/message_0.db",
+                             "logical_shard_id": "opaque-shard",
+                             "generation_id": "opaque-generation",
+                             "state": "present",
+                         }],
+                     },
+                 ), \
+                 patch(
+                     "scripts.health_check.inspect_mounted_resource_backup",
+                     return_value={
+                         "state": "disabled",
+                         "enabled": False,
+                         "target_configured": False,
+                         "handoff_semantics": "target_not_configured",
+                         "delivery_counts": {},
+                         "provider_side_sync": "unknown",
+                         "remote_verified": False,
+                     },
+                 ), \
                  patch("scripts.health_check.EXTRACT_LOG", str(key_log)):
                 output = StringIO()
                 with redirect_stdout(output):
@@ -517,6 +811,7 @@ gui/501/com.example.wechat-summary = {
             self.assertIn("/private/raw stderr", text)
             self.assertIn("/Applications/WeGroupchatObsidian.app", text)
             self.assertIn("com.private.label", text)
+            self.assertIn("message/message_0.db", text)
 
     def test_delete_sensitive_key_log_requires_explicit_flag(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_resource_backup.py
+++ b/tests/test_resource_backup.py
@@ -10,6 +10,7 @@ import sqlite3
 import tempfile
 import threading
 import unittest
+import uuid
 from contextlib import redirect_stdout
 from pathlib import Path
 from urllib.parse import unquote
@@ -17,6 +18,9 @@ from unittest.mock import Mock, patch
 
 import scripts.resource_backup as resource_backup_cli
 from core.resource_backup import (
+    BACKUP_SCHEMA,
+    DESTINATION_MARKER_NAME,
+    DESTINATION_MARKER_SCHEMA,
     FILE_SURFACE_STATES,
     LOCAL_INDEX_MANIFEST_SCHEMA,
     MountedResourceBackup,
@@ -26,6 +30,7 @@ from core.resource_backup import (
     _safe_month,
     classify_file_occurrence,
     evaluate_resource_backup_outcome,
+    inspect_mounted_resource_backup,
     load_resource_backup_settings,
     save_resource_backup_settings,
     summarize_file_coverage,
@@ -251,6 +256,119 @@ class ResourceBackupTests(unittest.TestCase):
     @staticmethod
     def _digest(data):
         return hashlib.sha256(data).hexdigest()
+
+    def test_read_only_mounted_health_inspector_reports_verified_handoff(self):
+        archive_id = "archive-health-fixture"
+        destination_id = str(uuid.uuid4())
+        snapshot_id = "20260830T120000Z-health"
+        marker_dir = Path(self.target) / "wgo-resource-backup"
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        (marker_dir / DESTINATION_MARKER_NAME).write_text(json.dumps({
+            "schema": DESTINATION_MARKER_SCHEMA,
+            "archive_id": archive_id,
+            "destination_uuid": destination_id,
+        }), encoding="utf-8")
+
+        conn = sqlite3.connect(self.capture_db)
+        conn.executescript(
+            """
+            CREATE TABLE resource_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE resource_deliveries (
+                destination_id TEXT NOT NULL,
+                object_sha256 TEXT NOT NULL,
+                object_size INTEGER NOT NULL,
+                target_relpath TEXT NOT NULL,
+                status TEXT NOT NULL,
+                last_error_code TEXT NOT NULL DEFAULT '',
+                updated_at REAL NOT NULL,
+                PRIMARY KEY(destination_id, object_sha256)
+            );
+            CREATE TABLE resource_backup_state (
+                destination_id TEXT PRIMARY KEY,
+                catalog_sha256 TEXT NOT NULL DEFAULT '',
+                snapshot_id TEXT NOT NULL DEFAULT '',
+                updated_at REAL NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO resource_meta(key, value) VALUES ('archive_id', ?)",
+            (archive_id,),
+        )
+        conn.execute(
+            "INSERT INTO resource_deliveries VALUES (?, ?, ?, ?, ?, '', ?)",
+            (destination_id, "a" * 64, 3, "objects/sha256/aa/object", "sync_delegated", 1),
+        )
+        conn.execute(
+            "INSERT INTO resource_backup_state VALUES (?, ?, ?, ?)",
+            (destination_id, "catalog", snapshot_id, 1),
+        )
+        conn.commit()
+        conn.close()
+
+        snapshot_dir = (
+            marker_dir / "v3" / "snapshots" / snapshot_id
+        )
+        snapshot_dir.mkdir(parents=True)
+        resources_bytes = b""
+        resources_sha256 = hashlib.sha256(resources_bytes).hexdigest()
+        manifest = {
+            "schema": BACKUP_SCHEMA,
+            "archive_id": archive_id,
+            "snapshot_id": snapshot_id,
+            "handoff_semantics": "sync_delegated",
+            "source_observation": {"complete": True},
+            "resources_sha256": resources_sha256,
+        }
+        manifest_bytes = (
+            json.dumps(
+                manifest,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ) + "\n"
+        ).encode("utf-8")
+        complete = {
+            "schema": BACKUP_SCHEMA,
+            "snapshot_id": snapshot_id,
+            "state": "complete",
+            "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+            "resources_sha256": resources_sha256,
+        }
+        (snapshot_dir / "manifest.json").write_bytes(manifest_bytes)
+        (snapshot_dir / "COMPLETE").write_text(
+            json.dumps(complete), encoding="utf-8"
+        )
+
+        report = inspect_mounted_resource_backup({
+            **self.config,
+            "resource_backup_enabled": True,
+        }, settings_path=os.path.join(self.root, "missing-settings.json"))
+
+        self.assertEqual(report["state"], "ready")
+        self.assertEqual(report["handoff_semantics"], "sync_delegated")
+        self.assertEqual(report["delivery_counts"], {"sync_delegated": 1})
+        self.assertTrue(report["latest_snapshot"])
+        self.assertTrue(report["source_complete"])
+        self.assertEqual(report["provider_side_sync"], "unknown")
+        self.assertFalse(report["remote_verified"])
+        self.assertNotIn(self.target, str(report))
+        self.assertNotIn(destination_id, str(report))
+        self.assertFalse((snapshot_dir / "resources.jsonl").exists())
+
+    def test_read_only_mounted_health_inspector_does_not_create_settings(self):
+        settings_path = os.path.join(self.root, "absent", "settings.json")
+        report = inspect_mounted_resource_backup(
+            {"resource_backup_enabled": False},
+            settings_path=settings_path,
+        )
+
+        self.assertEqual(report["state"], "disabled")
+        self.assertEqual(report["handoff_semantics"], "target_not_configured")
+        self.assertEqual(report["provider_side_sync"], "unknown")
+        self.assertFalse(report["remote_verified"])
+        self.assertFalse(os.path.exists(settings_path))
+        self.assertFalse(os.path.exists(settings_path + ".lock"))
 
     def _write_candidate_files(self):
         first = b"first file bytes"


### PR DESCRIPTION
## Tranche 6 closure

1. Repository/base/head: IndelibleVivi/we-groupchat-obsidian; base 2c4a9162340d2667c4ccaf8da9d9fa5b3566ff36; head 4168c70.
2. Problem fixed: the operator health surface previously collapsed monitor, source, mounted handoff, and Drive evidence and did not state the retired/unsupported boundaries directly.
3. Authority/schema: scripts/health_check.py is now the canonical privacy-safe health matrix. Read-only monitor, source-inventory, and mounted-handoff inspectors were added; no durable schema changed.
4. Migration behavior: valid unversioned monitor state remains readable; corrupt state blocks; inventory inspection never initializes or migrates; legacy preview/full-export/send settings remain fail-closed or inert; Windows W0.1 remains import-only.
5. Files changed: health/runtime helpers, focused tests, README EN/ZH, reliability EN/ZH, mounted-backup spec, Windows map, and durable contributor contract.
6. Focused coverage: healthy/missing/corrupt/conflict monitor state, raw generation-bound cursors, source degradation counts, no-create inspection, mounted control-only inspection without CAS/catalog payload reads, default privacy, explicit sensitive output, and separate Direct Drive verification.
7. Full verification: python -m unittest discover -s tests -t . -p test_*.py -> 914 tests OK, 1 skipped; compileall OK; all .command launchers pass bash -n; git diff --check OK.
8. Privacy scan: no real secrets, private keys, personal home paths, continuity, database/WAL/log/runtime artifacts, or binary payloads. Matches are source identifiers, documented scan terms, or explicit synthetic leakage sentinels.
9. Live acceptance: not performed. No live config/data, app bundle, LaunchAgent, mounted target, OAuth account, or provider state was mutated.
10. Remaining unsupported edges: mounted provider-side sync remains unknown; Direct Drive is optional and separate; link preview remains disabled; MCP sending remains retired; Windows product support is not claimed.