### PR TITLE
Harden WeChat recovery trust boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,46 @@ Update README EN/ZH when entrypoints, supported behavior, privacy boundaries,
 installation, repository layout or ordinary commands change. Update operator
 guides for changed procedures and this file when source ownership, required
 verification or deployment gates change.
+
+## Recovery hardening boundary
+
+- `core/key_extractor.py::recover_keys` returns a structured observed-key
+  result. Only HMAC-verified candidates may be published; C staging JSON is
+  never authority. Every publisher, including legacy rematch, uses the same
+  existing portable lock backend around fresh-read/reverify/merge/replace.
+  This adds a macOS runtime consumer, not Windows key/runtime support.
+- Profile selection binds to the selected NSRunningApplication's launch,
+  executable, bundle build and executing architecture. Diagnostic default-app
+  lookup and Python architecture must never choose the scan mask.
+- `core/wechat_resign.py` owns explicit exact-target re-sign orchestration;
+  `scripts/resign_wechat.py` and `launchers/启动.command` are thin entrypoints.
+  Bind canonical bundle, PID/launch/executable identity across sudo, graceful
+  termination, signing, independent verification and exact-path reopen. Never
+  restore process-name kill, post-mutation default-app discovery or implicit
+  re-sign permission.
+- Scanner execution authority is an immutable private build directory plus a
+  single atomic `scanner-current.json` pointer. The receipt binds source,
+  compiler, target architecture, flags and binary identity. A legacy fixed
+  binary, incomplete directory or metadata-only match is not admissible.
+- `extract_keys()` returns keys only for a freshly verified complete observed
+  set. Partial/unsupported/failed operations preserve the cache on disk and
+  do not claim refresh success. Observed keys do not prove expected inventory
+  completeness or successful monitor decoding.
+- Zstd decoding failures raise `source_message_decode_failed`; they must not
+  become empty filtered rows, advance monitor/resource cursors, or trigger AI.
+- First source enablement stays from-now. Once per-shard cursors exist, a
+  replacement generation or new logical shard must fail before page/provider
+  work with an exact content-free admission plan; never borrow the global
+  timestamp. Durable message identity is logical and generation-stable, while
+  the physical generation remains separate cursor evidence. The v1 plan does
+  not itself authorize replay or cursor translation.
+- Canonical events and `daily_digest_changes` commit in one knowledge-DB
+  transaction. Digest repair consumes canonical SQLite, atomically republishes
+  existing affected pages, and ACKs only the completed prefix. Before provider
+  replay, monitor retry must adopt an already committed `source_batch_id` and
+  advance that exact batch; lookup failure preserves the checkpoint.
+- Catch-up prints the actual `rebuild_projections` notes/actions contract;
+  tests must connect the real producer to apply/output/receipt.
+- Source acceptance and remaining migration/live gates are described in
+  `docs/recovery-acceptance.md`. Native Cocoa/C/macOS canary, installation,
+  activation and deployment consent remain separate from source tests.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ independently deployed microservices. Editable sources:
   bodies/XML, `source_message_id`, `wxid`, and WeChat cache paths are not Drive
   metadata. The project does not delete Drive files, WeChat cache, or local CAS
   objects.
-- Extracting database keys may require ad-hoc re-signing `WeChat.app`. The regular double-click flow does not silently do this; commands that perform it are explicit.
+- Extracting database keys may require ad-hoc re-signing `WeChat.app`. The regular double-click flow does not silently do this; commands that perform it are explicit. Re-signing binds one canonical bundle path and, when running, its exact PID/launch/executable identity through privilege acquisition, graceful termination, signing, independent verification, and exact-path reopen. Ambiguity or identity change stops the operation.
 - macOS may ask once per menu-app process for access to WeChat App Data. The
   project does not schedule short-lived source/resource workers that would make
   that process-lifetime consent recur; attachment-byte resolution is a separate
@@ -297,11 +297,39 @@ If WeChat was updated or key extraction needs a fresh authorization:
 ./启动.command --allow-wechat-resign
 ```
 
+If more than one WeChat installation exists, bind the intended bundle instead
+of relying on LaunchServices discovery:
+
+```bash
+./启动.command --allow-wechat-resign --wechat-app=/Applications/WeChat.app
+```
+
 WGO has verified protected binary cipher-context key recovery for macOS WeChat
 `4.1.11 (269136)` on arm64. Protected-key profiles are bound to an exact WeChat
 build, and every candidate must pass page-one HMAC verification against its
 encrypted database before entering the private key cache. An unknown future
 build fails closed and preserves the previously verified cache.
+
+The scanner executable is admitted only from an immutable build directory
+whose receipt binds the C source digest, compiler binary/version/target,
+explicit target architecture, flags, and produced binary digest. A single
+atomic `scanner-current.json` pointer selects the complete build; an old fixed
+binary or a partially published build is never executed.
+
+First monitor enablement still starts from now. After per-shard cursors exist,
+a replacement generation or newly discovered logical shard is blocked before
+any page read or AI call with `source_generation_admission_required`. The
+returned content-free plan binds the exact inventory and old/new generations;
+ordinary monitoring never borrows a global timestamp to skip older unseen
+rows. An explicit continuity proof or bounded replay/reconciliation remains an
+operator migration step.
+
+Daily Digest Markdown uses durable atomic publication. Canonical event commits
+also enqueue a SQLite invalidation in the same transaction; the menu timer and
+event path rebuild existing affected Digests before acknowledging that journal.
+If an event committed before its monitor cursor, retry adopts the stable
+`source_batch_id`, repairs projections, and advances the batch without calling
+the AI provider again.
 
 ### Documentation map
 
@@ -312,6 +340,8 @@ build fails closed and preserves the previously verified cache.
 - `功能说明.txt`: concise current capability index, not an operational contract.
 - `docs/source-reliability*.md`: detailed source guard, archive, mounted backup,
   Drive, backup, and rollout contract.
+- `docs/recovery-acceptance.md`: recovery hardening, migration boundaries, and
+  source/installed/live acceptance status.
 - `docs/resource-capture-and-mounted-backup-spec.md`: formal resource occurrence,
   selection, projection, handoff, status, and failure semantics.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,7 +158,7 @@ DeepSeek 按实际 token 用量计费，输入缓存命中、输入缓存未命�
 这个项目适合个人本地使用。它涉及微信本地数据库和进程内 key 提取，所以公开使用前请先理解这些边界：
 
 - 程序读取本机微信数据库副本，不修改微信聊天数据库。
-- 首次提取数据库 key，或微信更新后重新提取 key，可能需要对 `WeChat.app` 做 ad-hoc re-sign。脚本不会在普通双击启动时偷偷执行这一步，必须显式运行带 `--allow-wechat-resign` 的命令。
+- 首次提取数据库 key，或微信更新后重新提取 key，可能需要对 `WeChat.app` 做 ad-hoc re-sign。脚本不会在普通双击启动时偷偷执行这一步，必须显式运行带 `--allow-wechat-resign` 的命令。重签会把一次操作绑定到 canonical bundle path，以及运行时的 exact PID、launch 与 executable identity；取得 sudo 后会复核，只正常退出该 target，再对同一 bundle 签名、独立验签并按 exact path reopen。歧义、超时或 identity 变化都会停止。
 - macOS 可能在每次菜单 app 进程启动时询问一次 WeChat App Data 权限。项目不会再调度短命 source/resource
   worker 反复消耗这个 process-lifetime consent；附件 bytes 解析是仅存在于内存、本次 app 会话有效的
   显式授权，重启后必定归零，也不会从 config 恢复；关闭后，in-flight resolver 会在下一次读取附件
@@ -252,12 +252,35 @@ cd we-groupchat-obsidian
 ./启动.command --allow-wechat-resign
 ```
 
+若本机并存多个 WeChat 安装副本，请显式绑定目标：
+
+```bash
+./启动.command --allow-wechat-resign --wechat-app=/Applications/WeChat.app
+```
+
 这一步可能会退出微信，并要求输入 Mac 登录密码。输入密码时终端不显示字符是正常的。
 
 WGO 已验证 macOS 微信 `4.1.11 (269136)` arm64 的 protected binary
 cipher-context key 读取。Protected-key profile 与精确微信 build 绑定，每个
 candidate 都必须通过相应 encrypted DB 的 page-one HMAC 验证才会写入私有
 key cache；未识别的后续 build 会 fail closed 并保留已验证 cache。
+
+实际执行的 scanner 必须来自 immutable build directory；receipt 精确绑定 C source
+digest、compiler binary/version/target、显式 target architecture、flags 与产物 digest，
+再由单个 atomic `scanner-current.json` pointer 选择完整 build。历史 fixed binary 或只发布
+了一半的 build 都不会被执行。
+
+Monitor 第一次 enable 仍采用 from-now。已有 per-shard cursor 后，如果 physical generation
+被替换，或 inventory 新增 logical shard，系统会在任何 page read / AI call 之前返回
+`source_generation_admission_required`；content-free plan 绑定 exact inventory、旧/新
+generation 与 bounded reconciliation 上限。普通 monitor 不会再借用全局 timestamp 跳过
+较旧但未消费的 row；continuity proof 或 bounded replay/reconciliation 仍是显式 operator
+migration。
+
+Daily Digest Markdown 通过 durable atomic replace 发布；canonical event 与 Digest
+invalidation 在同一 SQLite transaction 提交，event path 与 menu timer 重建现有 affected
+Digest 后才 ACK journal。如果 event 已 commit、monitor cursor 尚未 commit，retry 会按稳定
+`source_batch_id` 直接复用 canonical event、修 projection 并推进原 batch，不再次调用 AI。
 
 ### 文档地图
 
@@ -266,6 +289,8 @@ key cache；未识别的后续 build 会 fail closed 并保留已验证 cache。
 - `功能说明.txt`：当前能力的简明索引，不替代操作 contract。
 - `docs/source-reliability*.md`：source guard、archive、mounted backup、Drive、
   filesystem snapshot 和 safe rollout 的详细 contract。
+- `docs/recovery-acceptance.md`：恢复 hardening、migration boundary，以及
+  source / installed / live 验收状态。
 - `docs/resource-capture-and-mounted-backup-spec.md`：resource occurrence、selection、
   projection、handoff、status 与 failure semantics 的 formal spec。
 

--- a/app.py
+++ b/app.py
@@ -77,8 +77,7 @@ from core.daily_digest import (
     DAILY_DIGEST_STATE_FILE,
     mark_daily_digest_success,
     notification_summary,
-    refresh_existing_daily_digests,
-    source_window_dates,
+    refresh_pending_daily_digests,
     should_run_daily_digest,
     write_daily_digest,
 )
@@ -93,7 +92,6 @@ from core.key_extractor import (
     is_wechat_signed,
     extract_keys,
     get_cached_keys,
-    compile_scanner,
     check_new_databases,
 )
 from core.wechat_db import WeChatDB
@@ -1920,34 +1918,20 @@ class WeGroupchatObsidianApp(rumps.App):
             )
             print(f"[monitor] projection warning; canonical event saved: {summary}")
 
-        event_written = bool(result.get("knowledge_event_written")) or result.get("knowledge_event_id") is not None
-        if event_written:
-            affected_dates = list(result.get("affected_dates") or [])
-            if not affected_dates:
-                source_window = result.get("source_window") or {}
-                affected_dates = source_window_dates(
-                    self.config,
-                    source_window.get("start", ""),
-                    source_window.get("end", ""),
-                    fallback_ts=result.get("last_msg_ts"),
+        event_written = bool(result.get("knowledge_event_written"))
+        event_reused = bool(result.get("knowledge_event_reused"))
+        if not dry_run and (event_written or event_reused):
+            digest_refresh = refresh_pending_daily_digests(self.config)
+            for date_label in digest_refresh.get("written_dates") or []:
+                print(
+                    "[daily-digest] refreshed after canonical event: "
+                    f"{date_label}"
                 )
-            if affected_dates:
-                try:
-                    refreshed_digests = refresh_existing_daily_digests(
-                        self.config,
-                        affected_dates,
-                    )
-                    for refreshed_digest in refreshed_digests:
-                        print(
-                            "[daily-digest] refreshed after canonical event: "
-                            f"{refreshed_digest['date']} "
-                            f"notes={refreshed_digest['new_notes_count']}"
-                        )
-                except Exception as exc:
-                    print(
-                        "[daily-digest] canonical-event refresh failed: "
-                        f"{type(exc).__name__}"
-                    )
+            if digest_refresh.get("state") == "deferred":
+                print(
+                    "[daily-digest] canonical-event refresh deferred: "
+                    f"{digest_refresh.get('error_code', 'unknown')}"
+                )
             if not dry_run and self.config.get("attachment_archive_enabled", False):
                 self._start_attachment_archive_consumer()
 
@@ -2072,33 +2056,39 @@ class WeGroupchatObsidianApp(rumps.App):
     def _on_daily_digest_timer(self, _):
         if not self.config.get("daily_digest_enabled", True):
             return
-        if not should_run_daily_digest(DAILY_DIGEST_STATE_FILE, self.config):
-            return
         threading.Thread(target=self._run_daily_digest, daemon=True).start()
 
     def _run_daily_digest(self):
         if not self._daily_digest_lock.acquire(blocking=False):
             return
         try:
-            digest = write_daily_digest(self.config)
-            mark_daily_digest_success(DAILY_DIGEST_STATE_FILE, self.config)
-            print(
-                f"[daily-digest] 写入: {digest['path']} "
-                f"notes={digest['new_notes_count']} "
-                f"actions={digest.get('today_action_count', 0)} "
-                f"risk={digest.get('today_risk_count', 0)}"
-            )
-            if (
-                self.config.get("background_notifications_enabled", True)
-                and self.config.get("daily_digest_notify", True)
-            ):
-                subtitle, message = notification_summary(digest)
-                _notify(
-                    "关注推送 Daily Digest",
-                    subtitle,
-                    message,
-                    data=notification_data_for_path(digest.get("path")),
+            due = should_run_daily_digest(DAILY_DIGEST_STATE_FILE, self.config)
+            digest = write_daily_digest(self.config) if due else None
+            repair = refresh_pending_daily_digests(self.config)
+            if repair.get("state") == "deferred":
+                raise RuntimeError(
+                    "daily_digest_repair_deferred:"
+                    + str(repair.get("error_code") or "unknown")
                 )
+            if digest is not None:
+                mark_daily_digest_success(DAILY_DIGEST_STATE_FILE, self.config)
+                print(
+                    f"[daily-digest] 写入: {digest['path']} "
+                    f"notes={digest['new_notes_count']} "
+                    f"actions={digest.get('today_action_count', 0)} "
+                    f"risk={digest.get('today_risk_count', 0)}"
+                )
+                if (
+                    self.config.get("background_notifications_enabled", True)
+                    and self.config.get("daily_digest_notify", True)
+                ):
+                    subtitle, message = notification_summary(digest)
+                    _notify(
+                        "关注推送 Daily Digest",
+                        subtitle,
+                        message,
+                        data=notification_data_for_path(digest.get("path")),
+                    )
         except Exception as e:
             traceback.print_exc()
             if self.config.get("background_notifications_enabled", True):
@@ -2753,10 +2743,6 @@ class WeGroupchatObsidianApp(rumps.App):
                 return
             if not signed:
                 _notify("微信总结", "微信需要重新授权", _wechat_signing_message())
-                self._set_status(ICON_ERROR)
-                return
-            if not compile_scanner():
-                _notify("微信总结", "编译失败", "需安装 Xcode CLI Tools")
                 self._set_status(ICON_ERROR)
                 return
             _notify("微信总结", "首次运行", "正在同步数据源...")

--- a/core/daily_digest.py
+++ b/core/daily_digest.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import tempfile
 import time
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .config import DATA_DIR, ensure_private_dir, ensure_private_file
-from .knowledge import _obsidian_link, ensure_obsidian_vault, safe_obsidian_subdir
+from .knowledge import (
+    KnowledgeStore,
+    _obsidian_link,
+    ensure_obsidian_vault,
+    safe_obsidian_subdir,
+)
 from .review_queue import QUEUE_ACTIONABILITIES, ReviewQueue, priority_for_item
 from .source_contract import projection_source_lines
 from .url_safety import redact_url_for_display, redact_urls_in_text
@@ -525,6 +531,38 @@ def build_daily_digest(
     return digest
 
 
+def _atomic_write_digest(path: str, text: str) -> None:
+    """Durably publish one app-owned Digest without truncating the last good file."""
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    fd, temporary = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.",
+        suffix=".tmp",
+        dir=directory,
+    )
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        temporary = ""
+        directory_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if temporary:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
+
+
 def write_daily_digest(
     config: dict,
     now_func=time.time,
@@ -549,9 +587,7 @@ def write_daily_digest(
         os.makedirs(os.path.dirname(path), exist_ok=True)
     else:
         ensure_private_dir(os.path.dirname(path))
-    with open(path, "w", encoding="utf-8") as handle:
-        handle.write(digest["markdown"])
-    ensure_private_file(path)
+    _atomic_write_digest(path, digest["markdown"])
     digest["path"] = path
     digest["obsidian_path"] = obsidian_path
     return digest
@@ -594,6 +630,93 @@ def refresh_existing_daily_digests(
             target_date=date_label,
         ))
     return refreshed
+
+
+def refresh_pending_daily_digests(config: dict, now_func=time.time) -> dict:
+    """Repair existing Digest projections from a durable event journal.
+
+    Canonical events and invalidations commit in one SQLite transaction. A
+    crash may leave Markdown stale, but it cannot erase the repair trigger.
+    Only a successfully rewritten prefix is acknowledged.
+    """
+    store = KnowledgeStore.from_config(config)
+    if not os.path.isfile(store.db_path):
+        return {
+            "state": "idle",
+            "affected_dates": [],
+            "written_dates": [],
+            "acknowledged_changes": 0,
+        }
+    batch = store.pending_daily_digest_changes()
+    changes = list(batch.get("changes") or [])
+    if not changes:
+        return {
+            "state": "idle",
+            "affected_dates": [],
+            "written_dates": [],
+            "acknowledged_changes": 0,
+        }
+    dates = []
+    for change in changes:
+        fallback = change.get("fallback_timestamp")
+        try:
+            if float(fallback or 0) <= 0:
+                fallback = change.get("created_at")
+        except (TypeError, ValueError):
+            fallback = change.get("created_at")
+        dates.extend(source_window_dates(
+            config,
+            str(change.get("window_start") or ""),
+            str(change.get("window_end") or ""),
+            fallback_ts=fallback,
+        ))
+    affected_dates = sorted(set(dates))
+    expected_existing = []
+    for date_label in affected_dates:
+        path, _ = digest_output_path(config, date_label, now_func=now_func)
+        if os.path.isfile(path):
+            expected_existing.append(date_label)
+    try:
+        refreshed = refresh_existing_daily_digests(
+            config,
+            affected_dates,
+            now_func=now_func,
+        )
+    except Exception as exc:
+        return {
+            "state": "deferred",
+            "affected_dates": affected_dates,
+            "written_dates": [],
+            "acknowledged_changes": 0,
+            "error_code": type(exc).__name__,
+        }
+    written_dates = [item["date"] for item in refreshed]
+    if written_dates != expected_existing:
+        return {
+            "state": "deferred",
+            "affected_dates": affected_dates,
+            "written_dates": written_dates,
+            "acknowledged_changes": 0,
+            "error_code": "daily_digest_projection_changed",
+        }
+    try:
+        acknowledged = store.ack_daily_digest_changes(
+            int(batch.get("cutoff_change_id") or 0)
+        )
+    except Exception as exc:
+        return {
+            "state": "deferred",
+            "affected_dates": affected_dates,
+            "written_dates": written_dates,
+            "acknowledged_changes": 0,
+            "error_code": type(exc).__name__,
+        }
+    return {
+        "state": "refreshed",
+        "affected_dates": affected_dates,
+        "written_dates": written_dates,
+        "acknowledged_changes": acknowledged,
+    }
 
 
 def notification_summary(digest: dict) -> tuple[str, str]:

--- a/core/key_extractor.py
+++ b/core/key_extractor.py
@@ -1,13 +1,17 @@
 """Recover and cumulatively store local WeChat database keys."""
 import json
+import hashlib
 import os
 import platform
 import plistlib
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
+import stat
+from dataclasses import dataclass, field
 
 from .config import (
     APP_DIR,
@@ -19,7 +23,6 @@ from .config import (
 
 
 C_SOURCE = os.path.join(APP_DIR, "c_src", "find_keys_macos.c")
-C_BINARY = os.path.join(DATA_DIR, "find_keys_macos")
 KEYS_FILE = os.path.join(DATA_DIR, "all_keys.json")
 EXTRACT_LOG = os.path.join(DATA_DIR, "extract_keys.log")
 DEFAULT_WECHAT_APP = "/Applications/WeChat.app"
@@ -114,7 +117,7 @@ def get_wechat_app_path():
 
 
 def get_wechat_build_identity(app_path=None):
-    """Return the exact app build and local architecture for scan profiles."""
+    """Installed-bundle diagnostic; interpreter CPU is never scan authority."""
     app_path = app_path or get_wechat_app_path()
     if not app_path:
         return None
@@ -130,9 +133,212 @@ def get_wechat_build_identity(app_path=None):
     return version, build, platform.machine()
 
 
-def _protected_key_memory_mask():
-    identity = get_wechat_build_identity()
+def _protected_key_memory_mask(identity=None):
+    """Select only an explicitly supplied target identity, never the default app."""
     return PROTECTED_KEY_MEMORY_MASKS.get(identity) if identity else None
+
+
+@dataclass(frozen=True)
+class ScanTarget:
+    pid: int
+    app_path: str
+    executable_path: str
+    launched_at: float
+    build_identity: tuple
+    executable_identity: tuple
+
+
+@dataclass(frozen=True)
+class KeyRecoveryResult:
+    status: str
+    keys: dict = field(default_factory=dict, repr=False)
+    verified_count: int = 0
+    missing_databases: tuple = field(default=(), repr=False)
+    reason: str = ""
+
+    @property
+    def ok(self):
+        return bool(self.status == "fresh_verified" and self.verified_count > 0
+                    and self.keys and not self.missing_databases)
+
+
+def get_wechat_scan_target(pid):
+    """Bind profile to the selected running app, including its executing CPU.
+
+    AppKit is already a macOS runtime dependency. No AppKit import occurs on
+    portable import-only paths. Missing LaunchServices identity fails closed.
+    """
+    try:
+        from AppKit import NSRunningApplication
+        running = NSRunningApplication.runningApplicationWithProcessIdentifier_(pid)
+        if running is None or running.isTerminated():
+            return None
+        bundle_url = running.bundleURL()
+        executable_url = running.executableURL()
+        launch_date = running.launchDate()
+        if bundle_url is None or executable_url is None or launch_date is None:
+            return None
+        app_path = os.path.realpath(str(bundle_url.path()))
+        executable = os.path.realpath(str(executable_url.path()))
+        with open(os.path.join(app_path, "Contents", "Info.plist"), "rb") as handle:
+            info = plistlib.load(handle)
+        # The protected profile is for the main application, not a helper.
+        if (str(running.bundleIdentifier()) != "com.tencent.xinWeChat"
+                or info.get("CFBundleIdentifier") != "com.tencent.xinWeChat"):
+            return None
+        expected = os.path.realpath(os.path.join(
+            app_path, "Contents", "MacOS", str(info.get("CFBundleExecutable") or "")
+        ))
+        if executable != expected or os.path.basename(executable) != "WeChat":
+            return None
+        architecture = {0x0100000C: "arm64", 0x01000007: "x86_64"}.get(
+            int(running.executableArchitecture())
+        )
+        version = str(info.get("CFBundleShortVersionString") or "").strip()
+        build = str(info.get("CFBundleVersion") or "").strip()
+        if not architecture or not version or not build:
+            return None
+        st = os.stat(executable)
+        if not stat.S_ISREG(st.st_mode):
+            return None
+        return ScanTarget(
+            pid, app_path, executable, float(launch_date.timeIntervalSince1970()),
+            (version, build, architecture),
+            (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns),
+        )
+    except Exception:
+        # Do not surface Cocoa exception text or paths in operator output.
+        return None
+
+
+def get_wechat_scan_targets():
+    """Return every verified running main-app target for the WeChat bundle id."""
+    try:
+        from AppKit import NSRunningApplication
+        applications = NSRunningApplication.runningApplicationsWithBundleIdentifier_(
+            "com.tencent.xinWeChat"
+        )
+    except Exception:
+        return ()
+    targets = []
+    for application in applications or ():
+        try:
+            pid = int(application.processIdentifier())
+        except Exception:
+            continue
+        target = get_wechat_scan_target(pid)
+        if target is not None:
+            targets.append(target)
+    return tuple(sorted(targets, key=lambda item: (item.app_path, item.pid)))
+
+
+def select_wechat_scan_target(app_path=None):
+    """Select one exact running main app, rejecting ambiguous installations."""
+    targets = get_wechat_scan_targets()
+    if app_path:
+        expected = os.path.realpath(os.path.expanduser(str(app_path)))
+        targets = tuple(item for item in targets if item.app_path == expected)
+    return targets[0] if len(targets) == 1 else None
+
+
+class KeyCacheError(RuntimeError):
+    pass
+
+
+def _private_regular_path(path):
+    """Reject non-regular cache/lock entries without changing their targets."""
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return
+    if not stat.S_ISREG(st.st_mode) or st.st_uid != os.getuid():
+        raise KeyCacheError("key_cache_path_unsafe")
+
+
+def _valid_key_entry(item):
+    return (isinstance(item, dict) and isinstance(item.get("enc_key"), str)
+            and re.fullmatch(r"[0-9a-fA-F]{64}", item["enc_key"]) is not None)
+
+
+def _unique_json_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise KeyCacheError("key_cache_duplicate_property")
+        result[key] = value
+    return result
+
+
+def _required_pages(db_dir):
+    """Read only current required page-one bytes; retain uncertainty explicitly.
+
+    This proves the observed key set only. SourceInventoryStore remains the
+    separate authority for missing historical shards and source completeness.
+    """
+    pages, issues = {}, []
+    if not db_dir or not os.path.isdir(db_dir):
+        return pages, ["source_unavailable"]
+    def onerror(_exc):
+        issues.append("source_unreadable")
+    for root, dirs, files in os.walk(db_dir, followlinks=False, onerror=onerror):
+        for name in list(dirs):
+            if os.path.islink(os.path.join(root, name)):
+                dirs.remove(name)
+                issues.append("source_symlink")
+        for name in sorted(files):
+            path = os.path.join(root, name)
+            rel = os.path.relpath(path, db_dir).replace("\\", "/")
+            if not is_required_database(rel):
+                continue
+            try:
+                fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+                with os.fdopen(fd, "rb") as handle:
+                    before = os.fstat(handle.fileno())
+                    if not stat.S_ISREG(before.st_mode):
+                        issues.append(rel)
+                        continue
+                    page = handle.read(SQLCIPHER_PAGE_SIZE)
+                    after = os.fstat(handle.fileno())
+                if (before.st_ino, before.st_size, before.st_mtime_ns) != (
+                        after.st_ino, after.st_size, after.st_mtime_ns):
+                    issues.append(rel)
+                elif page.startswith(b"SQLite format 3\x00"):
+                    continue
+                elif len(page) != SQLCIPHER_PAGE_SIZE:
+                    issues.append(rel)
+                else:
+                    pages[rel] = page
+            except OSError:
+                issues.append(rel)
+    return pages, sorted(set(issues))
+
+
+def _verified_mapping(pages, keys):
+    from .decryptor import verify_page1
+    return {
+        rel: {"enc_key": keys[rel]["enc_key"].lower()}
+        for rel, page in pages.items()
+        if rel in keys and _valid_key_entry(keys[rel])
+        and verify_page1(bytes.fromhex(keys[rel]["enc_key"]), page)
+    }
+
+
+def _publish_verified_keys(db_dir, candidates):
+    """Reverify, fresh-read, merge and durably replace under one shared lock."""
+    from .platform import create_file_lock, LockMode
+    directory = os.path.dirname(KEYS_FILE) or "."
+    ensure_private_dir(directory)
+    lock_path = KEYS_FILE + ".lock"
+    _private_regular_path(lock_path)
+    with create_file_lock().acquire(lock_path, mode=LockMode.EXCLUSIVE, blocking=True):
+        _private_regular_path(KEYS_FILE)
+        current = _read_keys_file(KEYS_FILE)
+        pages, _issues = _required_pages(db_dir)
+        verified = _verified_mapping(pages, candidates)
+        if verified:
+            current.update(verified)
+            _atomic_write_keys(KEYS_FILE, current)
+        return current, verified
 
 
 def is_required_database(rel_path):
@@ -161,38 +367,324 @@ def is_wechat_signed():
         return False
 
 
-def compile_scanner():
-    """Compile C key scanner."""
-    os.makedirs(DATA_DIR, exist_ok=True)
+_SCANNER_RECEIPT_SCHEMA = "we-groupchat-obsidian.scanner-build.v1"
+_SCANNER_POINTER_SCHEMA = "we-groupchat-obsidian.scanner-current.v1"
 
-    if os.path.exists(C_BINARY):
-        # Check if recompilation needed
-        if os.path.getmtime(C_BINARY) >= os.path.getmtime(C_SOURCE):
-            return True
 
+def _regular_file_bytes(path):
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
     try:
-        result = subprocess.run(
-            ["cc", "-O2", "-o", C_BINARY, C_SOURCE, "-framework", "Foundation"],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            print(f"编译失败: {result.stderr}", file=sys.stderr)
-            return False
-        return True
-    except Exception as e:
-        print(f"编译失败: {e}", file=sys.stderr)
-        return False
+        value = os.fstat(fd)
+        if not stat.S_ISREG(value.st_mode):
+            raise OSError("not_regular")
+        chunks = []
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+
+
+def _compiler_identity():
+    compiler = shutil.which("cc")
+    if not compiler:
+        raise OSError("compiler_unavailable")
+    compiler = os.path.realpath(compiler)
+    version = subprocess.run(
+        [compiler, "--version"], capture_output=True, text=True, timeout=10,
+    )
+    target = subprocess.run(
+        [compiler, "-dumpmachine"], capture_output=True, text=True, timeout=10,
+    )
+    if version.returncode or target.returncode:
+        raise OSError("compiler_identity_unavailable")
+    version_text = (version.stdout or version.stderr or "").strip()
+    target_text = (target.stdout or "").strip()
+    if not version_text or not target_text:
+        raise OSError("compiler_identity_unavailable")
+    return {
+        "path": compiler,
+        "sha256": hashlib.sha256(_regular_file_bytes(compiler)).hexdigest(),
+        "version": version_text,
+        "target": target_text,
+    }
+
+
+def _scanner_build_spec(target_architecture):
+    source = _regular_file_bytes(C_SOURCE)
+    compiler = _compiler_identity()
+    architecture = str(target_architecture or "").strip()
+    if architecture not in {"arm64", "x86_64"}:
+        raise OSError("scanner_target_unsupported")
+    flags = ["-O2", "-arch", architecture, "-framework", "Foundation"]
+    return {
+        "schema": _SCANNER_RECEIPT_SCHEMA,
+        "source_sha256": hashlib.sha256(source).hexdigest(),
+        "source_size": len(source),
+        "compiler": compiler,
+        "target_platform": sys.platform,
+        "target_architecture": architecture,
+        "flags": flags,
+    }
+
+
+def _scanner_builds_dir():
+    return os.path.join(DATA_DIR, "scanner-builds")
+
+
+def _scanner_pointer_path():
+    return os.path.join(DATA_DIR, "scanner-current.json")
+
+
+def _read_json_regular(path):
+    try:
+        data = _regular_file_bytes(path)
+        value = json.loads(data.decode("utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _private_directory(path):
+    try:
+        value = os.lstat(path)
+    except FileNotFoundError:
+        os.mkdir(path, 0o700)
+        return
+    if (
+        not stat.S_ISDIR(value.st_mode)
+        or value.st_uid != os.getuid()
+        or stat.S_ISLNK(value.st_mode)
+    ):
+        raise OSError("scanner_build_directory_unsafe")
+
+
+@dataclass(frozen=True)
+class ScannerBuild:
+    binary_path: str
+    receipt_path: str
+    input_identity: str
+    binary_sha256: str
+
+
+def _scanner_input_identity(spec):
+    encoded = json.dumps(
+        spec, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _validated_scanner_build(spec):
+    pointer = _read_json_regular(_scanner_pointer_path())
+    if not pointer or pointer.get("schema") != _SCANNER_POINTER_SCHEMA:
+        return None
+    input_identity = _scanner_input_identity(spec)
+    if pointer.get("input_identity") != input_identity:
+        return None
+    directory_name = str(pointer.get("build_directory") or "")
+    if not re.fullmatch(r"[0-9a-f]{16}-[0-9a-f]{16}-[0-9a-f]{12}", directory_name):
+        return None
+    builds_dir = os.path.realpath(_scanner_builds_dir())
+    build_dir = os.path.realpath(os.path.join(builds_dir, directory_name))
+    if os.path.commonpath((builds_dir, build_dir)) != builds_dir:
+        return None
+    try:
+        build_stat = os.lstat(build_dir)
+    except OSError:
+        return None
+    if (
+        not stat.S_ISDIR(build_stat.st_mode)
+        or stat.S_ISLNK(build_stat.st_mode)
+        or build_stat.st_uid != os.getuid()
+    ):
+        return None
+    receipt_path = os.path.join(build_dir, "receipt.json")
+    binary_path = os.path.join(build_dir, "find_keys_macos")
+    receipt = _read_json_regular(receipt_path)
+    if not receipt:
+        return None
+    for key, value in spec.items():
+        if receipt.get(key) != value:
+            return None
+    if receipt.get("input_identity") != input_identity:
+        return None
+    expected_binary = str(receipt.get("binary_sha256") or "")
+    if expected_binary != str(pointer.get("binary_sha256") or ""):
+        return None
+    try:
+        binary = _regular_file_bytes(binary_path)
+        binary_stat = os.stat(binary_path, follow_symlinks=False)
+    except OSError:
+        return None
+    if not (
+        re.fullmatch(r"[0-9a-f]{64}", expected_binary)
+        and hashlib.sha256(binary).hexdigest() == expected_binary
+        and int(receipt.get("binary_size") or -1) == len(binary)
+        and binary_stat.st_uid == os.getuid()
+        and stat.S_ISREG(binary_stat.st_mode)
+        and binary_stat.st_mode & stat.S_IXUSR
+    ):
+        return None
+    return ScannerBuild(binary_path, receipt_path, input_identity, expected_binary)
+
+
+def _atomic_write_private_json(path, value):
+    directory = os.path.dirname(path) or "."
+    fd, temporary = tempfile.mkstemp(prefix=".scanner-pointer.", dir=directory)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            json.dump(value, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        temporary = ""
+        directory_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if temporary:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
+
+
+def compile_scanner(target_architecture=None):
+    """Return an immutable scanner build admitted by one atomic current pointer."""
+    ensure_private_dir(DATA_DIR)
+    lock_path = os.path.join(DATA_DIR, "scanner-build.lock")
+    try:
+        from .platform import LockMode, create_file_lock
+        _private_regular_path(lock_path)
+        with create_file_lock().acquire(
+            lock_path, mode=LockMode.EXCLUSIVE, blocking=True
+        ):
+            builds_dir = _scanner_builds_dir()
+            _private_directory(builds_dir)
+            _private_regular_path(_scanner_pointer_path())
+            architecture = target_architecture or platform.machine()
+            spec = _scanner_build_spec(architecture)
+            current = _validated_scanner_build(spec)
+            if current is not None:
+                return current
+            input_identity = _scanner_input_identity(spec)
+            source = _regular_file_bytes(C_SOURCE)
+            stage = tempfile.mkdtemp(prefix=".scanner-build.", dir=builds_dir)
+            try:
+                source_path = os.path.join(stage, "find_keys_macos.c")
+                source_fd = os.open(
+                    source_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+                )
+                with os.fdopen(source_fd, "wb") as handle:
+                    handle.write(source)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                binary_path = os.path.join(stage, "find_keys_macos")
+                result = subprocess.run(
+                    [
+                        spec["compiler"]["path"],
+                        *spec["flags"],
+                        "-o",
+                        binary_path,
+                        source_path,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                if result.returncode != 0:
+                    return None
+                os.chmod(binary_path, 0o700)
+                binary = _regular_file_bytes(binary_path)
+                with open(binary_path, "rb") as handle:
+                    os.fsync(handle.fileno())
+                receipt = {
+                    **spec,
+                    "input_identity": input_identity,
+                    "binary_sha256": hashlib.sha256(binary).hexdigest(),
+                    "binary_size": len(binary),
+                }
+                receipt_path = os.path.join(stage, "receipt.json")
+                receipt_fd = os.open(
+                    receipt_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+                )
+                with os.fdopen(receipt_fd, "w", encoding="utf-8") as handle:
+                    json.dump(receipt, handle, sort_keys=True, separators=(",", ":"))
+                    handle.write("\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                stage_fd = os.open(stage, os.O_RDONLY)
+                try:
+                    os.fsync(stage_fd)
+                finally:
+                    os.close(stage_fd)
+                nonce = os.path.basename(stage).rsplit(".", 1)[-1]
+                directory_name = (
+                    f"{input_identity[:16]}-{receipt['binary_sha256'][:16]}-"
+                    f"{hashlib.sha256(nonce.encode()).hexdigest()[:12]}"
+                )
+                final_dir = os.path.join(builds_dir, directory_name)
+                os.rename(stage, final_dir)
+                stage = ""
+                builds_fd = os.open(builds_dir, os.O_RDONLY)
+                try:
+                    os.fsync(builds_fd)
+                finally:
+                    os.close(builds_fd)
+                _atomic_write_private_json(_scanner_pointer_path(), {
+                    "schema": _SCANNER_POINTER_SCHEMA,
+                    "build_directory": directory_name,
+                    "input_identity": input_identity,
+                    "binary_sha256": receipt["binary_sha256"],
+                })
+                return _validated_scanner_build(spec)
+            finally:
+                if stage:
+                    shutil.rmtree(stage, ignore_errors=True)
+    except Exception:
+        return None
 
 
 def _read_keys_file(path):
+    """Missing is empty; corrupt or unsafe is an error, never permission to reset."""
+    _private_regular_path(path)
     try:
-        with open(path, encoding="utf-8") as handle:
-            value = json.load(handle)
-    except (json.JSONDecodeError, OSError):
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    except FileNotFoundError:
         return {}
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            st = os.fstat(handle.fileno())
+            if not stat.S_ISREG(st.st_mode) or st.st_uid != os.getuid():
+                raise KeyCacheError("key_cache_path_unsafe")
+            if st.st_size > 4 * 1024 * 1024:
+                raise KeyCacheError("key_cache_too_large")
+            value = json.load(handle, object_pairs_hook=_unique_json_object)
+    except (ValueError, UnicodeError) as exc:
+        raise KeyCacheError("key_cache_corrupt") from exc
+    finally:
+        if fd >= 0:
+            os.close(fd)
     if not isinstance(value, dict):
-        return {}
-    return {key: item for key, item in value.items() if not key.startswith("_")}
+        raise KeyCacheError("key_cache_corrupt")
+    keys = {key: item for key, item in value.items() if not key.startswith("_")}
+    for name, item in keys.items():
+        normalized = name.replace("\\", "/")
+        if (not _valid_key_entry(item) or "\0" in name
+                or any(part in {"", ".", ".."} for part in normalized.split("/"))
+                or not normalized.endswith(".db")):
+            raise KeyCacheError("key_cache_corrupt")
+    return keys
 
 
 def _atomic_write_keys(path, keys):
@@ -209,6 +701,11 @@ def _atomic_write_keys(path, keys):
             os.fsync(handle.fileno())
         os.replace(temporary, path)
         ensure_private_file(path)
+        directory_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
     finally:
         if fd >= 0:
             os.close(fd)
@@ -218,94 +715,118 @@ def _atomic_write_keys(path, keys):
             pass
 
 
-def extract_keys():
-    """Run the read-only C scanner, escalating only if task access is denied.
-
-    Returns:
-        dict: {db_rel_path: {"enc_key": hex_string}, ...} or None.
-    """
-    if not compile_scanner():
-        return None
-
-    pid = get_wechat_pid()
-    if not pid:
-        return None
-    home_dir = os.path.expanduser("~")
-    db_dir = load_config().get("db_dir", "")
-    scanner_output = ""
-    cached_keys = _read_keys_file(KEYS_FILE)
-    scanner_args = [C_BINARY, str(pid), home_dir, db_dir]
-    protected_key_mask = _protected_key_memory_mask()
-    if protected_key_mask:
-        scanner_args.append(protected_key_mask.hex())
-
-    # The scanner owns only a private staging directory. A failed or empty scan
-    # must never truncate the cumulative canonical cache.
-    ensure_private_dir(DATA_DIR)
-    with tempfile.TemporaryDirectory(prefix=".key-scan-", dir=DATA_DIR) as scan_dir:
-        os.chmod(scan_dir, 0o700)
-        try:
-            result = subprocess.run(
-                scanner_args,
-                capture_output=True, text=True,
-                cwd=scan_dir,
-                timeout=60,
-            )
-            scanner_output += "\n".join((result.stdout or "", result.stderr or ""))
-
-            if result.returncode != 0:
-                result = subprocess.run(
-                    ["sudo", "-n", *scanner_args],
-                    capture_output=True,
-                    text=True,
-                    cwd=scan_dir,
-                    timeout=60,
+def recover_keys():
+    """Recover freshly verified keys; preserved cache is never fresh success."""
+    try:
+        cached_keys = _read_keys_file(KEYS_FILE)
+    except (OSError, KeyCacheError):
+        return KeyRecoveryResult("failed", reason="key_cache_unreadable")
+    expected_app = str(
+        os.environ.get("WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH") or ""
+    ).strip()
+    target = select_wechat_scan_target(expected_app or None)
+    if target is None:
+        return KeyRecoveryResult("failed", reason="target_identity_unavailable")
+    pid = target.pid
+    try:
+        db_dir = os.path.expanduser(str(load_config().get("db_dir") or ""))
+        if not db_dir or not os.path.isdir(db_dir):
+            return KeyRecoveryResult("failed", reason="source_unavailable")
+        db_dir = os.path.realpath(db_dir)
+        root_stat = os.stat(db_dir)
+        root_identity = (root_stat.st_dev, root_stat.st_ino)
+        scanner_build = compile_scanner(target.build_identity[2])
+        if not scanner_build:
+            return KeyRecoveryResult("failed", reason="scanner_compile_failed")
+    except Exception:
+        return KeyRecoveryResult("failed", reason="recovery_setup_failed")
+    scanner_path = getattr(scanner_build, "binary_path", "")
+    if not isinstance(scanner_path, str) or not scanner_path:
+        return KeyRecoveryResult("failed", reason="scanner_identity_unavailable")
+    scanner_args = [
+        scanner_path,
+        str(pid),
+        os.path.expanduser("~"),
+        db_dir,
+    ]
+    mask = _protected_key_memory_mask(target.build_identity)
+    if mask:
+        scanner_args.append(mask.hex())
+    try:
+        ensure_private_dir(DATA_DIR)
+        with tempfile.TemporaryDirectory(prefix=".key-scan-", dir=DATA_DIR) as scan_dir:
+            os.chmod(scan_dir, 0o700)
+            def scan(args):
+                if select_wechat_scan_target(expected_app or None) != target:
+                    raise KeyCacheError("target_changed")
+                return subprocess.run(
+                    args, capture_output=True, text=True, cwd=scan_dir, timeout=60,
                 )
-                scanner_output += "\n".join((result.stdout or "", result.stderr or ""))
-                if result.returncode != 0:
-                    # Last resort: one explicit macOS administrator dialog.
-                    shell_command = (
-                        f"cd {shlex.quote(scan_dir)} && "
-                        + " ".join(shlex.quote(value) for value in scanner_args)
+            result = scan(scanner_args)
+            # The current C scanner reports task access denial explicitly.
+            # Generic scanner failures must not trigger administrator prompts.
+            if result.returncode and "task_for_pid failed:" in (result.stderr or ""):
+                result = scan(["sudo", "-n", *scanner_args])
+                if result.returncode and any(
+                    marker in (result.stderr or "") for marker in (
+                        "task_for_pid failed:", "a password is required",
+                        "a terminal is required",
                     )
-                    result = subprocess.run(
-                        [
-                            "osascript",
-                            "-e",
-                            f"do shell script {json.dumps(shell_command)} "
-                            "with administrator privileges",
-                        ],
-                        capture_output=True,
-                        text=True,
-                        timeout=60,
-                    )
-                    scanner_output += "\n".join(
-                        (result.stdout or "", result.stderr or "")
-                    )
-                    if result.returncode != 0:
-                        return cached_keys or None
+                ):
+                    shell_command = (f"cd {shlex.quote(scan_dir)} && "
+                                     + " ".join(shlex.quote(v) for v in scanner_args))
+                    result = scan([
+                        "osascript", "-e",
+                        f"do shell script {json.dumps(shell_command)} with administrator privileges",
+                    ])
+            if result.returncode:
+                return KeyRecoveryResult("failed", reason="scanner_failed")
+            output = "\n".join((result.stdout or "", result.stderr or ""))
+            # Deliberately ignore all_keys.json in staging. C salt association
+            # is candidate discovery, never cryptographic evidence.
+        if select_wechat_scan_target(expected_app or None) != target:
+            return KeyRecoveryResult("failed", reason="target_changed")
+        current_root = os.stat(db_dir)
+        if (current_root.st_dev, current_root.st_ino) != root_identity:
+            return KeyRecoveryResult("failed", reason="source_root_changed")
+        matched = _rematch_keys_from_output(db_dir, output, persist=False)
+        if not matched:
+            status = "unsupported_build" if mask is None else (
+                "cache_only" if cached_keys else "failed"
+            )
+            return KeyRecoveryResult(status, reason="no_fresh_verified_keys")
+        merged, fresh = _publish_verified_keys(db_dir, matched)
+        pages, issues = _required_pages(db_dir)
+        verified = _verified_mapping(pages, merged)
+        missing = tuple(sorted(set(issues) | (set(pages) - set(verified))))
+        if (not fresh or not pages or set(fresh) != set(matched)
+                or any(verified.get(rel) != entry for rel, entry in fresh.items())):
+            return KeyRecoveryResult("failed", reason="source_changed_before_publication")
+        if select_wechat_scan_target(expected_app or None) != target:
+            return KeyRecoveryResult("failed", reason="target_changed")
+        final_root = os.stat(db_dir)
+        if (final_root.st_dev, final_root.st_ino) != root_identity:
+            return KeyRecoveryResult("failed", reason="source_root_changed")
+        if missing:
+            return KeyRecoveryResult("partial", verified, len(fresh), missing,
+                                     "observed_keys_incomplete")
+        return KeyRecoveryResult("fresh_verified", verified, len(fresh))
+    except subprocess.TimeoutExpired:
+        return KeyRecoveryResult("failed", reason="scanner_timeout")
+    except KeyCacheError as exc:
+        return KeyRecoveryResult("failed", reason=str(exc))
+    except Exception:
+        return KeyRecoveryResult("failed", reason="key_recovery_failed")
 
-        except subprocess.TimeoutExpired:
-            return cached_keys or None
-        except Exception:
-            return cached_keys or None
 
-        keys = _read_keys_file(os.path.join(scan_dir, "all_keys.json"))
+def extract_keys():
+    """Compatibility API: only a fresh complete observed-key refresh succeeds.
 
-    # Python runs as the logged-in user and authoritatively page-verifies both
-    # legacy key+salt and current key-only scanner candidates.
-    if db_dir and os.path.isdir(db_dir):
-        rematched = _rematch_keys_from_output(
-            db_dir, scanner_output, persist=False
-        )
-        keys = {**keys, **rematched}
-
-    if not keys:
-        return cached_keys or None
-
-    merged = {**cached_keys, **keys}
-    _atomic_write_keys(KEYS_FILE, merged)
-    return merged
+    Failure/partial recovery leaves the cache on disk for separately verified
+    consumers. Call recover_keys() for the structured outcome.
+    """
+    result = recover_keys()
+    return result.keys if result.ok else None
 
 
 def _parse_raw_keys_from_text(text):
@@ -361,68 +882,20 @@ def _parse_raw_keys_from_log(log_path=EXTRACT_LOG):
 
 
 def _rematch_keys_from_output(db_dir, scanner_output, *, persist=True):
-    """Match captured key candidates against encrypted database page one.
-
-    Solves the issue where root cannot read macOS sandbox files.
-    """
-    raw_keys = _parse_raw_keys_from_text(scanner_output)
-    if not raw_keys:
-        return {}
-
-    print(f"[key_extractor] 从 scanner 输出解析到 {len(raw_keys)} 个 key candidate，用 Python 重新匹配...")
-
-    # Build salt -> key_hex index
-    salt_to_key = {}
-    for key_hex, salt_hex in raw_keys:
-        if salt_hex:
-            salt_to_key[salt_hex] = key_hex
-    unique_candidates = sorted({key_hex for key_hex, _salt_hex in raw_keys})
+    """Only HMAC-verified candidates may cross the cache publication boundary."""
     from .decryptor import verify_page1
-
-    # Walk all required encrypted DBs. Current WeChat builds retain only the
-    # key-only literal, so page-one verification is the authoritative match.
+    candidates = sorted({key for key, _salt in _parse_raw_keys_from_text(scanner_output)})
+    if not candidates:
+        return {}
+    pages, _issues = _required_pages(db_dir)
     matched = {}
-    for root, _dirs, files in os.walk(db_dir):
-        for fname in files:
-            if not fname.endswith(".db"):
-                continue
-            full_path = os.path.join(root, fname)
-            rel = os.path.relpath(full_path, db_dir).replace("\\", "/")
-            if not is_required_database(rel):
-                continue
-            try:
-                with open(full_path, "rb") as f:
-                    page1 = f.read(SQLCIPHER_PAGE_SIZE)
-                if len(page1) != SQLCIPHER_PAGE_SIZE:
-                    continue
-                # Unencrypted SQLite, skip
-                if page1.startswith(b"SQLite format 3\x00"):
-                    continue
-                file_salt = page1[:16].hex().lower()
-                ordered_candidates = []
-                if file_salt in salt_to_key:
-                    ordered_candidates.append(salt_to_key[file_salt])
-                ordered_candidates.extend(
-                    key_hex
-                    for key_hex in unique_candidates
-                    if key_hex not in ordered_candidates
-                )
-                for key_hex in ordered_candidates:
-                    if verify_page1(bytes.fromhex(key_hex), page1):
-                        matched[rel] = {"enc_key": key_hex}
-                        print(f"  ✓ 匹配: {rel}")
-                        break
-            except OSError:
-                continue
-
+    for rel, page in pages.items():
+        for candidate in candidates:
+            if verify_page1(bytes.fromhex(candidate), page):
+                matched[rel] = {"enc_key": candidate}
+                break
     if matched and persist:
-        try:
-            merged = {**_read_keys_file(KEYS_FILE), **matched}
-            _atomic_write_keys(KEYS_FILE, merged)
-            print(f"[key_extractor] Python 重新匹配成功: {len(matched)} 个数据库")
-        except OSError:
-            pass
-
+        _merged, matched = _publish_verified_keys(db_dir, matched)
     return matched
 
 
@@ -436,51 +909,20 @@ def _rematch_keys_from_log(db_dir):
 
 
 def get_cached_keys():
-    """Get cached keys (without re-extraction)."""
-    if not os.path.exists(KEYS_FILE):
-        return None
+    """Read the existing cache; availability does not imply a fresh recovery."""
     try:
-        with open(KEYS_FILE) as f:
-            keys = json.load(f)
-        keys = {k: v for k, v in keys.items() if not k.startswith("_")}
-        return keys if keys else None
-    except (json.JSONDecodeError, OSError):
+        return _read_keys_file(KEYS_FILE) or None
+    except (OSError, KeyCacheError):
         return None
 
 
 def check_new_databases(db_dir, keys):
-    """Detect new encrypted databases under db_dir that are missing keys.
+    """Report absent/invalid keys and unreadable current required source files.
 
-    Scans db_storage directory for all .db files, reads first 16 bytes to
-    check if encrypted, compares against existing keys, returns list of
-    databases missing keys.
-
-    Args:
-        db_dir: db_storage directory path.
-        keys: Current key dict {rel_path: {"enc_key": ...}}.
-
-    Returns:
-        list[str]: Relative paths of databases missing keys.
+    Historical missing shards are still owned by SourceInventoryStore. This
+    helper must never equate dictionary membership with a usable current key.
     """
-    missing = []
-    normalized_keys = {k.replace("\\", "/") for k in keys}
-    for root, _dirs, files in os.walk(db_dir):
-        for fname in files:
-            if not fname.endswith(".db"):
-                continue
-            full = os.path.join(root, fname)
-            rel = os.path.relpath(full, db_dir).replace("\\", "/")
-            if not is_required_database(rel):
-                continue
-            if rel in normalized_keys:
-                continue  # Already has key
-            # Read first 16 bytes to check if encrypted
-            try:
-                with open(full, "rb") as f:
-                    header = f.read(16)
-                if len(header) < 16 or header[:15] == b"SQLite format 3":
-                    continue  # Too small or unencrypted, skip
-                missing.append(rel)
-            except OSError:
-                continue
-    return sorted(missing)
+    pages, issues = _required_pages(db_dir)
+    normalized = {k.replace("\\", "/"): v for k, v in (keys or {}).items()}
+    verified = _verified_mapping(pages, normalized)
+    return sorted(set(issues) | (set(pages) - set(verified)))

--- a/core/knowledge.py
+++ b/core/knowledge.py
@@ -1009,6 +1009,15 @@ class KnowledgeStore:
             CREATE INDEX IF NOT EXISTS idx_events_topic_id ON events(topic_id);
             CREATE INDEX IF NOT EXISTS idx_events_message_hash ON events(message_hash);
 
+            CREATE TABLE IF NOT EXISTS daily_digest_changes (
+                change_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                window_start TEXT NOT NULL DEFAULT '',
+                window_end TEXT NOT NULL DEFAULT '',
+                fallback_timestamp REAL NOT NULL DEFAULT 0,
+                change_kind TEXT NOT NULL,
+                created_at REAL NOT NULL
+            );
+
             CREATE TABLE IF NOT EXISTS relations (
                 relation_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 source_topic_id INTEGER NOT NULL,
@@ -1263,6 +1272,13 @@ class KnowledgeStore:
                 config,
                 now,
             )
+            self._record_daily_digest_change(
+                conn,
+                ctx,
+                messages,
+                "canonical_event",
+                now,
+            )
             if relation in {"update", "contradiction"} and linked_topic_id:
                 self._bump_new_topic_event_count(conn, topic_id, now)
                 rel_name = "updates" if relation == "update" else "contradicts"
@@ -1328,7 +1344,9 @@ class KnowledgeStore:
     def _source_batch_result(self, conn, source_batch_id):
         row = conn.execute(
             """
-            SELECT e.event_id, e.topic_id, e.relation, t.obsidian_path
+            SELECT e.event_id, e.topic_id, e.relation,
+                   e.window_start, e.window_end, e.created_at,
+                   t.obsidian_path
             FROM events AS e
             JOIN topics AS t ON t.topic_id = e.topic_id
             WHERE e.source_batch_id = ?
@@ -1347,25 +1365,44 @@ class KnowledgeStore:
             "knowledge_path": self.full_obsidian_path(obsidian_path),
             "projection_warnings": [],
             "reused": True,
+            "window_start": str(row["window_start"] or ""),
+            "window_end": str(row["window_end"] or ""),
+            "event_created_at": float(row["created_at"] or 0),
         }
+
+    def recover_source_batch(self, source_batch_id):
+        """Return and repair an already committed batch without model replay."""
+        batch_id = str(source_batch_id or "").strip()[:96]
+        if not batch_id:
+            return None
+        conn = self.connect()
+        try:
+            existing = self._source_batch_result(conn, batch_id)
+            if existing is None:
+                return None
+            return self._repair_reused_source_batch_projection(conn, existing)
+        finally:
+            conn.close()
 
     def _repair_reused_source_batch_projection(self, conn, result):
         repaired = dict(result)
         knowledge_path = str(repaired.get("knowledge_path") or "")
-        if knowledge_path and os.path.isfile(knowledge_path):
-            return repaired
-
         projection_warnings = []
-        try:
-            self._write_topic_markdown(conn, int(repaired["topic_id"]))
-        except OSError as exc:
-            projection_warnings.append({
-                "surface": "topic_markdown",
-                "error_type": type(exc).__name__,
-                "errno": exc.errno,
-            })
-            repaired["knowledge_path"] = ""
-        else:
+        topic_ready = bool(knowledge_path and os.path.isfile(knowledge_path))
+        if not topic_ready:
+            try:
+                self._write_topic_markdown(conn, int(repaired["topic_id"]))
+            except OSError as exc:
+                projection_warnings.append({
+                    "surface": "topic_markdown",
+                    "error_type": type(exc).__name__,
+                    "errno": exc.errno,
+                })
+                repaired["knowledge_path"] = ""
+            else:
+                topic_ready = True
+
+        if topic_ready:
             try:
                 self.write_date_indexes()
             except OSError as exc:
@@ -1377,6 +1414,78 @@ class KnowledgeStore:
 
         repaired["projection_warnings"] = projection_warnings
         return repaired
+
+    @staticmethod
+    def _record_daily_digest_change(conn, ctx, messages, change_kind, now):
+        """Journal a Digest invalidation in the canonical-event transaction."""
+        fallback_timestamp = float(now)
+        for message in reversed(messages or []):
+            try:
+                candidate = float(message.get("timestamp") or 0)
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if candidate > 0:
+                fallback_timestamp = candidate
+                break
+        conn.execute(
+            """
+            INSERT INTO daily_digest_changes(
+                window_start, window_end, fallback_timestamp,
+                change_kind, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                str(ctx.get("window_start") or ""),
+                str(ctx.get("window_end") or ""),
+                fallback_timestamp,
+                str(change_kind or "knowledge"),
+                now,
+            ),
+        )
+
+    def pending_daily_digest_changes(self, limit=5000):
+        """Peek one durable invalidation prefix without acknowledging it."""
+        conn = self.connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT change_id, window_start, window_end,
+                       fallback_timestamp, change_kind, created_at
+                FROM daily_digest_changes
+                ORDER BY change_id
+                LIMIT ?
+                """,
+                (max(1, int(limit)),),
+            ).fetchall()
+        finally:
+            conn.close()
+        if not rows:
+            return {"cutoff_change_id": 0, "changes": []}
+        return {
+            "cutoff_change_id": int(rows[-1]["change_id"]),
+            "changes": [dict(row) for row in rows],
+        }
+
+    def ack_daily_digest_changes(self, cutoff_change_id):
+        """Acknowledge only the exact invalidation prefix already refreshed."""
+        if self.read_only:
+            raise RuntimeError("knowledge store is read-only")
+        cutoff = max(0, int(cutoff_change_id or 0))
+        if cutoff == 0:
+            return 0
+        conn = self.connect()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM daily_digest_changes WHERE change_id <= ?",
+                (cutoff,),
+            )
+            conn.commit()
+            return int(cursor.rowcount or 0)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     @staticmethod
     def _register_attachment_mentions(conn, event_id, topic_id, messages, config, now):

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -222,6 +222,16 @@ class TopicMonitor:
                 messages,
                 max_messages,
             )
+            recovered = self._recover_committed_source_batch(source_batch)
+            if recovered is not None:
+                if recovered.get("status") == "knowledge_recovery_unavailable":
+                    return recovered
+                return self._commit_monitor_result(
+                    snapshot,
+                    state,
+                    recovered,
+                    source_batch,
+                )
         else:
             query_since_ts = self._get_query_since_ts(since_ts)
             page_forward = not dry_run and since_ts > 0
@@ -411,7 +421,11 @@ class TopicMonitor:
             if isinstance(error, MonitorSourceError)
             else "monitor_source_error"
         )
-        return {"status": code, "message": code}
+        result = {"status": code, "message": code}
+        details = getattr(error, "details", None)
+        if isinstance(details, dict):
+            result.update(details)
+        return result
 
     def _commit_monitor_result(self, snapshot, state, result, source_batch=None):
         if source_batch is not None:
@@ -708,6 +722,49 @@ class TopicMonitor:
         if self.knowledge_store is not None:
             return self.knowledge_store
         return KnowledgeStore.from_config(self.config, now_func=self.now_func, read_only=dry_run)
+
+    def _recover_committed_source_batch(self, source_batch):
+        """Advance a committed batch without asking the provider a second time."""
+        if not self._knowledge_enabled() or not source_batch.source_batch_id:
+            return None
+        store = self._get_knowledge_store(dry_run=False)
+        try:
+            knowledge = store.recover_source_batch(source_batch.source_batch_id)
+        except Exception as exc:
+            return {
+                "status": "knowledge_recovery_unavailable",
+                "message": "knowledge_recovery_unavailable",
+                "error_code": type(exc).__name__,
+            }
+        if knowledge is None:
+            return None
+        source_window = {
+            "start": str(knowledge.get("window_start") or ""),
+            "end": str(knowledge.get("window_end") or ""),
+        }
+        return {
+            "status": "duplicate",
+            "message": "canonical source batch already committed",
+            "message_count": len(source_batch.visible_messages),
+            "raw_message_count": source_batch.raw_count,
+            "source_eof": source_batch.source_eof,
+            "knowledge_topic_id": knowledge.get("topic_id"),
+            "knowledge_event_id": knowledge.get("event_id"),
+            "knowledge_event_written": False,
+            "knowledge_event_reused": True,
+            "knowledge_path": knowledge.get("knowledge_path", ""),
+            "obsidian_path": knowledge.get("obsidian_path", ""),
+            "knowledge_projection_warnings": knowledge.get(
+                "projection_warnings", []
+            ),
+            "source_window": source_window,
+            "affected_dates": source_window_dates(
+                self.config,
+                source_window["start"],
+                source_window["end"],
+                fallback_ts=knowledge.get("event_created_at"),
+            ),
+        }
 
     def _get_review_queue(self):
         if self.review_queue is not None:

--- a/core/monitor_source.py
+++ b/core/monitor_source.py
@@ -13,8 +13,9 @@ _ACTIVE_STATES = frozenset({"present", "generation_changed"})
 class MonitorSourceError(RuntimeError):
     """A path-free source batch failure."""
 
-    def __init__(self, code: str):
+    def __init__(self, code: str, *, details: dict | None = None):
         self.code = str(code or "monitor_source_error")
+        self.details = dict(details or {})
         super().__init__(self.code)
 
 
@@ -129,7 +130,62 @@ def _normalized_state_cursors(value) -> dict[str, dict[str, str]]:
             "generation_id": generation_id,
             "cursor_token": cursor_token,
         }
+        start_cursor = item.get("start_cursor")
+        if start_cursor is not None:
+            if not isinstance(start_cursor, str):
+                raise MonitorSourceError("monitor_source_cursors_corrupt")
+            normalized[logical_id]["start_cursor"] = start_cursor
     return normalized
+
+
+def _generation_admission_plan(
+    snapshot: dict,
+    shards: tuple[dict, ...],
+    previous_cursors: dict[str, dict[str, str]],
+    *,
+    raw_limit: int,
+) -> dict | None:
+    """Describe an exact, bounded reconciliation without reading source rows.
+
+    The returned plan is deliberately non-executable: an old cursor is not
+    evidence that the replacement contains the same prefix.  It gives an
+    operator/recovery path a stable exact-inventory input while this ordinary
+    monitor run remains read-only and leaves the checkpoint untouched.
+    """
+    changes = []
+    for shard in shards:
+        logical_id = shard["logical_shard_id"]
+        generation_id = shard["generation_id"]
+        prior = previous_cursors.get(logical_id)
+        if prior is None:
+            changes.append({
+                "logical_shard_id": logical_id,
+                "previous_generation_id": "",
+                "current_generation_id": generation_id,
+                "previous_cursor_token": "",
+                "reason": "new_logical_shard",
+            })
+        elif prior["generation_id"] != generation_id:
+            changes.append({
+                "logical_shard_id": logical_id,
+                "previous_generation_id": prior["generation_id"],
+                "current_generation_id": generation_id,
+                "previous_cursor_token": prior["cursor_token"],
+                "reason": "generation_replaced",
+            })
+    if not changes:
+        return None
+    plan = {
+        "schema": "we-groupchat-obsidian.generation-admission-plan.v1",
+        "inventory_digest": str(snapshot["inventory_digest"]),
+        "inventory_revision": int(snapshot["inventory_revision"]),
+        "max_reconciliation_rows": max(1, int(raw_limit)),
+        "changes": changes,
+        "policy": "prove_stable_prefix_or_explicit_bounded_replay",
+    }
+    canonical = json.dumps(plan, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    plan["plan_id"] = "wgadmit_" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return plan
 
 
 def _message_position(message: dict, generation_id: str) -> tuple[tuple, str]:
@@ -138,7 +194,12 @@ def _message_position(message: dict, generation_id: str) -> tuple[tuple, str]:
     envelope = message.get("source_envelope")
     if not isinstance(envelope, dict):
         raise MonitorSourceError("source_envelope_invalid")
-    if str(envelope.get("db_shard_id") or "") != generation_id:
+    observed_generation = str(
+        envelope.get("source_generation_id")
+        or envelope.get("db_shard_id")
+        or ""
+    )
+    if observed_generation != generation_id:
         raise MonitorSourceError("source_generation_changed")
     source_message_id = str(
         message.get("source_message_id")
@@ -182,6 +243,7 @@ def initialize_monitor_source_state(db, checkpoint) -> dict:
         row["logical_shard_id"]: {
             "generation_id": row["generation_id"],
             "cursor_token": start,
+            "start_cursor": start,
         }
         for row in shards
     }
@@ -224,6 +286,24 @@ def read_monitor_source_batch(
     previous_checkpoint = _checkpoint(state.get("last_checked_ts"))
     previous_cursors = _normalized_state_cursors(state.get("source_cursors"))
     migration_start = _cursor_token(previous_checkpoint, 0)
+
+    # Existing installations without per-shard cursors retain their one-time
+    # compatibility migration.  Once any shard binding exists, however, a
+    # replacement or newly discovered shard must be admitted explicitly.  The
+    # ordinary monitor may not borrow a global timestamp and silently skip an
+    # older unseen row.
+    if previous_cursors:
+        admission_plan = _generation_admission_plan(
+            snapshot,
+            shards,
+            previous_cursors,
+            raw_limit=limit,
+        )
+        if admission_plan is not None:
+            raise MonitorSourceError(
+                "source_generation_admission_required",
+                details={"generation_admission_plan": admission_plan},
+            )
 
     cursors = {}
     streams = {}
@@ -290,6 +370,10 @@ def read_monitor_source_batch(
             "generation_id": generation_id,
             "cursor_token": start_cursor,
         }
+        if prior.get("start_cursor"):
+            cursors[logical_id]["start_cursor"] = prior["start_cursor"]
+        elif not prior:
+            cursors[logical_id]["start_cursor"] = migration_start
         streams[logical_id] = {
             "generation_id": generation_id,
             "fetch_cursor": start_cursor,

--- a/core/wechat_db.py
+++ b/core/wechat_db.py
@@ -847,6 +847,28 @@ class WeChatDB:
             f"wechat-db-shard-v3\0{namespace}\0{path}\0{source_identity}".encode()
         ).hexdigest()[:20]
 
+    def _source_message_shard_identity(self, rel_key, *, cache_path=""):
+        """Return a logical shard identity for durable source-message IDs.
+
+        Cursor admission continues to use the physical generation identity.
+        Keeping that generation out of the message ID lets an explicitly
+        reconciled replacement recognize the same logical source row instead
+        of manufacturing a second identity solely because cache bytes/inodes
+        were rebuilt.
+        """
+        source_path = os.path.join(self.db_dir, rel_key)
+        if cache_path:
+            identity_path = cache_path
+        elif self._is_plain_sqlite(source_path):
+            identity_path = source_path
+        else:
+            identity_path = self._cache_path(rel_key)
+        basename = os.path.basename(str(identity_path))
+        namespace = str(getattr(self, "cache_namespace", "legacy-unscoped"))
+        return hashlib.sha256(
+            f"wechat-db-shard-v2\0{namespace}\0{basename}".encode()
+        ).hexdigest()[:20]
+
     @staticmethod
     def _source_message_id(username, envelope):
         parts = ["wechat-source-message-v1", hashlib.sha256(username.encode()).hexdigest()]
@@ -985,8 +1007,10 @@ class WeChatDB:
             if ct and ct == 4 and isinstance(content, bytes):
                 try:
                     content = _zstd_dctx.decompress(content).decode("utf-8", errors="replace")
-                except Exception:
-                    content = None
+                except Exception as exc:
+                    # Failed decoding is an unreadable source row, not an
+                    # intentionally filtered envelope that may advance a cursor.
+                    raise WeChatSourceDegraded("source_message_decode_failed") from exc
             elif isinstance(content, bytes):
                 try:
                     content = content.decode("utf-8", errors="replace")
@@ -1355,9 +1379,16 @@ class WeChatDB:
             limit=page_limit + 1,
             page_forward=True,
             include_filtered=True,
-            db_shard_id=str(spec["source_shard_id"]),
+            db_shard_id=self._source_message_shard_identity(
+                spec["rel_key"],
+                cache_path=spec["cache_path"],
+            ),
             after_cursor=after_cursor,
         )
+        for message in messages:
+            envelope = message.get("source_envelope")
+            if isinstance(envelope, dict):
+                envelope["source_generation_id"] = str(spec["source_shard_id"])
         exhausted = len(messages) <= page_limit
         page = messages[:page_limit]
         next_cursor = str(cursor_token or "")
@@ -1423,7 +1454,10 @@ class WeChatDB:
             page_forward=page_forward,
             since_inclusive=since_inclusive,
             include_filtered=include_filtered,
-            db_shard_id=str(spec["source_shard_id"]),
+            db_shard_id=self._source_message_shard_identity(
+                spec["rel_key"],
+                cache_path=spec["cache_path"],
+            ),
         )
 
     def get_messages(

--- a/core/wechat_resign.py
+++ b/core/wechat_resign.py
@@ -1,0 +1,332 @@
+"""Exact-target macOS WeChat re-sign orchestration.
+
+This module performs no work at import time.  The mutation path is entered only
+by the explicit operator script and keeps one bundle/process identity bound
+through privilege acquisition, termination, signing, verification and reopen.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import plistlib
+import re
+import stat
+import subprocess
+import threading
+import time
+
+from . import key_extractor
+
+
+class WeChatResignError(RuntimeError):
+    def __init__(self, code: str):
+        self.code = str(code or "wechat_resign_failed")
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True)
+class WeChatBundleIdentity:
+    app_path: str
+    bundle_identifier: str
+    executable_path: str
+    executable_name: str
+    version: str
+    build: str
+    bundle_identity: tuple[int, int]
+    executable_identity: tuple[int, int, int, int]
+    info_plist_sha256: str
+
+
+@dataclass(frozen=True)
+class WeChatResignTarget:
+    bundle: WeChatBundleIdentity
+    running: key_extractor.ScanTarget | None
+
+
+@dataclass(frozen=True)
+class WeChatResignOutcome:
+    bundle: WeChatBundleIdentity
+    running: key_extractor.ScanTarget
+
+
+def _read_regular(path: str) -> bytes:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        value = os.fstat(descriptor)
+        if not stat.S_ISREG(value.st_mode):
+            raise WeChatResignError("wechat_target_invalid")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+    finally:
+        os.close(descriptor)
+
+
+def inspect_wechat_bundle(app_path) -> WeChatBundleIdentity:
+    app = os.path.realpath(os.path.expanduser(os.fspath(app_path)))
+    try:
+        bundle_stat = os.stat(app, follow_symlinks=False)
+        if not stat.S_ISDIR(bundle_stat.st_mode):
+            raise WeChatResignError("wechat_target_invalid")
+        info_path = os.path.join(app, "Contents", "Info.plist")
+        info_bytes = _read_regular(info_path)
+        info = plistlib.loads(info_bytes)
+        bundle_id = str(info.get("CFBundleIdentifier") or "")
+        executable_name = str(info.get("CFBundleExecutable") or "")
+        version = str(info.get("CFBundleShortVersionString") or "").strip()
+        build = str(info.get("CFBundleVersion") or "").strip()
+        if (
+            bundle_id != "com.tencent.xinWeChat"
+            or executable_name != "WeChat"
+            or not version
+            or not build
+        ):
+            raise WeChatResignError("wechat_target_invalid")
+        executable = os.path.realpath(
+            os.path.join(app, "Contents", "MacOS", executable_name)
+        )
+        expected_parent = os.path.realpath(os.path.join(app, "Contents", "MacOS"))
+        if os.path.dirname(executable) != expected_parent:
+            raise WeChatResignError("wechat_target_invalid")
+        executable_stat = os.stat(executable, follow_symlinks=False)
+        if not stat.S_ISREG(executable_stat.st_mode):
+            raise WeChatResignError("wechat_target_invalid")
+    except WeChatResignError:
+        raise
+    except (OSError, ValueError, plistlib.InvalidFileException) as exc:
+        raise WeChatResignError("wechat_target_invalid") from exc
+    return WeChatBundleIdentity(
+        app,
+        bundle_id,
+        executable,
+        executable_name,
+        version,
+        build,
+        (int(bundle_stat.st_dev), int(bundle_stat.st_ino)),
+        (
+            int(executable_stat.st_dev),
+            int(executable_stat.st_ino),
+            int(executable_stat.st_size),
+            int(executable_stat.st_mtime_ns),
+        ),
+        hashlib.sha256(info_bytes).hexdigest(),
+    )
+
+
+def resolve_wechat_resign_target(
+    app_path,
+    *,
+    explicit_target: bool = False,
+) -> WeChatResignTarget:
+    bundle = inspect_wechat_bundle(app_path)
+    running = key_extractor.get_wechat_scan_targets()
+    if not explicit_target and len(running) > 1:
+        raise WeChatResignError("wechat_target_ambiguous")
+    matching = tuple(
+        target
+        for target in running
+        if target.app_path == bundle.app_path
+        and target.executable_path == bundle.executable_path
+    )
+    if len(matching) > 1:
+        raise WeChatResignError("wechat_target_ambiguous")
+    if running and not matching and not explicit_target:
+        raise WeChatResignError("wechat_target_ambiguous")
+    return WeChatResignTarget(bundle, matching[0] if matching else None)
+
+
+def revalidate_wechat_resign_target(
+    target: WeChatResignTarget,
+    *,
+    explicit_target: bool = False,
+) -> WeChatResignTarget:
+    if inspect_wechat_bundle(target.bundle.app_path) != target.bundle:
+        raise WeChatResignError("wechat_target_changed")
+    current = resolve_wechat_resign_target(
+        target.bundle.app_path,
+        explicit_target=explicit_target,
+    )
+    if current.running != target.running:
+        raise WeChatResignError("wechat_target_changed")
+    return current
+
+
+def terminate_wechat_target(
+    target: key_extractor.ScanTarget | None,
+    *,
+    timeout_seconds: float = 15.0,
+) -> None:
+    if target is None:
+        return
+    try:
+        from AppKit import NSRunningApplication
+        running = NSRunningApplication.runningApplicationWithProcessIdentifier_(
+            target.pid
+        )
+        if running is None or key_extractor.get_wechat_scan_target(target.pid) != target:
+            raise WeChatResignError("wechat_target_changed")
+        if not running.terminate():
+            raise WeChatResignError("wechat_target_quit_rejected")
+        deadline = time.monotonic() + max(0.1, float(timeout_seconds))
+        while time.monotonic() < deadline:
+            if running.isTerminated():
+                return
+            time.sleep(0.1)
+    except WeChatResignError:
+        raise
+    except Exception as exc:
+        raise WeChatResignError("wechat_target_quit_failed") from exc
+    raise WeChatResignError("wechat_target_quit_timeout")
+
+
+def _same_post_sign_bundle(
+    expected: WeChatBundleIdentity,
+    observed: WeChatBundleIdentity,
+) -> bool:
+    return (
+        expected.app_path == observed.app_path
+        and expected.bundle_identifier == observed.bundle_identifier
+        and expected.executable_path == observed.executable_path
+        and expected.executable_name == observed.executable_name
+        and expected.version == observed.version
+        and expected.build == observed.build
+        and expected.bundle_identity == observed.bundle_identity
+        and expected.info_plist_sha256 == observed.info_plist_sha256
+    )
+
+
+def verify_resigned_wechat_bundle(
+    expected: WeChatBundleIdentity,
+    *,
+    runner=subprocess.run,
+) -> WeChatBundleIdentity:
+    verify = runner(
+        [
+            "codesign", "--verify", "--deep", "--strict", "--verbose=2",
+            expected.app_path,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if verify.returncode:
+        raise WeChatResignError("wechat_signature_invalid")
+    display = runner(
+        ["codesign", "--display", "--verbose=4", expected.app_path],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if display.returncode:
+        raise WeChatResignError("wechat_signature_invalid")
+    detail = "\n".join((display.stdout or "", display.stderr or ""))
+    signature = next(
+        (line.strip() for line in detail.splitlines() if line.strip().startswith("Signature=")),
+        "",
+    )
+    flags = next(
+        (line.strip() for line in detail.splitlines() if re.search(r"\bflags=", line)),
+        "",
+    )
+    if signature != "Signature=adhoc":
+        raise WeChatResignError("wechat_signature_not_adhoc")
+    if not flags or re.search(r"\bruntime\b", flags, flags=re.IGNORECASE):
+        raise WeChatResignError("wechat_hardened_runtime_still_enabled")
+    observed = inspect_wechat_bundle(expected.app_path)
+    if not _same_post_sign_bundle(expected, observed):
+        raise WeChatResignError("wechat_target_changed")
+    return observed
+
+
+def reopen_wechat_target(
+    expected: WeChatBundleIdentity,
+    *,
+    previous: key_extractor.ScanTarget | None,
+    timeout_seconds: float = 30.0,
+) -> key_extractor.ScanTarget:
+    try:
+        from AppKit import NSWorkspace, NSWorkspaceOpenConfiguration
+        from Foundation import NSURL
+
+        completed = threading.Event()
+        outcome = {}
+
+        def callback(application, error):
+            outcome["application"] = application
+            outcome["error"] = error
+            completed.set()
+
+        url = NSURL.fileURLWithPath_(expected.app_path)
+        configuration = NSWorkspaceOpenConfiguration.configuration()
+        NSWorkspace.sharedWorkspace().openApplicationAtURL_configuration_completionHandler_(
+            url,
+            configuration,
+            callback,
+        )
+        if not completed.wait(max(0.1, float(timeout_seconds))):
+            raise WeChatResignError("wechat_reopen_timeout")
+        application = outcome.get("application")
+        if application is None or outcome.get("error") is not None:
+            raise WeChatResignError("wechat_reopen_failed")
+        target = key_extractor.get_wechat_scan_target(int(application.processIdentifier()))
+    except WeChatResignError:
+        raise
+    except Exception as exc:
+        raise WeChatResignError("wechat_reopen_failed") from exc
+    if (
+        target is None
+        or target.app_path != expected.app_path
+        or target.executable_path != expected.executable_path
+        or target.build_identity[:2] != (expected.version, expected.build)
+        or (previous is not None and target.launched_at <= previous.launched_at)
+    ):
+        raise WeChatResignError("wechat_reopen_identity_mismatch")
+    exact = key_extractor.select_wechat_scan_target(expected.app_path)
+    if exact != target:
+        raise WeChatResignError("wechat_reopen_identity_mismatch")
+    return target
+
+
+def resign_wechat_bundle(
+    app_path,
+    *,
+    allow: bool,
+    explicit_target: bool = False,
+    runner=subprocess.run,
+) -> WeChatResignOutcome:
+    if not allow:
+        raise WeChatResignError("wechat_resign_not_authorized")
+    target = resolve_wechat_resign_target(
+        app_path,
+        explicit_target=explicit_target,
+    )
+    privilege = runner(["sudo", "-v"], timeout=60)
+    if privilege.returncode:
+        raise WeChatResignError("wechat_privilege_unavailable")
+    target = revalidate_wechat_resign_target(
+        target,
+        explicit_target=explicit_target,
+    )
+    terminate_wechat_target(target.running)
+    if inspect_wechat_bundle(target.bundle.app_path) != target.bundle:
+        raise WeChatResignError("wechat_target_changed")
+    try:
+        signed = runner(
+            [
+                "sudo", "-n", "codesign", "--force", "--deep", "--sign", "-",
+                target.bundle.app_path,
+            ],
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WeChatResignError("wechat_resign_outcome_ambiguous") from exc
+    if signed.returncode:
+        raise WeChatResignError("wechat_resign_failed")
+    verified = verify_resigned_wechat_bundle(target.bundle, runner=runner)
+    reopened = reopen_wechat_target(verified, previous=target.running)
+    return WeChatResignOutcome(verified, reopened)

--- a/docs/WINDOWS-PORT-MAP.md
+++ b/docs/WINDOWS-PORT-MAP.md
@@ -113,6 +113,7 @@ root, `ai/`, `core/`, `ui/`, and `scripts/` Python module and imports every
 | `core/taxonomy_migration.py` | `deferred-w0.2` | Direct `fcntl` and knowledge storage. |
 | `core/url_safety.py` | `windows-import-safe` | Stdlib-only canonical URL display/export/prompt redaction. |
 | `core/wechat_db.py` | `windows-import-safe` | Existing shared crypto/query import surface; schema/source adapters are W1.1+. |
+| `core/wechat_resign.py` | `macos-only` | Exact-target AppKit/codesign/sudo re-sign orchestration; Windows key-provider authorization belongs to W1+. |
 | `core/wechat_source_guard.py` | `macos-only` | `fcntl`, macOS key/process adapter, and osascript notification behavior. |
 | `ui/__init__.py` | `windows-import-safe` | Empty reusable UI package boundary; Windows tray is W6. |
 | `scripts/__init__.py` | `windows-import-safe` | Empty operator package boundary. |
@@ -129,6 +130,7 @@ root, `ai/`, `core/`, `ui/`, and `scripts/` Python module and imports every
 | `scripts/migrate_taxonomy.py` | `operator-deferred` | Depends on W0.2 config/knowledge storage. |
 | `scripts/organize_obsidian.py` | `operator-deferred` | Depends on W0.2 path/storage and W3 projection activation. |
 | `scripts/refresh_data_source.py` | `macos-only` | Invokes the current macOS key/process adapter. |
+| `scripts/resign_wechat.py` | `macos-only` | Explicit-consent thin CLI for the exact-target macOS re-sign operation. |
 | `scripts/repair_relation_markdown.py` | `operator-deferred` | Depends on knowledge/config storage. |
 | `scripts/repair_relations.py` | `operator-deferred` | Depends on configured private relation state. |
 | `scripts/resource_backup.py` | `macos-only` | Current LaunchAgent/source/backup operator surface; Windows backup is W5. |

--- a/docs/recovery-acceptance.md
+++ b/docs/recovery-acceptance.md
@@ -1,0 +1,146 @@
+# WGO recovery hardening acceptance
+
+This document records the source contract added on top of public baseline
+`c9e5fdaf342674661ce40a5eea3a3ded1321e6d7`. It is not an installed-app or live
+WeChat attestation. The exact protected profile remains macOS WeChat
+`4.1.11 (269136)` arm64; a version string from another distribution channel is
+not interchangeable evidence.
+
+## Source behavior
+
+### Key recovery
+
+`core/key_extractor.py::recover_keys` returns a structured observed-key result:
+
+| State | Meaning |
+| --- | --- |
+| `fresh_verified` | This scan produced page-one HMAC-verified candidates and every currently observed required encrypted DB has a verified key. |
+| `partial` | Verified discoveries were retained, but at least one current required DB remains unreadable or lacks a verified key. |
+| `cache_only` | A known-profile scan produced no fresh verified key; old cache bytes were preserved but are not refresh success. |
+| `unsupported_build` | No exact protected profile and no page-verified legacy candidate. |
+| `failed` | Setup, target identity, scanner, source race, cache parse, or publication failed. |
+
+The C scanner staging JSON is never cache authority. Every admitted candidate
+is re-matched against a freshly read encrypted page one, and every writer uses
+the same locked fresh-read/reverify/merge/fsync/replace path. Unknown protected
+profiles are not guessed. Key freshness does not prove expected source-shard
+completeness or successful row decoding.
+
+The scanner executable comes only from an immutable build directory. Its
+receipt binds the C source bytes, compiler path/binary/version/target, explicit
+target architecture and flags, and output digest/size. Source, binary, and
+receipt are complete and fsynced before one atomic `scanner-current.json`
+pointer publishes the build. Fixed legacy binaries, partial directories,
+tampered receipts/binaries, and unattributed mock-style success values are not
+execution authority.
+
+### Exact re-sign target
+
+`core/wechat_resign.py` owns the high-impact operation; the launcher and
+`scripts/resign_wechat.py` are thin explicit-consent entrypoints. One canonical
+bundle path is inspected before privilege acquisition. When running, its PID,
+launch time, executable path/inode, version, and build are bound and rechecked
+after privilege acquisition. Only that application receives a normal terminate
+request. Timeout or identity change stops before signing. Signing, independent
+strict verification, exact-path reopen, and new-process identity verification
+must all succeed.
+
+There is no name-based `killall`, default-app rediscovery after mutation, or
+automatic SIP/permission broadening. Multiple running copies fail closed unless
+the operator supplied `--wechat-app=/exact/path/WeChat.app`. Ordinary startup
+still never re-signs without `--allow-wechat-resign`.
+
+### Generation admission
+
+First enablement keeps the established from-now policy. A legacy monitor state
+with no per-shard cursors may perform its one compatibility migration. Once any
+logical-shard binding exists, a replacement physical generation or a newly
+discovered logical shard stops before every page read and provider call with
+`source_generation_admission_required`. The checkpoint file is unchanged.
+
+The returned content-free v1 plan binds exact inventory digest/revision,
+logical shard, previous/current generation, prior cursor, reason, and the
+bounded reconciliation-row limit. The plan is deliberately non-executable:
+the old cursor alone cannot prove that the replacement contains the same
+prefix. Ordinary monitoring never copies it or substitutes the global
+timestamp. An operator migration must later supply a stable-prefix proof or an
+explicit bounded replay/reconciliation decision.
+
+Durable `source_message_id` is separated from physical cursor generation. It
+uses stable source namespace and logical cache basename, while the envelope
+carries `source_generation_id` separately. This preserves identity for the
+same logical row across an explicitly reconciled rebuild and prevents physical
+inode churn alone from manufacturing duplicate message identities.
+
+### Canonical event and projection crash recovery
+
+Compressed-row decode errors raise `source_message_decode_failed`. They cannot
+become presentation-filtered empty rows, consume catch-up page budget, invoke
+the provider, or advance a cursor.
+
+Daily Digest output uses a same-directory private temporary file, file fsync,
+atomic replace, and parent-directory fsync. The last-known-good page remains on
+publication failure. Every new canonical event inserts a
+`daily_digest_changes` row in the same SQLite transaction. Existing affected
+pages are rebuilt from canonical SQLite; the exact invalidation prefix is ACKed
+only after every page that existed at inspection time was republished. The
+event path drains immediately, and the menu timer drains every 60 seconds even
+when the scheduled Digest is not due.
+
+If a canonical event commits before the corresponding monitor-state CAS, the
+next run checks its stable `source_batch_id` before any provider call. It repairs
+missing topic/date projections, reuses the event, and commits the original
+source cursor once. A failed canonical lookup leaves the cursor unchanged.
+Thus projection repair does not create another event or ask the provider to
+reinterpret the committed batch.
+
+Catch-up output uses the actual `rebuild_projections()` `notes` and `actions`
+fields. It does not invent event/topic counters or hide a producer/consumer
+schema mismatch behind default zeroes.
+
+## Verification boundary
+
+Use a temporary `HOME` before Python imports so default runtime paths remain
+syntactically real while no live state is reachable:
+
+```bash
+TEST_HOME="$(mktemp -d)"
+HOME="$TEST_HOME" .venv/bin/python -m unittest \
+  tests.test_key_extractor tests.test_refresh_data_source \
+  tests.test_key_recovery_hardening tests.test_recovery_pipeline_hardening \
+  tests.test_catch_up_monitor tests.test_monitor_source \
+  tests.test_wechat_resign
+HOME="$TEST_HOME" .venv/bin/python -m unittest discover -s tests -t . -p 'test_*.py'
+HOME="$TEST_HOME" .venv/bin/python -m compileall -q \
+  app.py mcp_server.py setup.py ai core ui scripts tests
+for launcher in 启动.command launchers/*.command; do bash -n "$launcher"; done
+```
+
+The native C warning gate compiles `c_src/find_keys_macos.c` with
+`-Wall -Wextra -O2 -arch <target> -framework Foundation` into a temporary
+output and never executes it. Synthetic tests cover the real repository
+producer/consumer chain for key publication, Digest→catch-up apply→receipt,
+decode failure→cursor unchanged, exact re-sign binding, scanner identity,
+generation pre-admission, and event-commit→projection-repair without provider
+replay.
+
+## Still separate from source acceptance
+
+Source tests do not attest the installed `.app`, LaunchAgent checkout, current
+process, real AppKit metadata, actual App Store bundle, task-memory access, or
+real chat source. A separately authorized canary must verify:
+
+- the actual bundle/executable identity and exact re-sign/reopen behavior;
+- the real compiler/scanner receipt and process CPU match;
+- foreground/background and sleep/wake behavior;
+- DB/WAL mutation, temporary source loss, a newly created shard, and overlap;
+- one consented source message producing exactly one canonical event and an
+  openable projection; and
+- provider/read failure preserving checkpoint bytes and recovered inventory
+  reaching verified EOF.
+
+Generation plans whose prefix cannot be proven remain supervised migration
+work; the source gate blocks them safely but does not silently choose between
+loss and duplicate replay. No source-only result authorizes re-signing WeChat,
+clearing cache, resetting checkpoints, reloading a LaunchAgent, running live
+historical catch-up, or publishing a release tag.

--- a/docs/source-reliability.md
+++ b/docs/source-reliability.md
@@ -97,12 +97,36 @@ username; it does not expose the username or `wxid`.
 
 An explicitly configured `db_dir` remains authoritative even when its mount or
 container is temporarily unavailable; auto-detection can fill only a still-empty
-canonical value. Message-shard identity includes the source namespace, key
-fingerprint, and stable database-generation evidence (file identity plus the
+canonical value. Cursor-shard identity includes the source namespace, key
+fingerprint, and database-generation evidence (file identity plus the
 encrypted-page salt/header prefix). Replacing or rekeying a database at the
-same relative path therefore starts a new shard cursor instead of reusing the
-old generation. A decrypted cache with no corresponding live source is marked
-`source_cache_only` and cannot produce an applicable backfill plan.
+same relative path therefore starts a new physical generation. Durable
+`source_message_id` instead uses the stable source namespace plus logical cache
+basename, so the same logical row can retain its identity across an explicitly
+reconciled cache/DB rebuild. The envelope carries the physical generation
+separately for cursor admission. A decrypted cache with no corresponding live
+source is marked `source_cache_only` and cannot produce an applicable backfill
+plan.
+
+### Re-sign and scanner identity
+
+The explicit re-sign path accepts one canonical WeChat bundle. If that bundle
+is running, its PID, launch time, executable path/inode and version/build remain
+bound through privilege acquisition, graceful termination, signing,
+independent `codesign` verification and exact-path reopen. It never terminates
+by process name and never rediscovers a default app after mutation. Multiple
+running copies require an explicit `--wechat-app=...` selection; cancellation,
+identity change, quit timeout, signing failure, hardened-runtime verification
+failure or reopen mismatch stops the operation.
+
+The read-only C scanner is only a candidate producer. A scanner build receipt
+binds the exact source digest/size, compiler path and binary digest,
+compiler/target identity, explicit `arm64|x86_64` target and flags, plus the
+output digest/size. Source, executable and receipt are completed in an
+immutable private build directory before one fsynced atomic current pointer is
+published. A missing/tampered receipt, pointer, binary or source/compiler input
+forces a rebuild; failed compilation or pointer publication preserves the old
+current pointer but does not certify it for the changed input.
 
 ### Authoritative shard inventory
 
@@ -126,9 +150,15 @@ cursor resumes and occurrence deduplication prevents duplicates.
 
 `core/monitor_source.py` turns that complete inventory into one bounded monitor
 batch. Durable `source_cursors` are keyed by logical shard and bind the current
-generation ID plus its opaque `(create_time, rowid)` token. A legacy timestamp
-checkpoint is used only once to seed missing generation cursors; an old
-generation's token is never inherited by a replacement generation.
+generation ID plus its opaque `(create_time, rowid)` token and initial boundary.
+First enablement binds every then-present shard from now. A legacy state with no
+per-shard cursor may perform its one compatibility migration. After any shard
+binding exists, a replacement generation or new logical shard is rejected
+before page reads with `source_generation_admission_required`. The returned
+content-free plan binds the exact inventory digest/revision, old/new generation
+IDs, prior cursor and bounded row limit. It is evidence for a later explicit
+continuity proof or bounded replay/reconciliation, not permission to copy a
+cursor or borrow the global timestamp.
 
 The reader keeps a bounded page for each present shard, performs a k-way merge
 by `create_time` and stable `source_message_id`, and stops at the configured raw
@@ -148,11 +178,20 @@ exactly; a run before the deadline returns `ai_backoff` without calling the
 provider. A successful retry clears both current and legacy failure metadata.
 
 Knowledge writes use a source-ID-derived `source_batch_id`; if the event commits
-but the state revision loses its CAS, the retry adopts that exact event instead
-of inserting another canonical event. Reuse normally performs no projection
-write. If the managed topic Markdown is absent, however, reuse reconstructs that
-note and the date indexes from canonical SQLite without changing the event or
-topic identity; an I/O failure remains an explicit `projection_warnings` result.
+but the state revision loses its CAS, the next run checks canonical SQLite
+before calling the provider, adopts that exact event and advances the same
+source batch without inserting another event or reinterpreting the messages.
+If that lookup fails, the cursor remains unchanged. Missing managed topic
+Markdown and date indexes are rebuilt from canonical SQLite.
+
+Every new canonical event also inserts a `daily_digest_changes` row in the same
+SQLite transaction. Existing affected Digest pages are rebuilt from canonical
+events and the exact journal prefix is acknowledged only after every page that
+existed at inspection time was atomically republished. Digest publication uses
+a same-directory private temporary file, file fsync, atomic replace and parent
+directory fsync, preserving the last-known-good file on failure. The event path
+drains immediately; the 60-second menu timer also drains while the scheduled
+Digest itself is not due, so a restart retains an independent repair trigger.
 
 ### Catch-up receipt finalization
 

--- a/docs/source-reliability.zh-CN.md
+++ b/docs/source-reliability.zh-CN.md
@@ -82,10 +82,26 @@ source envelope 会保留 `local_id`、`server_id`、`sort_seq`、SQLite `rowid`
 `source_message_id` 由这些值和 chat username 的 hash 派生，不暴露 username 或 `wxid`。
 
 显式配置的 `db_dir` 即使 mount/container 暂时不可用也仍是 authority；auto-detect 只能填入锁内复核后
-仍为空的 canonical 值。Message shard identity 同时绑定 source namespace、key fingerprint 与稳定的
-database-generation evidence（file identity 加 encrypted-page salt/header prefix）。因此同一 relative path
-上的 DB 被替换或 rekey 后会得到新 shard cursor，不会沿用旧 generation。只有 decrypted cache、没有
-对应 live source 时会明确报告 `source_cache_only`，不能生成 applicable backfill plan。
+仍为空的 canonical 值。Cursor shard identity 绑定 source namespace、key fingerprint 与 physical
+database-generation evidence（file identity 加 encrypted-page salt/header prefix），所以同一 relative path
+上的 DB 被替换或 rekey 后会得到新 generation。Durable `source_message_id` 则使用稳定的 source
+namespace 与 logical cache basename；经过明确 reconciliation 后，同一逻辑 row 不会仅因 DB/cache 重建
+而制造第二个 identity。Envelope 另带 physical generation，专门用于 cursor admission。只有 decrypted
+cache、没有对应 live source 时仍明确报告 `source_cache_only`，不能生成 applicable backfill plan。
+
+### Re-sign 与 scanner identity
+
+显式重签路径只接受一个 canonical WeChat bundle。该 bundle 正在运行时，PID、launch time、executable
+path/inode 与 version/build 会贯穿 privilege acquisition、正常退出、签名、独立 `codesign` 验证及
+exact-path reopen。它不按进程名退出，也不会在 mutation 后重新发现“默认微信”。多个运行副本必须用
+`--wechat-app=...` 显式选择；取消、identity 变化、退出超时、签名失败、hardened runtime 验证失败或
+reopen mismatch 都会停止。
+
+Read-only C scanner 只产生 candidate。Scanner build receipt 绑定 exact source digest/size、compiler
+path/binary digest、compiler/target identity、显式 `arm64|x86_64` target、flags 与产物 digest/size。
+Source、binary、receipt 先在 private immutable build directory 内完整落盘，再 fsync 并 atomic 发布一个
+current pointer。Receipt/pointer/binary 被改，或 source/compiler input 变化，都会要求重建；compile 或
+pointer publish 失败只保留旧 pointer，不把它冒充当前 input 的合格 build。
 
 ### Authoritative shard inventory
 
@@ -105,8 +121,12 @@ namespace 加 normalized relative path 构成；文件替换或 key rotation 只
 
 `core/monitor_source.py` 把 complete inventory 变成一批 bounded monitor work。Durable
 `source_cursors` 以 logical shard 为 key，绑定当前 generation ID 与 opaque
-`(create_time, rowid)` token。Legacy timestamp checkpoint 只在某 generation 没有 cursor 时用于
-一次 seed；replacement generation 绝不会继承旧 generation 的 token。
+`(create_time, rowid)` token 和 initial boundary。第一次 enable 会把当时存在的全部 shard 从 now
+绑定；完全没有 per-shard cursor 的 legacy state 可做一次 compatibility migration。一旦已有任一
+shard binding，replacement generation 或新 logical shard 会在 page read 前返回
+`source_generation_admission_required`。Content-free plan 绑定 exact inventory digest/revision、旧/新
+generation ID、prior cursor 与 bounded row limit；它只给后续显式 continuity proof 或 bounded
+replay/reconciliation 提供 exact input，不授权复制旧 cursor 或借用 global timestamp。
 
 Reader 为每个 present shard 保留 bounded page，再按 `create_time` 与稳定 `source_message_id`
 做 k-way merge，并在 configured raw-row budget 停止。可提交 token 只从最后一条真正消费的 row
@@ -123,9 +143,15 @@ checkpoint。Deadline 之前的 run 返回 `ai_backoff`，不会调用 provider�
 legacy failure metadata。
 
 Knowledge write 使用由 source IDs 派生的 `source_batch_id`：若 event 已 commit、state revision CAS
-却失败，retry 会 adopt 同一条 event，不再插入第二条 canonical event。通常 reuse 不写 projection；
-但 managed topic Markdown 确实缺失时，会从 canonical SQLite 重建该 note 与 date indexes，不改变
-event/topic identity，I/O 失败仍以明确的 `projection_warnings` 返回。
+却失败，下一轮会在 provider 之前检查 canonical SQLite，adopt 同一 event 并推进同一 source batch，
+既不插入第二条 event，也不再次让模型解释消息。若 canonical lookup 自己失败，cursor 保持不动。
+缺失的 managed topic Markdown 与 date indexes 从 canonical SQLite 重建。
+
+每条新 canonical event 还会在同一个 SQLite transaction 插入 `daily_digest_changes`。已有 affected
+Digest 从 canonical events 重建；inspection 时存在的每个 page 都 atomic republish 成功后，才 ACK
+exact journal prefix。Digest 写入使用同目录 private temp、file fsync、atomic replace 与 parent fsync，
+失败时保住 last-known-good。Event path 会立即 drain；60 秒 menu timer 即使当天 scheduled Digest
+尚未 due，也会 drain journal，所以进程重启后仍有独立 repair trigger。
 
 ### Catch-up receipt finalization
 

--- a/launchers/启动.command
+++ b/launchers/启动.command
@@ -20,7 +20,8 @@ BACKFILL_HISTORY=0
 ORGANIZE_OBSIDIAN=0
 HEALTH_CHECK=0
 REFRESH_DATA_SOURCE=0
-WECHAT_RESIGNED=0
+WECHAT_APP_PATH_ARG=""
+WECHAT_EXPLICIT_TARGET=0
 INSTALL_AUTOSTART=0
 UNINSTALL_AUTOSTART=0
 AUTOSTART_MODE=0
@@ -59,6 +60,10 @@ for arg in "$@"; do
         --allow-wechat-resign)
             ALLOW_WECHAT_RESIGN=1
             ;;
+        --wechat-app=*)
+            WECHAT_APP_PATH_ARG="${arg#--wechat-app=}"
+            WECHAT_EXPLICIT_TARGET=1
+            ;;
     esac
 done
 
@@ -73,6 +78,13 @@ pause_and_exit() {
 
 get_wechat_app_path() {
     local app_path=""
+    if [[ -n "$WECHAT_APP_PATH_ARG" ]]; then
+        if [[ -d "$WECHAT_APP_PATH_ARG" ]]; then
+            (cd "$WECHAT_APP_PATH_ARG" && pwd -P)
+            return 0
+        fi
+        return 1
+    fi
     app_path="$(osascript -e 'POSIX path of (path to application "WeChat")' 2>/dev/null | tr -d '\r')"
     if [[ -n "$app_path" && -d "$app_path" ]]; then
         printf '%s\n' "${app_path%/}"
@@ -240,6 +252,10 @@ is_wechat_signed() {
     local app_path="$1"
     local codesign_output=""
 
+    if ! codesign --verify --deep --strict "$app_path" &>/dev/null; then
+        return 1
+    fi
+
     if ! codesign_output="$(codesign -dvv "$app_path" 2>&1)"; then
         return 1
     fi
@@ -248,22 +264,11 @@ is_wechat_signed() {
         return 1
     fi
 
+    if ! printf '%s\n' "$codesign_output" | grep -qx "Signature=adhoc"; then
+        return 1
+    fi
+
     return 0
-}
-
-quit_wechat_if_running() {
-    if ! pgrep -x "WeChat" &>/dev/null; then
-        return 0
-    fi
-
-    echo "  检测到微信正在运行，正在退出..."
-    osascript -e 'tell application "WeChat" to quit' 2>/dev/null || true
-    sleep 2
-    if pgrep -x "WeChat" &>/dev/null; then
-        killall WeChat 2>/dev/null || true
-        sleep 1
-    fi
-    echo "  ✓ 微信已退出"
 }
 
 ensure_wechat_signed() {
@@ -273,6 +278,8 @@ ensure_wechat_signed() {
         pause_and_exit 1
     fi
 
+    export WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH="$app_path"
+
     if is_wechat_signed "$app_path"; then
         echo "[2/3] 微信授权状态正常"
         return 0
@@ -280,13 +287,16 @@ ensure_wechat_signed() {
 
     echo "[2/3] 检测到微信需要重新授权..."
     echo "  为了读取本地微信数据库，本项目需要对 WeChat.app 做 ad-hoc re-sign。"
-    echo "  这是高影响操作：会修改 /Applications/WeChat.app 的签名，微信更新后可能失效。"
+    echo "  这是高影响操作：会修改下列 exact target 的签名，微信更新后可能失效。"
+    echo "  Target: $app_path"
     echo ""
     if [[ "$ALLOW_WECHAT_RESIGN" != "1" ]]; then
         echo "  privacy-first 版本不会在双击启动时自动执行这一步。"
         echo "  确认要继续时，请在项目目录手动运行："
         echo ""
         echo "    ./启动.command --allow-wechat-resign"
+        echo "  多个 WeChat.app 并存时，请显式绑定："
+        echo "    ./启动.command --allow-wechat-resign --wechat-app=/exact/path/WeChat.app"
         echo ""
         echo "  或仅做环境检查："
         echo ""
@@ -294,12 +304,18 @@ ensure_wechat_signed() {
         pause_and_exit 1
     fi
 
-    echo "  即将执行重签名，需要输入电脑登录密码；输入时终端不会显示字符，这是正常的"
-    quit_wechat_if_running
+    echo "  即将对上述 target 执行重签名，需要输入电脑登录密码；输入时终端不会显示字符，这是正常的"
+    local resign_args=(
+        "$PROJECT_DIR/scripts/resign_wechat.py"
+        --app "$app_path"
+        --allow-wechat-resign
+    )
+    if [[ "$WECHAT_EXPLICIT_TARGET" -eq 1 ]]; then
+        resign_args+=(--explicit-target)
+    fi
 
-    if sudo codesign --force --deep --sign - "$app_path"; then
-        echo "  ✓ 微信已重签名"
-        WECHAT_RESIGNED=1
+    if "$PYTHON_BIN" "${resign_args[@]}"; then
+        echo "  ✓ 微信 exact target 已重签名、验签并重新打开"
         return 0
     fi
 
@@ -308,12 +324,9 @@ ensure_wechat_signed() {
     echo "  ❌ 微信重新授权失败"
     echo "============================================"
     echo ""
-    echo "请按下面步骤处理后，再重新双击「启动.command」："
-    echo "  1. 打开「系统设置」"
-    echo "  2. 进入「隐私与安全性」"
-    echo "  3. 找到「App 管理」或「完全磁盘访问权限」"
-    echo "  4. 打开「终端」的开关"
-    echo "  5. 重新运行本脚本"
+    echo "Target 没有被当作重签成功，也不会自动扩大权限。"
+    echo "如果错误是 macOS 拒绝修改 app，请在「系统设置 → 隐私与安全性 → App 管理」"
+    echo "检查当前终端的权限后重试；不要为这一步默认开启「完全磁盘访问权限」。"
     pause_and_exit 1
 }
 
@@ -381,17 +394,6 @@ if [[ "$ORGANIZE_OBSIDIAN" -eq 1 ]]; then
 fi
 
 if [[ "$REFRESH_DATA_SOURCE" -eq 1 ]]; then
-    if [[ "$WECHAT_RESIGNED" -eq 1 ]]; then
-        app_path="$(get_wechat_app_path)"
-        echo "正在重新打开微信以加载数据库..."
-        open "$app_path"
-        for _ in {1..30}; do
-            if pgrep -x "WeChat" &>/dev/null; then
-                break
-            fi
-            sleep 1
-        done
-    fi
     exec "$PYTHON_BIN" "$PROJECT_DIR/scripts/refresh_data_source.py"
 fi
 

--- a/scripts/catch_up_monitor.py
+++ b/scripts/catch_up_monitor.py
@@ -264,6 +264,7 @@ def drain_monitors(
                 "source_inventory_invalid",
                 "source_inventory_unavailable",
                 "source_shard_unavailable",
+                "source_message_decode_failed",
             }:
                 block(username, status)
                 continue
@@ -595,6 +596,17 @@ def _load_runtime() -> tuple[dict, list[dict], WeChatDB]:
     return config, chats, db
 
 
+def _print_projection_summary(projections):
+    """Print the real producer contract; do not invent event/topic counters."""
+    if projections:
+        print(f"  date indexes: {projections['indexes'].get('written_count', 0)}")
+        for digest in projections["digests"]:
+            print(
+                f"  Digest {digest['date']}: {digest['notes']} notes / "
+                f"{digest['actions']} actions"
+            )
+
+
 def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
     started_at = datetime.now().astimezone().isoformat(timespec="seconds")
     run_id = datetime.now().strftime("%Y%m%d-%H%M%S") + f"-{time.time_ns() % 1_000_000:06d}"
@@ -779,15 +791,7 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
         print(f"  完成群聊: {len(result['complete'])}/{len(chats)}")
         if result["blocked"]:
             print(f"  未完成: {result['blocked']}")
-    if projections:
-        print(f"  date indexes: {projections['indexes'].get('written_count', 0)}")
-        for digest in projections["digests"]:
-            print(
-                f"  Digest {digest['date']}: {digest['events']} events / "
-                f"{digest['touched_topics']} touched topics / "
-                f"{digest['new_topics']} new topics / "
-                f"{digest['actions']} actions"
-            )
+    _print_projection_summary(projections)
     if validation:
         print(
             "  canonical: "

--- a/scripts/daily_digest.py
+++ b/scripts/daily_digest.py
@@ -11,7 +11,7 @@ if str(PROJECT_DIR) not in sys.path:
     sys.path.insert(0, str(PROJECT_DIR))
 
 from core.config import load_config
-from core.daily_digest import write_daily_digest
+from core.daily_digest import refresh_pending_daily_digests, write_daily_digest
 
 
 def main() -> int:
@@ -22,7 +22,14 @@ def main() -> int:
         help="Digest source date in YYYY-MM-DD; defaults to today.",
     )
     args = parser.parse_args()
-    digest = write_daily_digest(load_config(), target_date=args.date or None)
+    config = load_config()
+    digest = write_daily_digest(config, target_date=args.date or None)
+    repair = refresh_pending_daily_digests(config)
+    if repair.get("state") == "deferred":
+        raise RuntimeError(
+            "daily_digest_repair_deferred:"
+            + str(repair.get("error_code") or "unknown")
+        )
     print(f"Daily digest: {digest['path']}")
     print(f"  notes: {digest['new_notes_count']}")
     print(f"  actions: {digest.get('today_action_count', 0)}")

--- a/scripts/refresh_data_source.py
+++ b/scripts/refresh_data_source.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-"""Refresh local WeChat database keys without using the menu bar UI."""
+"""Refresh observed WeChat keys; report source completeness separately."""
 from __future__ import annotations
-
 from dataclasses import dataclass
-import os
 import sys
 from pathlib import Path
 
@@ -11,13 +9,7 @@ PROJECT_DIR = Path(__file__).resolve().parents[1]
 if str(PROJECT_DIR) not in sys.path:
     sys.path.insert(0, str(PROJECT_DIR))
 
-from core.config import load_config
-from core.key_extractor import (
-    check_new_databases,
-    extract_keys,
-    is_wechat_running,
-    process_lookup_available,
-)
+from core.key_extractor import recover_keys, process_lookup_available
 
 
 @dataclass(frozen=True)
@@ -26,51 +18,45 @@ class RefreshResult:
     key_count: int = 0
     missing_databases: list[str] | None = None
     message: str = ""
+    status: str = "failed"
+    reason: str = ""
 
 
 def refresh_data_source() -> RefreshResult:
-    """Extract current DB keys and report whether any encrypted DBs remain missing."""
     if not process_lookup_available():
-        return RefreshResult(ok=False, message="当前进程无法检测 macOS process list；请在 Terminal/Finder 中运行刷新命令")
-    if not is_wechat_running():
-        return RefreshResult(ok=False, message="微信未运行，请先启动微信并登录")
-
-    config = load_config()
-    db_dir = os.path.expanduser(config.get("db_dir", ""))
-    if not db_dir or not os.path.isdir(db_dir):
-        return RefreshResult(ok=False, message=f"未找到微信数据目录: {db_dir or '未配置'}")
-
-    keys = extract_keys()
-    if not keys:
-        return RefreshResult(ok=False, message="数据源刷新失败；如果微信刚更新过，请重新运行带 --allow-wechat-resign 的启动命令")
-
-    missing = check_new_databases(db_dir, keys)
+        return RefreshResult(False, message="当前进程无法检测 macOS process list；请在 Terminal/Finder 中运行刷新命令",
+                             reason="process_lookup_unavailable")
+    result = recover_keys()
+    messages = {
+        "fresh_verified": "本轮已验证当前可见数据库的 key；历史分片完整性仍须查看 Source inventory。",
+        "partial": "仅部分数据库的 key 已验证；尚未恢复完整可读状态。",
+        "cache_only": "本轮没有取得新的验证证据；保留旧 cache，不计为刷新成功。",
+        "unsupported_build": "本轮未取得可验证 key，运行版本没有匹配的 protected profile；旧 cache 保持不变。",
+        "failed": "本轮刷新未完成；请按原因排查，不要清空现有 cache 或重置 checkpoint。",
+    }
     return RefreshResult(
-        ok=not bool(missing),
-        key_count=len(keys),
-        missing_databases=missing,
-        message="数据源刷新完成",
+        ok=result.ok,
+        key_count=len(result.keys),
+        missing_databases=list(result.missing_databases),
+        message=messages.get(result.status, messages["failed"]),
+        status=result.status,
+        reason=result.reason,
     )
 
 
 def main() -> int:
-    print("微信总结 数据源刷新")
-    print("")
     result = refresh_data_source()
-    if result.message:
-        print(result.message)
-    if result.key_count:
-        print(f"已同步数据库 key: {result.key_count} 个")
-    missing = result.missing_databases or []
-    if missing:
-        print(f"仍有 encrypted DB 缺少 key: {len(missing)} 个")
-        for rel in missing:
-            print(f"  - {rel}")
+    print("微信总结 数据源 key 验证")
+    print(f"state: {result.status}")
+    print(result.message)
+    if result.reason:
+        print(f"reason: {result.reason}")
+    print(f"本轮验证可用 key: {result.key_count} 个")
+    # Default output contains counts/codes, never source-relative paths.
+    if result.missing_databases:
+        print(f"未验证或不可读的当前源项: {len(result.missing_databases)} 个")
         return 2
-    if result.ok:
-        print("New encrypted DBs missing keys: 0 个")
-        return 0
-    return 1
+    return 0 if result.ok else 1
 
 
 if __name__ == "__main__":

--- a/scripts/resign_wechat.py
+++ b/scripts/resign_wechat.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Re-sign one exact WeChat bundle after explicit operator authorization."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+if str(PROJECT_DIR) not in sys.path:
+    sys.path.insert(0, str(PROJECT_DIR))
+
+from core.wechat_resign import WeChatResignError, resign_wechat_bundle
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", required=True)
+    parser.add_argument("--allow-wechat-resign", action="store_true")
+    parser.add_argument("--explicit-target", action="store_true")
+    args = parser.parse_args()
+    try:
+        result = resign_wechat_bundle(
+            args.app,
+            allow=args.allow_wechat_resign,
+            explicit_target=args.explicit_target,
+        )
+    except WeChatResignError as exc:
+        print(f"WeChat re-sign failed: {exc.code}", file=sys.stderr)
+        return 2
+    print(
+        "WeChat re-sign verified: "
+        f"{result.bundle.version} ({result.bundle.build}) · "
+        f"{result.running.build_identity[2]} · {result.bundle.app_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_monitor_resilience.py
+++ b/tests/test_app_monitor_resilience.py
@@ -56,7 +56,10 @@ class AppMonitorResilienceTests(unittest.TestCase):
         app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
         app.config = {"monitor_notify_writes": False}
 
-        with patch("app.refresh_existing_daily_digests") as refresh:
+        with patch(
+            "app.refresh_pending_daily_digests",
+            return_value={"state": "refreshed", "written_dates": ["2026-08-02", "2026-08-03"]},
+        ) as refresh:
             app._handle_monitor_result({
                 "status": "duplicate",
                 "knowledge_event_written": True,
@@ -65,13 +68,13 @@ class AppMonitorResilienceTests(unittest.TestCase):
                 "summary": "Summary",
             })
 
-        refresh.assert_called_once_with(app.config, ["2026-08-02", "2026-08-03"])
+        refresh.assert_called_once_with(app.config)
 
     def test_status_without_canonical_write_does_not_refresh_digest(self):
         app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
         app.config = {"monitor_notify_writes": False}
 
-        with patch("app.refresh_existing_daily_digests") as refresh:
+        with patch("app.refresh_pending_daily_digests") as refresh:
             app._handle_monitor_result({
                 "status": "notified",
                 "last_msg_ts": 1234,
@@ -89,7 +92,10 @@ class AppMonitorResilienceTests(unittest.TestCase):
         }
         app._start_attachment_archive_consumer = unittest.mock.Mock()
 
-        with patch("app.refresh_existing_daily_digests"):
+        with patch(
+            "app.refresh_pending_daily_digests",
+            return_value={"state": "idle", "written_dates": []},
+        ):
             app._handle_monitor_result({
                 "status": "duplicate",
                 "knowledge_event_written": True,
@@ -106,13 +112,14 @@ class AppMonitorResilienceTests(unittest.TestCase):
         }
         app._start_attachment_archive_consumer = unittest.mock.Mock()
 
-        with patch("app.refresh_existing_daily_digests"), patch("app._notify"):
+        with patch("app.refresh_pending_daily_digests") as refresh, patch("app._notify"):
             app._handle_monitor_result(
                 {"status": "matched", "knowledge_event_written": True},
                 dry_run=True,
             )
 
         app._start_attachment_archive_consumer.assert_not_called()
+        refresh.assert_not_called()
 
     def test_background_notification_toggle_mutes_automatic_hit_banner(self):
         app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
@@ -181,14 +188,32 @@ class AppMonitorResilienceTests(unittest.TestCase):
             "today_risk_count": 0,
         }
 
-        with patch("app.write_daily_digest", return_value=digest) as write, \
+        with patch("app.should_run_daily_digest", return_value=True), \
+             patch("app.write_daily_digest", return_value=digest) as write, \
+             patch("app.refresh_pending_daily_digests", return_value={"state": "idle"}) as repair, \
              patch("app.mark_daily_digest_success") as mark, \
              patch("app._notify") as notify:
             app._run_daily_digest()
 
         write.assert_called_once_with(app.config)
+        repair.assert_called_once_with(app.config)
         mark.assert_called_once()
         notify.assert_not_called()
+
+    def test_not_due_timer_still_drains_durable_digest_repairs(self):
+        app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
+        app.config = {"daily_digest_enabled": True}
+        app._daily_digest_lock = threading.Lock()
+
+        with patch("app.should_run_daily_digest", return_value=False), \
+             patch("app.write_daily_digest") as write, \
+             patch("app.refresh_pending_daily_digests", return_value={"state": "refreshed"}) as repair, \
+             patch("app.mark_daily_digest_success") as mark:
+            app._run_daily_digest()
+
+        write.assert_not_called()
+        repair.assert_called_once_with(app.config)
+        mark.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_catch_up_monitor.py
+++ b/tests/test_catch_up_monitor.py
@@ -326,9 +326,7 @@ class CatchUpMonitorTests(unittest.TestCase):
             "indexes": {"written_count": 2},
             "digests": [{
                 "date": "2026-08-02",
-                "events": 3,
-                "touched_topics": 2,
-                "new_topics": 1,
+                "notes": 1,
                 "actions": 4,
                 "path": "/tmp/digest.md",
             }],

--- a/tests/test_daily_digest.py
+++ b/tests/test_daily_digest.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import time
 import unittest
+from unittest.mock import patch
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -439,6 +440,40 @@ class DailyDigestTests(unittest.TestCase):
         )
         with open(digest["path"], encoding="utf-8") as handle:
             self.assertIn("# WeChat Daily Digest - 2026-06-18", handle.read())
+
+    def test_write_daily_digest_preserves_last_good_file_when_publish_fails(self):
+        path, _ = digest_output_path(
+            self.config,
+            "2026-06-18",
+            now_func=lambda: local_ts("2026-06-18 21:31"),
+        )
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("last-known-good\n")
+
+        with patch("core.daily_digest.os.replace", side_effect=OSError("interrupted")):
+            with self.assertRaisesRegex(OSError, "interrupted"):
+                write_daily_digest(
+                    self.config,
+                    now_func=lambda: local_ts("2026-06-18 21:31"),
+                )
+
+        with open(path, encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), "last-known-good\n")
+        self.assertEqual(
+            [name for name in os.listdir(os.path.dirname(path)) if name.endswith(".tmp")],
+            [],
+        )
+
+    def test_write_daily_digest_fsyncs_payload_and_parent_before_success(self):
+        with patch("core.daily_digest.os.fsync", wraps=os.fsync) as fsync:
+            digest = write_daily_digest(
+                self.config,
+                now_func=lambda: local_ts("2026-06-18 21:31"),
+            )
+
+        self.assertTrue(os.path.isfile(digest["path"]))
+        self.assertEqual(fsync.call_count, 2)
 
     def test_historical_digest_is_written_under_month_subfolder(self):
         digest = write_daily_digest(

--- a/tests/test_key_extractor.py
+++ b/tests/test_key_extractor.py
@@ -72,16 +72,9 @@ class KeyExtractorTests(unittest.TestCase):
 
     def test_protected_key_mask_is_enabled_only_for_an_exact_supported_build(self):
         identity = ("4.1.11", "269136", "arm64")
-        with patch("core.key_extractor.get_wechat_build_identity", return_value=identity):
-            self.assertEqual(
-                _protected_key_memory_mask(),
-                PROTECTED_KEY_MEMORY_MASKS[identity],
-            )
-        with patch(
-            "core.key_extractor.get_wechat_build_identity",
-            return_value=("4.1.12", "future", "arm64"),
-        ):
-            self.assertIsNone(_protected_key_memory_mask())
+        self.assertEqual(_protected_key_memory_mask(identity), PROTECTED_KEY_MEMORY_MASKS[identity])
+        self.assertIsNone(_protected_key_memory_mask(("4.1.12", "future", "arm64")))
+        self.assertIsNone(_protected_key_memory_mask())
 
     def test_missing_extract_log_returns_empty_list(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -158,11 +151,11 @@ class KeyExtractorTests(unittest.TestCase):
                  ):
                 result = extract_keys()
 
-            self.assertEqual(result, existing)
+            self.assertIsNone(result)
             with open(keys_file, encoding="utf-8") as handle:
                 self.assertEqual(json.load(handle), existing)
 
-    def test_partial_scan_merges_with_existing_key_cache(self):
+    def test_unverified_partial_stage_preserves_existing_key_cache(self):
         with tempfile.TemporaryDirectory() as tmp:
             keys_file = os.path.join(tmp, "all_keys.json")
             existing = {
@@ -185,8 +178,9 @@ class KeyExtractorTests(unittest.TestCase):
                  ):
                 result = extract_keys()
 
-            expected = {**existing, **discovered}
-            self.assertEqual(result, expected)
+            # Staged JSON has no HMAC authority, even when nonempty.
+            expected = existing
+            self.assertIsNone(result)
             with open(keys_file, encoding="utf-8") as handle:
                 self.assertEqual(json.load(handle), expected)
 

--- a/tests/test_key_recovery_hardening.py
+++ b/tests/test_key_recovery_hardening.py
@@ -1,0 +1,508 @@
+"""Runs both in the repository and in the explicitly isolated offline harness."""
+import contextlib
+import hashlib
+import hmac
+import io
+import json
+import multiprocessing
+import os
+from pathlib import Path
+import plistlib
+import struct
+import subprocess
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+from core import key_extractor as k
+
+KEY_A='12'*32
+KEY_B='ab'*32
+BAD='ef'*32
+DB_A='message/message_0.db'
+DB_B='message/message_1.db'
+
+
+def write_page(root, rel, key=KEY_A, salt=b'0123456789abcdef'):
+    path=Path(root)/rel; path.parent.mkdir(parents=True, exist_ok=True)
+    page=bytearray(4096); page[:16]=salt
+    mac_key=hashlib.pbkdf2_hmac('sha512',bytes.fromhex(key),bytes(x^0x3a for x in salt),2,dklen=32)
+    hm=hmac.new(mac_key,page[16:4032],hashlib.sha512)
+    hm.update(struct.pack('<I',1)); page[-64:]=hm.digest()
+    path.write_bytes(page)
+    return path
+
+
+def target():
+    if hasattr(k,'ScanTarget'):
+        return k.ScanTarget(42,'/fixture/WeChat.app','/fixture/WeChat',1.,('4.1.11','269136','arm64'),(1,2,3,4))
+    return object()
+
+
+class RecoveryFixtures(unittest.TestCase):
+    def setUp(self):
+        self.tmp=tempfile.TemporaryDirectory(); self.root=Path(self.tmp.name)
+        self.db=self.root/'db_storage'; self.db.mkdir()
+        self.cache=self.root/'all_keys.json'
+        self.stack=contextlib.ExitStack(); self.addCleanup(self.stack.close); self.addCleanup(self.tmp.cleanup)
+        for name,value in [('DATA_DIR',str(self.root)),('KEYS_FILE',str(self.cache))]:
+            self.stack.enter_context(patch.object(k,name,value))
+        self.stack.enter_context(patch.object(k,'get_wechat_pid',return_value=42))
+        self.stack.enter_context(patch.object(
+            k,
+            'compile_scanner',
+            return_value=types.SimpleNamespace(binary_path='/fixture/verified-scanner'),
+        ))
+        self.stack.enter_context(patch.object(k,'get_wechat_scan_target',return_value=target(),create=True))
+        self.stack.enter_context(patch.object(k,'select_wechat_scan_target',return_value=target(),create=True))
+        self.stack.enter_context(patch.object(k,'_protected_key_memory_mask',return_value=b'\0'*32))
+        self.stack.enter_context(patch.object(k,'load_config',return_value={'db_dir':str(self.db)}))
+
+    def cached(self,entries=None):
+        entries=entries or {DB_A:{'enc_key':KEY_A}}
+        self.cache.write_text(json.dumps(entries))
+        return self.cache.read_bytes()
+
+    def scanner(self, mapping=None, output='', code=0, stderr=''):
+        mapping=mapping or {}
+        def run(args,**kwargs):
+            (Path(kwargs['cwd'])/'all_keys.json').write_text(json.dumps(mapping))
+            return subprocess.CompletedProcess(args,code,output,stderr)
+        return patch.object(k.subprocess,'run',side_effect=run)
+
+
+
+class RecoveryContract(RecoveryFixtures):
+    def test_unverified_staged_json_never_enters_canonical_cache(self):
+        before=self.cached()
+        write_page(self.db,DB_A)
+        with self.scanner({DB_A:{'enc_key':BAD}}):
+            result=k.extract_keys()
+        self.assertIsNone(result)
+        self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_short_page_does_not_promote_staged_wrong_key(self):
+        before=self.cached(); p=write_page(self.db,DB_A); p.write_bytes(b'x'*16)
+        with self.scanner({DB_A:{'enc_key':BAD}},f'WGO_KEY {BAD} -\n'):
+            result=k.extract_keys()
+        self.assertIsNone(result); self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_empty_scan_keeps_bytes_but_is_not_refresh_success(self):
+        before=self.cached(); write_page(self.db,DB_A)
+        with self.scanner(): result=k.extract_keys()
+        self.assertIsNone(result); self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_timeout_keeps_cache_but_is_not_refresh_success(self):
+        before=self.cached(); write_page(self.db,DB_A)
+        with patch.object(k.subprocess,'run',side_effect=subprocess.TimeoutExpired('fixture',60)):
+            result=k.extract_keys()
+        self.assertIsNone(result); self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_generic_scanner_error_does_not_prompt_for_admin(self):
+        self.cached(); write_page(self.db,DB_A)
+        with self.scanner(code=1,stderr='fixture generic failure') as run:
+            result=k.extract_keys()
+        self.assertIsNone(result); self.assertEqual(run.call_count,1)
+
+    def test_unattributed_scanner_success_is_rejected_before_execution(self):
+        before=self.cached(); write_page(self.db,DB_A)
+        with patch.object(k,'compile_scanner',return_value=True):
+            with self.scanner({},f'WGO_KEY {KEY_A} -\n') as run:
+                result=k.recover_keys()
+        self.assertEqual(result.reason,'scanner_identity_unavailable')
+        self.assertEqual(run.call_count,0)
+        self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_invalid_existing_key_is_reported_missing(self):
+        write_page(self.db,DB_A)
+        self.assertEqual(k.check_new_databases(str(self.db),{DB_A:{'enc_key':BAD}}),[DB_A])
+
+    def test_truncated_current_source_is_not_reported_healthy(self):
+        p=write_page(self.db,DB_A); p.write_bytes(b'x'*16)
+        self.assertIn(DB_A,k.check_new_databases(str(self.db),{DB_A:{'enc_key':KEY_A}}))
+
+    def test_symlink_source_is_not_reported_healthy(self):
+        p=write_page(self.db,DB_A); other=self.root/'outside.db'; p.rename(other); p.symlink_to(other)
+        self.assertIn(DB_A,k.check_new_databases(str(self.db),{DB_A:{'enc_key':KEY_A}}))
+
+    def test_corrupt_cache_is_not_silently_replaced(self):
+        self.cache.write_bytes(b'{broken'); before=self.cache.read_bytes(); write_page(self.db,DB_A)
+        with self.scanner({DB_A:{'enc_key':KEY_A}},f'WGO_KEY {KEY_A} -\n'):
+            result=k.extract_keys()
+        self.assertIsNone(result); self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_wrong_top_level_cache_type_fails_without_exception(self):
+        self.cache.write_text('[]')
+        self.assertIsNone(k.get_cached_keys())
+
+    def test_successful_current_hmac_round_trip_is_private(self):
+        write_page(self.db,DB_A)
+        with self.scanner({},f'WGO_KEY {KEY_A} -\n') as run:
+            result=k.extract_keys()
+        self.assertEqual(result,{DB_A:{'enc_key':KEY_A}})
+        self.assertEqual(run.call_args.args[0][0], '/fixture/verified-scanner')
+        self.assertEqual(self.cache.stat().st_mode&0o777,0o600)
+        self.assertFalse((self.root/'extract_keys.log').exists())
+
+    def test_both_same_salt_candidates_choose_verified_key(self):
+        write_page(self.db,DB_A)
+        salt=b'0123456789abcdef'.hex()
+        with self.scanner({DB_A:{'enc_key':BAD}},f'WGO_KEY {KEY_A} {salt}\nWGO_KEY {BAD} {salt}\n'):
+            result=k.extract_keys()
+        self.assertEqual(result,{DB_A:{'enc_key':KEY_A}})
+
+    def test_partial_scan_preserves_unobserved_historical_cache(self):
+        self.cached({DB_B:{'enc_key':KEY_B}}); write_page(self.db,DB_A)
+        with self.scanner({},f'WGO_KEY {KEY_A} -\n'):
+            k.extract_keys()
+        saved=json.loads(self.cache.read_text())
+        self.assertEqual(saved,{DB_A:{'enc_key':KEY_A},DB_B:{'enc_key':KEY_B}})
+
+    @unittest.skipUnless(os.name=='posix','POSIX process test; native Windows is a separate gate')
+    def test_overlapping_process_scans_preserve_both_discoveries(self):
+        write_page(self.db,DB_A); write_page(self.db,DB_B,KEY_B,salt=b'fedcba9876543210')
+        self.cache.write_text('{}')
+        ctx=multiprocessing.get_context('fork'); barrier=ctx.Barrier(2)
+        def worker(rel,key):
+            def run(args,**kwargs):
+                (Path(kwargs['cwd'])/'all_keys.json').write_text(json.dumps({rel:{'enc_key':key}}))
+                barrier.wait(timeout=10)
+                return subprocess.CompletedProcess(args,0,f'WGO_KEY {key} -\n','')
+            with patch.object(k.subprocess,'run',side_effect=run):
+                with contextlib.redirect_stdout(io.StringIO()): k.extract_keys()
+        children=[ctx.Process(target=worker,args=(DB_A,KEY_A)),ctx.Process(target=worker,args=(DB_B,KEY_B))]
+        for p in children:p.start()
+        try:
+            for p in children:p.join(timeout=15)
+            self.assertEqual([p.exitcode for p in children],[0,0])
+            self.assertEqual(json.loads(self.cache.read_text()),{DB_A:{'enc_key':KEY_A},DB_B:{'enc_key':KEY_B}})
+        finally:
+            for p in children:
+                if p.is_alive():p.terminate(); p.join()
+
+
+@unittest.skipUnless(hasattr(k,'KeyRecoveryResult'),'candidate-only new contract')
+class NewBoundaryTests(RecoveryFixtures):
+    def test_direct_publication_reverifies_candidate(self):
+        before=self.cached(); write_page(self.db,DB_A)
+        _merged,fresh=k._publish_verified_keys(str(self.db),{DB_A:{'enc_key':BAD}})
+        self.assertEqual(fresh,{}); self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_cache_json_duplicates_are_not_silently_collapsed(self):
+        self.cache.write_text('{"x":{"enc_key":"'+KEY_A+'"},"x":{"enc_key":"'+BAD+'"}}')
+        self.assertIsNone(k.get_cached_keys())
+
+    def test_result_repr_never_contains_keys(self):
+        value=k.KeyRecoveryResult('fresh_verified',{DB_A:{'enc_key':KEY_A}},1)
+        self.assertNotIn(KEY_A,repr(value)); self.assertNotIn(DB_A,repr(value))
+        partial = k.KeyRecoveryResult('partial', verified_count=1, missing_databases=(DB_A,))
+        self.assertNotIn(DB_A, repr(partial))
+
+    def test_target_change_drops_scan_without_cache_write(self):
+        before=self.cached(); write_page(self.db,DB_A)
+        original=target()
+        with patch.object(k,'select_wechat_scan_target',side_effect=[original,original,None]):
+            with self.scanner({},f'WGO_KEY {KEY_A} -\n'): result=k.recover_keys()
+        self.assertFalse(result.ok); self.assertEqual(result.reason,'target_changed')
+        self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_directory_fsync_follows_atomic_publication(self):
+        with patch.object(k.os,'fsync',wraps=os.fsync) as fsync:
+            k._atomic_write_keys(str(self.cache),{DB_A:{'enc_key':KEY_A}})
+        self.assertEqual(fsync.call_count,2)
+
+    def test_cache_symlink_is_left_untouched(self):
+        target_path=self.root/'victim.json'; target_path.write_text(json.dumps({DB_A:{'enc_key':KEY_A}}))
+        self.cache.symlink_to(target_path); before=target_path.read_bytes(); write_page(self.db,DB_A)
+        with self.scanner({},f'WGO_KEY {KEY_A} -\n'): result=k.recover_keys()
+        self.assertFalse(result.ok); self.assertTrue(self.cache.is_symlink()); self.assertEqual(target_path.read_bytes(),before)
+
+    def test_write_failure_preserves_old_cache(self):
+        before=self.cached(); write_page(self.db,DB_B,KEY_B)
+        with patch.object(k.os,'replace',side_effect=OSError('fixture')):
+            with self.scanner({},f'WGO_KEY {KEY_B} -\n'): result=k.recover_keys()
+        self.assertFalse(result.ok); self.assertEqual(self.cache.read_bytes(),before)
+
+    def test_missing_key_produces_partial_not_success(self):
+        write_page(self.db,DB_A); write_page(self.db,DB_B,KEY_B)
+        with self.scanner({},f'WGO_KEY {KEY_A} -\n'): result=k.recover_keys()
+        self.assertEqual(result.status,'partial'); self.assertFalse(result.ok); self.assertIn(DB_B,result.missing_databases)
+
+@unittest.skipUnless(hasattr(k, 'KeyRecoveryResult'), 'candidate-only new contract')
+class FinalAdversarialTests(RecoveryFixtures):
+    def test_configuration_exception_is_structured(self):
+        with patch.object(k, 'load_config', side_effect=OSError('private/path')):
+            result = k.recover_keys()
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, 'recovery_setup_failed')
+        self.assertNotIn('private/path', repr(result))
+
+    def test_page_vanishes_after_publication_cannot_claim_success(self):
+        page = write_page(self.db, DB_A)
+        original = k._publish_verified_keys
+        def publish(*args):
+            result = original(*args)
+            page.unlink()
+            return result
+        with patch.object(k, '_publish_verified_keys', side_effect=publish):
+            with self.scanner({}, f'WGO_KEY {KEY_A} -\n'):
+                result = k.recover_keys()
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, 'source_changed_before_publication')
+
+    def test_page_changes_key_after_match_cannot_publish_stale_candidate(self):
+        before = self.cached()
+        write_page(self.db, DB_A)
+        original = k._publish_verified_keys
+        def publish(*args):
+            write_page(self.db, DB_A, KEY_B)
+            return original(*args)
+        with patch.object(k, '_publish_verified_keys', side_effect=publish):
+            with self.scanner({}, f'WGO_KEY {KEY_A} -\n'):
+                result = k.recover_keys()
+        self.assertFalse(result.ok)
+        self.assertEqual(self.cache.read_bytes(), before)
+
+    def test_unknown_profile_with_no_verified_candidate_preserves_cache(self):
+        before = self.cached()
+        write_page(self.db, DB_A)
+        with patch.object(k, '_protected_key_memory_mask', return_value=None):
+            with self.scanner():
+                result = k.recover_keys()
+        self.assertEqual(result.status, 'unsupported_build')
+        self.assertEqual(self.cache.read_bytes(), before)
+
+    def test_unknown_profile_can_still_verify_a_legacy_literal_without_mask(self):
+        write_page(self.db, DB_A)
+        with patch.object(k, '_protected_key_memory_mask', return_value=None):
+            with self.scanner({}, f'WGO_KEY {KEY_A} -\n') as run:
+                result = k.recover_keys()
+        self.assertTrue(result.ok)
+        self.assertEqual(len(run.call_args.args[0]), 4)
+
+    def test_sudo_scanner_error_does_not_trigger_administrator_dialog(self):
+        self.cached()
+        calls = [
+            subprocess.CompletedProcess([], 1, '', 'task_for_pid failed: 5'),
+            subprocess.CompletedProcess([], 1, '', 'scanner format error'),
+        ]
+        with patch.object(k.subprocess, 'run', side_effect=calls) as run:
+            result = k.recover_keys()
+        self.assertFalse(result.ok)
+        self.assertEqual(run.call_count, 2)
+
+    def test_cache_traversal_name_is_rejected_without_mutation(self):
+        before = self.cached({'../message/outside.db': {'enc_key': KEY_A}})
+        self.assertIsNone(k.get_cached_keys())
+        self.assertEqual(self.cache.read_bytes(), before)
+
+
+@unittest.skipUnless(hasattr(k, 'ScanTarget'), 'candidate-only target adapter')
+class TargetIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.app = Path(self.tmp.name) / 'Selected WeChat.app'
+        contents = self.app / 'Contents'
+        (contents / 'MacOS').mkdir(parents=True)
+        self.executable = contents / 'MacOS' / 'WeChat'
+        self.executable.write_bytes(b'synthetic executable identity only')
+        self.info = {
+            'CFBundleIdentifier': 'com.tencent.xinWeChat',
+            'CFBundleExecutable': 'WeChat',
+            'CFBundleShortVersionString': '4.1.11',
+            'CFBundleVersion': '269136',
+        }
+        self.plist = contents / 'Info.plist'
+        self.plist.write_bytes(plistlib.dumps(self.info))
+        self.running = types.SimpleNamespace(
+            isTerminated=lambda: False,
+            bundleURL=lambda: types.SimpleNamespace(path=lambda: str(self.app)),
+            executableURL=lambda: types.SimpleNamespace(path=lambda: str(self.executable)),
+            launchDate=lambda: types.SimpleNamespace(timeIntervalSince1970=lambda: 123.0),
+            bundleIdentifier=lambda: 'com.tencent.xinWeChat',
+            executableArchitecture=lambda: 0x0100000C,
+        )
+
+    def resolve(self):
+        import sys
+        bridge = types.ModuleType('AppKit')
+        bridge.NSRunningApplication = types.SimpleNamespace(
+            runningApplicationWithProcessIdentifier_=lambda pid: self.running if pid == 42 else None
+        )
+        with patch.dict(sys.modules, {'AppKit': bridge}):
+            return k.get_wechat_scan_target(42)
+
+    def test_selected_running_app_wins_over_default_install(self):
+        with patch.object(k, 'get_wechat_app_path', side_effect=AssertionError('default app must not be queried')):
+            result = self.resolve()
+        self.assertEqual(result.app_path, os.path.realpath(self.app))
+        self.assertEqual(result.pid, 42)
+        self.assertEqual(result.build_identity, ('4.1.11', '269136', 'arm64'))
+
+    def test_target_cpu_does_not_inherit_python_rosetta_cpu(self):
+        with patch.object(k.platform, 'machine', return_value='x86_64'):
+            result = self.resolve()
+        self.assertEqual(result.build_identity[2], 'arm64')
+
+    def test_missing_launch_identity_fails_closed(self):
+        self.running.launchDate = lambda: None
+        self.assertIsNone(self.resolve())
+
+    def test_terminated_target_fails_closed(self):
+        self.running.isTerminated = lambda: True
+        self.assertIsNone(self.resolve())
+
+    def test_wrong_running_bundle_id_fails_closed(self):
+        self.running.bundleIdentifier = lambda: 'com.example.helper'
+        self.assertIsNone(self.resolve())
+
+    def test_different_executable_fails_closed(self):
+        self.running.executableURL = lambda: types.SimpleNamespace(path=lambda: '/other/WeChat')
+        self.assertIsNone(self.resolve())
+
+    def test_scan_selection_rejects_ambiguous_running_copies(self):
+        first = target()
+        second = k.ScanTarget(
+            43,
+            '/fixture/Other WeChat.app',
+            '/fixture/Other WeChat.app/Contents/MacOS/WeChat',
+            2.0,
+            ('4.1.11', '269136', 'arm64'),
+            (1, 3, 3, 4),
+        )
+        with patch.object(k, 'get_wechat_scan_targets', return_value=(first, second), create=True):
+            self.assertIsNone(k.select_wechat_scan_target())
+
+    def test_scan_selection_honors_exact_canonical_app_path(self):
+        first = target()
+        second = k.ScanTarget(
+            43,
+            '/fixture/Other WeChat.app',
+            '/fixture/Other WeChat.app/Contents/MacOS/WeChat',
+            2.0,
+            ('4.1.11', '269136', 'arm64'),
+            (1, 3, 3, 4),
+        )
+        with patch.object(k, 'get_wechat_scan_targets', return_value=(first, second), create=True):
+            selected = k.select_wechat_scan_target('/fixture/Other WeChat.app')
+        self.assertEqual(selected, second)
+
+
+class ScannerBinaryIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.source = self.root / 'find_keys_macos.c'
+        self.pointer = self.root / 'scanner-current.json'
+        self.source.write_text('int main(void) { return 0; }\n')
+        self.stack = contextlib.ExitStack()
+        self.addCleanup(self.stack.close)
+        self.stack.enter_context(patch.object(k, 'DATA_DIR', str(self.root)))
+        self.stack.enter_context(patch.object(k, 'C_SOURCE', str(self.source)))
+        self.stack.enter_context(patch.object(
+            k,
+            '_compiler_identity',
+            return_value={
+                'path': '/fixture/cc',
+                'version': 'Fixture clang 1.0',
+                'target': 'arm64-apple-darwin',
+            },
+            create=True,
+        ))
+
+    def compiler(self, payload=b'compiled scanner', returncode=0):
+        def run(args, **_kwargs):
+            if returncode == 0:
+                output = Path(args[args.index('-o') + 1])
+                output.write_bytes(payload)
+            return subprocess.CompletedProcess(args, returncode, '', 'fixture compile error')
+        return patch.object(k.subprocess, 'run', side_effect=run)
+
+    def test_newer_mtime_without_identity_receipt_is_rebuilt(self):
+        legacy = self.root / 'find_keys_macos'
+        legacy.write_bytes(b'unattributed old binary')
+        os.utime(legacy, (4_000_000_000, 4_000_000_000))
+
+        with self.compiler() as run:
+            build = k.compile_scanner('arm64')
+
+        self.assertIsNotNone(build)
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(Path(build.binary_path).read_bytes(), b'compiled scanner')
+        receipt = json.loads(Path(build.receipt_path).read_text())
+        self.assertEqual(receipt['source_sha256'], hashlib.sha256(self.source.read_bytes()).hexdigest())
+        self.assertEqual(receipt['binary_sha256'], hashlib.sha256(Path(build.binary_path).read_bytes()).hexdigest())
+        self.assertEqual(receipt['target_architecture'], 'arm64')
+        self.assertEqual(json.loads(self.pointer.read_text())['build_directory'], Path(build.binary_path).parent.name)
+
+    def test_source_change_rebuilds_even_when_binary_mtime_is_newer(self):
+        with self.compiler(b'first'):
+            first = k.compile_scanner('arm64')
+        self.source.write_text('int main(void) { return 1; }\n')
+        os.utime(first.binary_path, (4_000_000_000, 4_000_000_000))
+
+        with self.compiler(b'second') as run:
+            second = k.compile_scanner('arm64')
+
+        self.assertEqual(run.call_count, 1)
+        self.assertNotEqual(second.binary_path, first.binary_path)
+        self.assertEqual(Path(second.binary_path).read_bytes(), b'second')
+
+    def test_compile_failure_preserves_previous_binary_and_receipt(self):
+        with self.compiler(b'known-good'):
+            build = k.compile_scanner('arm64')
+        binary_before = Path(build.binary_path).read_bytes()
+        pointer_before = self.pointer.read_bytes()
+        self.source.write_text('int main(void) { return 2; }\n')
+
+        with self.compiler(returncode=1):
+            self.assertIsNone(k.compile_scanner('arm64'))
+
+        self.assertEqual(Path(build.binary_path).read_bytes(), binary_before)
+        self.assertEqual(self.pointer.read_bytes(), pointer_before)
+
+    def test_tampered_binary_is_not_accepted_by_matching_build_metadata(self):
+        with self.compiler(b'known-good'):
+            first = k.compile_scanner('arm64')
+        Path(first.binary_path).write_bytes(b'tampered')
+
+        with self.compiler(b'rebuilt') as run:
+            rebuilt = k.compile_scanner('arm64')
+
+        self.assertIsNotNone(rebuilt)
+        self.assertEqual(run.call_count, 1)
+        self.assertNotEqual(rebuilt.binary_path, first.binary_path)
+        self.assertEqual(Path(rebuilt.binary_path).read_bytes(), b'rebuilt')
+
+    def test_pointer_publish_failure_preserves_previous_current_build(self):
+        with self.compiler(b'known-good'):
+            first = k.compile_scanner('arm64')
+        pointer_before = self.pointer.read_bytes()
+        binary_before = Path(first.binary_path).read_bytes()
+        self.source.write_text('int main(void) { return 3; }\n')
+        real_replace = os.replace
+
+        def fail_pointer(source, destination):
+            if os.path.abspath(destination) == os.path.abspath(self.pointer):
+                raise OSError('pointer publish failed')
+            return real_replace(source, destination)
+
+        with patch.object(k.os, 'replace', side_effect=fail_pointer):
+            with self.compiler(b'new-but-unpublished'):
+                self.assertIsNone(k.compile_scanner('arm64'))
+
+        self.assertEqual(self.pointer.read_bytes(), pointer_before)
+        self.assertEqual(Path(first.binary_path).read_bytes(), binary_before)
+
+    def test_target_architecture_is_part_of_build_identity_and_argv(self):
+        with self.compiler(b'arm64') as arm_run:
+            arm = k.compile_scanner('arm64')
+        with self.compiler(b'x86') as x86_run:
+            x86 = k.compile_scanner('x86_64')
+
+        self.assertNotEqual(arm.input_identity, x86.input_identity)
+        self.assertIn('arm64', arm_run.call_args.args[0])
+        self.assertIn('x86_64', x86_run.call_args.args[0])

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -789,6 +789,42 @@ class KnowledgeStoreTests(unittest.TestCase):
         self.assertEqual(len(self.rows("topics")), 1)
         self.assertEqual(len(self.rows("events")), 1)
 
+    def test_event_and_daily_digest_invalidation_commit_together(self):
+        result = self.store.apply_event(
+            candidate(links=[]),
+            self.messages,
+            self.config,
+            {"relation": "new"},
+        )
+
+        changes = self.rows("daily_digest_changes")
+        self.assertEqual(result["event_id"], 1)
+        self.assertEqual(len(self.rows("events")), 1)
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_kind"], "canonical_event")
+        self.assertEqual(changes[0]["window_start"], "2026-05-29 03:16")
+        self.assertEqual(changes[0]["window_end"], "2026-05-29 03:17")
+
+    def test_daily_digest_invalidation_rolls_back_with_event(self):
+        with patch.object(
+            self.store,
+            "_register_attachment_mentions",
+            side_effect=sqlite3.OperationalError("fixture transaction failure"),
+        ):
+            with self.assertRaisesRegex(
+                sqlite3.OperationalError,
+                "fixture transaction failure",
+            ):
+                self.store.apply_event(
+                    candidate(links=[]),
+                    self.messages,
+                    self.config,
+                    {"relation": "new"},
+                )
+
+        self.assertEqual(self.rows("events"), [])
+        self.assertEqual(self.rows("daily_digest_changes"), [])
+
     def test_apply_event_reports_topic_markdown_failure_without_writing_indexes(self):
         failure = OSError(errno.EIO, "I/O error")
 

--- a/tests/test_monitor_source.py
+++ b/tests/test_monitor_source.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 from core.knowledge import KnowledgeStore
 from core.monitor import TopicMonitor, load_state, save_state
@@ -352,6 +353,7 @@ class MonitorSourceCursorTests(unittest.TestCase):
             {
                 "generation_id": "generation-a",
                 "cursor_token": "[1000,0]",
+                "start_cursor": "[1000,0]",
             },
         )
 
@@ -457,7 +459,12 @@ class MonitorSourceCursorTests(unittest.TestCase):
             "topic_key": "source-cursor-retry",
             "category": "工具更新",
         }
-        monitor = self.monitor(db, lambda *_: decision, knowledge_store=knowledge)
+        provider_calls = []
+        monitor = self.monitor(
+            db,
+            lambda *_: provider_calls.append(True) or decision,
+            knowledge_store=knowledge,
+        )
 
         first = monitor.check_once()
         second = monitor.check_once()
@@ -465,6 +472,7 @@ class MonitorSourceCursorTests(unittest.TestCase):
         self.assertEqual(first["status"], "monitor_state_conflict")
         self.assertEqual(second["status"], "duplicate")
         self.assertTrue(second["knowledge_event_reused"])
+        self.assertEqual(provider_calls, [True])
         conn = knowledge.connect()
         try:
             self.assertEqual(conn.execute("SELECT COUNT(*) FROM events").fetchone()[0], 1)
@@ -474,6 +482,35 @@ class MonitorSourceCursorTests(unittest.TestCase):
             load_state(self.state_file)["source_cursors"]["logical-a"]["cursor_token"],
             "[11,1]",
         )
+
+    def test_committed_batch_lookup_failure_preserves_cursor_without_provider(self):
+        self.config.update({
+            "monitor_knowledge_enabled": True,
+            "monitor_knowledge_db": os.path.join(self.tmp.name, "knowledge.db"),
+            "monitor_obsidian_root": os.path.join(self.tmp.name, "obsidian"),
+        })
+        save_state({"last_checked_ts": 10}, self.state_file)
+        original = Path(self.state_file).read_bytes()
+        db = CursorDB({
+            "logical-a": (
+                "generation-a",
+                [raw_message("generation-a", 1, 11, "值得记录的新内容")],
+            ),
+        })
+        store = mock.Mock()
+        store.recover_source_batch.side_effect = OSError("fixture lookup failure")
+        provider_calls = []
+
+        result = self.monitor(
+            db,
+            lambda *_: provider_calls.append(True),
+            knowledge_store=store,
+        ).check_once()
+
+        self.assertEqual(result["status"], "knowledge_recovery_unavailable")
+        self.assertEqual(result["error_code"], "OSError")
+        self.assertEqual(provider_calls, [])
+        self.assertEqual(Path(self.state_file).read_bytes(), original)
 
     def test_new_generation_never_inherits_old_generation_cursor(self):
         save_state({
@@ -492,16 +529,59 @@ class MonitorSourceCursorTests(unittest.TestCase):
             ),
         })
 
+        original = Path(self.state_file).read_bytes()
+        provider_calls = []
         result = self.monitor(
             db,
-            lambda *_: {"match": False, "score": 20},
+            lambda *_: provider_calls.append(True) or {"match": False, "score": 20},
         ).check_once()
 
-        self.assertEqual(result["status"], "no_match")
-        self.assertEqual(db.page_calls[0]["cursor_token"], "[10,0]")
+        self.assertEqual(result["status"], "source_generation_admission_required")
+        self.assertEqual(db.page_calls, [])
+        self.assertEqual(provider_calls, [])
+        self.assertEqual(Path(self.state_file).read_bytes(), original)
+        plan = result["generation_admission_plan"]
+        self.assertEqual(plan["inventory_digest"], db.get_source_inventory()["inventory_digest"])
+        self.assertEqual(plan["max_reconciliation_rows"], 2)
+        self.assertEqual(plan["changes"], [{
+            "logical_shard_id": "logical-a",
+            "previous_generation_id": "generation-old",
+            "current_generation_id": "generation-new",
+            "previous_cursor_token": "[99,999]",
+            "reason": "generation_replaced",
+        }])
+        self.assertRegex(plan["plan_id"], r"^wgadmit_[0-9a-f]{64}$")
+
+    def test_new_logical_shard_requires_admission_before_any_page_read(self):
+        save_state({
+            "last_checked_ts": 10,
+            "source_cursors": {
+                "logical-a": {
+                    "generation_id": "generation-a",
+                    "cursor_token": "[10,0]",
+                },
+            },
+        }, self.state_file)
+        original = Path(self.state_file).read_bytes()
+        db = CursorDB({
+            "logical-a": ("generation-a", []),
+            "logical-b": (
+                "generation-b",
+                [raw_message("generation-b", 1, 1, "late-discovered older row")],
+            ),
+        })
+
+        result = self.monitor(
+            db,
+            lambda *_: self.fail("provider must not run before admission"),
+        ).check_once()
+
+        self.assertEqual(result["status"], "source_generation_admission_required")
+        self.assertEqual(db.page_calls, [])
+        self.assertEqual(Path(self.state_file).read_bytes(), original)
         self.assertEqual(
-            load_state(self.state_file)["source_cursors"]["logical-a"],
-            {"generation_id": "generation-new", "cursor_token": "[11,1]"},
+            result["generation_admission_plan"]["changes"][0]["reason"],
+            "new_logical_shard",
         )
 
     def test_generation_change_during_ai_aborts_before_cursor_commit(self):

--- a/tests/test_recovery_pipeline_hardening.py
+++ b/tests/test_recovery_pipeline_hardening.py
@@ -1,0 +1,243 @@
+"""Native-repository integration gates. These are not the offline harness.
+
+All fixtures use temporary synthetic data. No provider, WeChat process,
+LaunchAgent, live configuration or user's vault is accessed.
+"""
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import sqlite3
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest.mock import MagicMock, patch
+
+from core import wechat_db
+from core.daily_digest import refresh_pending_daily_digests, write_daily_digest
+from core.knowledge import KnowledgeStore
+from core.monitor import TopicMonitor, load_state, save_state
+from core.monitor_state import MonitorStateStore
+from core.monitor_source import MonitorSourceError
+from scripts import catch_up_monitor as catchup
+from tests.test_monitor_source import ConflictingKnowledgeStore, CursorDB, raw_message
+
+
+class RecoveryPipelineTests(unittest.TestCase):
+    def test_real_digest_producer_flows_through_apply_output_and_receipt(self):
+        """Never mock rebuild_projections, write_daily_digest, or receipt creation."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            config = {
+                'monitor_knowledge_db': str(root / 'knowledge.db'),
+                'monitor_obsidian_root': str(root / 'vault'),
+                'monitor_obsidian_subdir': 'WGO',
+                'daily_digest_dir': str(root / 'digests'),
+                'daily_digest_timezone': 'UTC',
+            }
+            store = KnowledgeStore(config['monitor_knowledge_db'], config['monitor_obsidian_root'])
+            store.connect().close()
+            chats = [{'username': 'fixture@chatroom', 'name': 'Synthetic group'}]
+            result = {
+                'complete': ['fixture@chatroom'], 'blocked': {},
+                'pages': {'fixture@chatroom': 1}, 'statuses': {'no_match': 1},
+                'affected_dates': ['2026-01-02'],
+                'per_chat': {'fixture@chatroom': {
+                    'pages': 1, 'statuses': {'no_match': 1}, 'event_ids': [],
+                    'affected_dates': ['2026-01-02'], 'outcome': 'complete',
+                    'blocked_reason': '',
+                }},
+            }
+            receipts = []
+            real_write = catchup.write_reconciliation_receipt
+            def capture(receipt):
+                path = real_write(receipt, receipts_dir=root / 'receipts')
+                receipts.append(json.loads(path.read_text()))
+                return path
+            stdout = io.StringIO()
+            lock = MagicMock()
+            lock.acquire.return_value = lock
+            with (
+                patch.object(catchup, 'audit_pending', return_value=[{
+                    'username': 'fixture@chatroom', 'name': 'Synthetic group',
+                    'checkpoint': 10, 'count': 1, 'capped': False,
+                }]),
+                patch.object(catchup, 'launch_agent_report', return_value=(None, SimpleNamespace(loaded=False))),
+                patch.object(catchup, 'AppInstanceLock', return_value=lock),
+                patch.object(catchup, 'backup_runtime_state', return_value=root / 'backup'),
+                patch.object(catchup, 'TopicMonitor'),
+                patch('core.daily_digest.ReviewQueue.from_config', return_value=SimpleNamespace(pending=lambda: [])),
+                patch.object(catchup, 'drain_monitors', return_value=result),
+                patch.object(catchup, '_checkpoint_for_chat', return_value=11),
+                patch.object(catchup, 'state_file_for_chat', return_value=str(root / 'fixture-state.json')),
+                patch.object(catchup, 'write_reconciliation_receipt', side_effect=capture),
+                contextlib.redirect_stdout(stdout),
+            ):
+                code = catchup.apply_catch_up(config, chats, object(), SimpleNamespace(
+                    audit_limit=100, max_pages_per_chat=3, max_minutes=1,
+                ))
+            self.assertEqual(code, 0)
+            self.assertEqual(receipts[-1]['state'], 'complete')
+            self.assertIn('Digest 2026-01-02: 0 notes / 0 actions', stdout.getvalue())
+            digest = receipts[-1]['projections']['digests'][0]
+            self.assertEqual(digest, {'date': '2026-01-02', 'notes': 0, 'actions': 0})
+            self.assertTrue((root / 'digests' / '2026-01-02-daily-digest.md').is_file())
+            lock.release.assert_called_once()
+
+    def test_actual_corrupt_zstd_row_never_advances_monitor_state(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            database = root / 'synthetic.db'
+            conn = sqlite3.connect(database)
+            conn.execute('CREATE TABLE Msg_fixture (local_type INTEGER, create_time INTEGER, message_content BLOB, WCDB_CT_message_content INTEGER, status INTEGER)')
+            conn.execute('INSERT INTO Msg_fixture VALUES (1, 11, ?, 4, 0)', (b'not a zstd frame',))
+            conn.commit()
+            conn.close()
+            reader = wechat_db.WeChatDB.__new__(wechat_db.WeChatDB)
+            reader._contacts = {}
+            reader._nick_to_remark = {}
+            reader._load_contacts = lambda: None
+            source = CursorDB({'logical-fixture': ('generation-fixture', [])})
+            def read_corrupt(*_args, **_kwargs):
+                # Actual SQLite reader and installed zstandard decoder, not a stub.
+                messages = reader._get_messages_from_paths(
+                    'fixture@chatroom', [str(database)], 'Msg_fixture',
+                    limit=2, page_forward=True, include_filtered=True,
+                    db_shard_id='generation-fixture', after_cursor=(10, 0),
+                )
+                return {'messages': messages, 'next_cursor': '[11,1]', 'exhausted': True}
+            source.get_cursor_page_for_shard = read_corrupt
+            state_path = str(root / 'state.json')
+            save_state({'last_checked_ts': 10}, state_path)
+            before = Path(state_path).read_bytes()
+            calls = []
+            monitor = TopicMonitor(
+                source, {
+                    'monitor_topic': 'synthetic',
+                    'monitor_chat_username': 'fixture@chatroom',
+                    'monitor_chat_display_name': 'Synthetic group',
+                    'monitor_context_overlap_minutes': 0,
+                    'monitor_max_messages_per_run': 2,
+                    'monitor_ai_retry_attempts': 0,
+                }, state_file=state_path, hits_dir=str(root / 'hits'),
+                ai_evaluator=lambda *_: calls.append(True) or {'match': False, 'score': 0},
+                now_func=lambda: 1000,
+            )
+            try:
+                result = monitor.check_once()
+            except (MonitorSourceError, wechat_db.WeChatSourceDegraded) as exc:
+                status = exc.code
+            else:
+                status = result['status']
+            self.assertEqual(status, 'source_message_decode_failed')
+            self.assertEqual(Path(state_path).read_bytes(), before)
+            self.assertEqual(calls, [])
+
+    def test_decode_failure_blocks_catchup_without_burning_page_budget(self):
+        monitor = MagicMock()
+        monitor.check_once.return_value = {'status': 'source_message_decode_failed'}
+        result = catchup.drain_monitors(
+            [({'username': 'fixture', 'name': 'Synthetic group'}, monitor)],
+            max_pages_per_chat=10, max_minutes=1,
+        )
+        self.assertEqual(result['blocked'], {'fixture': 'source_message_decode_failed'})
+        self.assertEqual(result['pages'], {})
+        monitor.check_once.assert_called_once()
+
+    def test_projection_publish_crash_repairs_without_provider_replay_or_cursor_rollback(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            config = {
+                'monitor_knowledge_db': str(root / 'knowledge.db'),
+                'monitor_obsidian_root': str(root / 'vault'),
+                'monitor_obsidian_subdir': 'WGO',
+                'daily_digest_dir': str(root / 'digests'),
+                'daily_digest_timezone': 'UTC',
+                'monitor_topic': 'synthetic repair',
+                'monitor_chat_username': 'fixture@chatroom',
+                'monitor_chat_display_name': 'Synthetic group',
+                'monitor_max_messages_per_run': 10,
+                'monitor_context_overlap_minutes': 0,
+                'monitor_ai_retry_attempts': 0,
+                'monitor_cooldown_minutes': 0,
+                'monitor_knowledge_enabled': True,
+            }
+            state_path = str(root / 'monitor-state.json')
+            save_state({'last_checked_ts': 10}, state_path)
+            state_store = MonitorStateStore(state_path)
+            store = ConflictingKnowledgeStore(
+                config['monitor_knowledge_db'],
+                config['monitor_obsidian_root'],
+                obsidian_subdir=config['monitor_obsidian_subdir'],
+                state_store=state_store,
+                now_func=lambda: 1767312000,
+            )
+            # A pre-existing page makes staleness observable after the event
+            # transaction commits but before its invalidation is drained.
+            stale = write_daily_digest(
+                config,
+                now_func=lambda: 1767315600,
+                target_date='2026-01-02',
+            )
+            stale_bytes = Path(stale['path']).read_bytes()
+            source_message = raw_message(
+                'generation-fixture', 1, 1767312000,
+                'synthetic committed event',
+            )
+            source_message['time_str'] = '2026-01-02 00:00'
+            db = CursorDB({
+                'logical-fixture': (
+                    'generation-fixture',
+                    [source_message],
+                ),
+            })
+            decision = {
+                'match': True,
+                'score': 95,
+                'title': 'Synthetic committed event',
+                'summary': 'Canonical event committed before Digest repair.',
+                'topic_key': 'projection-crash-repair',
+                'category': '测试',
+            }
+            provider_calls = []
+            monitor = TopicMonitor(
+                db,
+                config,
+                state_file=state_path,
+                hits_dir=str(root / 'hits'),
+                ai_evaluator=lambda *_: provider_calls.append(True) or decision,
+                knowledge_store=store,
+                now_func=lambda: 1767312000,
+            )
+
+            first = monitor.check_once()
+            self.assertEqual(first['status'], 'monitor_state_conflict')
+            self.assertEqual(Path(stale['path']).read_bytes(), stale_bytes)
+            self.assertEqual(load_state(state_path)['last_checked_ts'], 10)
+
+            second = monitor.check_once()
+            self.assertEqual(second['status'], 'duplicate')
+            self.assertTrue(second['knowledge_event_reused'])
+            self.assertEqual(provider_calls, [True])
+            repair = refresh_pending_daily_digests(
+                config,
+                now_func=lambda: 1767315600,
+            )
+            self.assertEqual(repair['state'], 'refreshed')
+            self.assertEqual(repair['written_dates'], ['2026-01-02'])
+            conn = store.connect()
+            try:
+                self.assertEqual(conn.execute('SELECT COUNT(*) FROM events').fetchone()[0], 1)
+                self.assertEqual(conn.execute('SELECT COUNT(*) FROM daily_digest_changes').fetchone()[0], 0)
+            finally:
+                conn.close()
+            self.assertEqual(
+                load_state(state_path)['source_cursors']['logical-fixture']['cursor_token'],
+                '[1767312000,1]',
+            )
+            self.assertIn('Synthetic committed event', Path(stale['path']).read_text())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_refresh_data_source.py
+++ b/tests/test_refresh_data_source.py
@@ -1,49 +1,43 @@
 import unittest
 from unittest.mock import patch
-
+from core.key_extractor import KeyRecoveryResult
 from scripts.refresh_data_source import refresh_data_source
 
 
 class RefreshDataSourceTests(unittest.TestCase):
-    def test_reports_success_when_all_database_keys_are_present(self):
-        config = {"db_dir": "/tmp/db_storage"}
-        keys = {"message/msg_0.db": {"enc_key": "abc"}}
+    def run_result(self, outcome):
+        with patch('scripts.refresh_data_source.process_lookup_available', return_value=True), \
+             patch('scripts.refresh_data_source.recover_keys', return_value=outcome):
+            return refresh_data_source()
 
-        with patch("scripts.refresh_data_source.load_config", return_value=config), \
-             patch("scripts.refresh_data_source.process_lookup_available", return_value=True), \
-             patch("scripts.refresh_data_source.is_wechat_running", return_value=True), \
-             patch("scripts.refresh_data_source.os.path.isdir", return_value=True), \
-             patch("scripts.refresh_data_source.extract_keys", return_value=keys), \
-             patch("scripts.refresh_data_source.check_new_databases", return_value=[]):
-            result = refresh_data_source()
-
+    def test_fresh_verified_observed_keys_succeed(self):
+        result=self.run_result(KeyRecoveryResult('fresh_verified',{'message/message_0.db':{'enc_key':'12'*32}},1))
         self.assertTrue(result.ok)
-        self.assertEqual(result.key_count, 1)
-        self.assertEqual(result.missing_databases, [])
+        self.assertEqual(result.key_count,1)
+        self.assertEqual(result.missing_databases,[])
+        self.assertIn('Source inventory',result.message)
 
-    def test_reports_missing_database_keys_after_refresh(self):
-        config = {"db_dir": "/tmp/db_storage"}
-        keys = {"message/msg_0.db": {"enc_key": "abc"}}
-
-        with patch("scripts.refresh_data_source.load_config", return_value=config), \
-             patch("scripts.refresh_data_source.process_lookup_available", return_value=True), \
-             patch("scripts.refresh_data_source.is_wechat_running", return_value=True), \
-             patch("scripts.refresh_data_source.os.path.isdir", return_value=True), \
-             patch("scripts.refresh_data_source.extract_keys", return_value=keys), \
-             patch("scripts.refresh_data_source.check_new_databases", return_value=["message/weclaw.db"]):
-            result = refresh_data_source()
-
+    def test_partial_does_not_claim_refresh_success(self):
+        result=self.run_result(KeyRecoveryResult('partial',{'message/message_0.db':{'enc_key':'12'*32}},1,('message/message_1.db',)))
         self.assertFalse(result.ok)
-        self.assertEqual(result.key_count, 1)
-        self.assertEqual(result.missing_databases, ["message/weclaw.db"])
+        self.assertEqual(result.key_count,1)
+        self.assertEqual(len(result.missing_databases),1)
 
-    def test_reports_when_process_list_cannot_be_checked(self):
-        with patch("scripts.refresh_data_source.process_lookup_available", return_value=False):
-            result = refresh_data_source()
-
+    def test_cache_only_is_failure_for_a_refresh(self):
+        result=self.run_result(KeyRecoveryResult('cache_only',reason='no_fresh_verified_keys'))
         self.assertFalse(result.ok)
-        self.assertIn("无法检测", result.message)
+        self.assertEqual(result.status,'cache_only')
 
+    def test_unsupported_build_is_not_fresh_success(self):
+        self.assertFalse(self.run_result(KeyRecoveryResult('unsupported_build')).ok)
 
-if __name__ == "__main__":
-    unittest.main()
+    def test_process_lookup_unknown_does_not_attempt_recovery(self):
+        with patch('scripts.refresh_data_source.process_lookup_available',return_value=False), \
+             patch('scripts.refresh_data_source.recover_keys') as recover:
+            result=refresh_data_source()
+        self.assertFalse(result.ok)
+        self.assertIn('无法检测',result.message)
+        recover.assert_not_called()
+
+    def test_empty_fresh_result_cannot_claim_success(self):
+        self.assertFalse(self.run_result(KeyRecoveryResult('fresh_verified',verified_count=1)).ok)

--- a/tests/test_startup_helpers.py
+++ b/tests/test_startup_helpers.py
@@ -73,17 +73,18 @@ class StartupHelperTests(unittest.TestCase):
         self.assertLess(confirmation, install_dependencies)
         self.assertIn("已取消安装，程序不会启动。", contents)
 
-    def test_refresh_reopens_wechat_after_this_launcher_resigns_it(self):
+    def test_refresh_uses_the_exact_target_reopened_by_resign_orchestration(self):
         launcher = repo_path("launchers", "启动.command")
         contents = launcher.read_text(encoding="utf-8")
 
-        signed = contents.index("WECHAT_RESIGNED=1")
+        bound = contents.index('export WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH="$app_path"')
+        signed = contents.index("scripts/resign_wechat.py")
         refresh = contents.index('if [[ "$REFRESH_DATA_SOURCE" -eq 1 ]]')
-        reopen = contents.index('open "$app_path"', refresh)
-        execute_refresh = contents.index("scripts/refresh_data_source.py", reopen)
+        execute_refresh = contents.index("scripts/refresh_data_source.py", refresh)
+        self.assertLess(bound, signed)
         self.assertLess(signed, refresh)
-        self.assertLess(refresh, reopen)
-        self.assertLess(reopen, execute_refresh)
+        self.assertLess(refresh, execute_refresh)
+        self.assertNotIn('open "$app_path"', contents)
 
     def test_launcher_has_no_legacy_key_cache_rewrite_block(self):
         launcher = repo_path("launchers", "启动.command")

--- a/tests/test_wechat_db.py
+++ b/tests/test_wechat_db.py
@@ -704,6 +704,79 @@ class WeChatSourceEnvelopeTests(unittest.TestCase):
         self.assertNotEqual(identities[0], other["source_message_id"])
 
 
+class WeChatStableSourceMessageIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.old_cache_dir = WeChatDB.CACHE_DIR
+        self.addCleanup(setattr, WeChatDB, "CACHE_DIR", self.old_cache_dir)
+        WeChatDB.CACHE_DIR = os.path.join(self.tmp.name, "cache")
+        self.root = os.path.join(self.tmp.name, "source")
+        self.rel_key = "message/message_0.db"
+        self.source_path = os.path.join(self.root, self.rel_key)
+        self.username = "stable-room@chatroom"
+        self.table = f"Msg_{hashlib.md5(self.username.encode()).hexdigest()}"
+
+    def _write_source(self, path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        conn = sqlite3.connect(path)
+        try:
+            conn.execute(f"""
+                CREATE TABLE [{self.table}] (
+                    local_id INTEGER, server_id INTEGER, sort_seq INTEGER,
+                    local_type INTEGER, create_time INTEGER,
+                    message_content TEXT, WCDB_CT_message_content INTEGER,
+                    status INTEGER, packed_info_data BLOB
+                )
+            """)
+            conn.execute(
+                f"INSERT INTO [{self.table}] VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (7, 7007, 70, 1, 100, "sender:\nstable row", None, 0, None),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _prepare(db):
+        db._contacts = {"sender": "成员"}
+        db._contacts_full = []
+        db._nick_to_remark = {}
+        db._load_contacts = lambda: None
+        return db
+
+    def test_physical_generation_changes_but_message_identity_stays_logical(self):
+        self._write_source(self.source_path)
+        db = self._prepare(WeChatDB(self.root, keys={}))
+        first_generation = db.get_message_shards(self.username)[0]
+        first = db.get_cursor_page_for_shard(
+            self.username, first_generation, limit=1,
+        )["messages"][0]
+
+        replacement = os.path.join(self.root, "replacement.db")
+        self._write_source(replacement)
+        os.replace(replacement, self.source_path)
+        second_generation = db.get_message_shards(self.username)[0]
+        second = db.get_cursor_page_for_shard(
+            self.username, second_generation, limit=1,
+        )["messages"][0]
+
+        self.assertNotEqual(first_generation, second_generation)
+        self.assertEqual(first["source_message_id"], second["source_message_id"])
+        self.assertEqual(
+            first["source_envelope"]["db_shard_id"],
+            second["source_envelope"]["db_shard_id"],
+        )
+        self.assertEqual(
+            first["source_envelope"]["source_generation_id"],
+            first_generation,
+        )
+        self.assertEqual(
+            second["source_envelope"]["source_generation_id"],
+            second_generation,
+        )
+
+
 class WeChatImageDecoderTests(unittest.TestCase):
     def test_v2_image_data_decodes_with_saved_key(self):
         key = b"1234567890abcdef"

--- a/tests/test_wechat_resign.py
+++ b/tests/test_wechat_resign.py
@@ -1,0 +1,306 @@
+import os
+from pathlib import Path
+import plistlib
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from core import key_extractor
+from core import wechat_resign
+from tests.paths import repo_path
+
+
+class WeChatResignTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.app = Path(self.tmp.name) / "Selected WeChat.app"
+        contents = self.app / "Contents"
+        (contents / "MacOS").mkdir(parents=True)
+        self.executable = contents / "MacOS" / "WeChat"
+        self.executable.write_bytes(b"synthetic executable")
+        (contents / "Info.plist").write_bytes(plistlib.dumps({
+            "CFBundleIdentifier": "com.tencent.xinWeChat",
+            "CFBundleExecutable": "WeChat",
+            "CFBundleShortVersionString": "4.1.11",
+            "CFBundleVersion": "269136",
+        }))
+        self.bundle = wechat_resign.inspect_wechat_bundle(self.app)
+        self.running = key_extractor.ScanTarget(
+            42,
+            self.bundle.app_path,
+            self.bundle.executable_path,
+            100.0,
+            (self.bundle.version, self.bundle.build, "arm64"),
+            self.bundle.executable_identity,
+        )
+        self.target = wechat_resign.WeChatResignTarget(self.bundle, self.running)
+
+    def test_ambiguous_running_copies_are_rejected_before_mutation(self):
+        other = key_extractor.ScanTarget(
+            43,
+            "/fixture/Other WeChat.app",
+            "/fixture/Other WeChat.app/Contents/MacOS/WeChat",
+            101.0,
+            ("4.1.11", "269136", "arm64"),
+            (2, 3, 4, 5),
+        )
+        with patch.object(
+            key_extractor,
+            "get_wechat_scan_targets",
+            return_value=(self.running, other),
+        ):
+            with self.assertRaisesRegex(
+                wechat_resign.WeChatResignError,
+                "wechat_target_ambiguous",
+            ):
+                wechat_resign.resolve_wechat_resign_target(
+                    self.app,
+                    explicit_target=False,
+                )
+
+    def test_explicit_path_selects_only_that_running_copy(self):
+        other = key_extractor.ScanTarget(
+            43,
+            "/fixture/Other WeChat.app",
+            "/fixture/Other WeChat.app/Contents/MacOS/WeChat",
+            101.0,
+            ("4.1.11", "269136", "arm64"),
+            (2, 3, 4, 5),
+        )
+        with patch.object(
+            key_extractor,
+            "get_wechat_scan_targets",
+            return_value=(self.running, other),
+        ):
+            target = wechat_resign.resolve_wechat_resign_target(
+                self.app,
+                explicit_target=True,
+            )
+        self.assertEqual(target.running, self.running)
+
+    def test_target_change_after_privilege_check_stops_before_signing(self):
+        calls = []
+
+        def runner(args, **_kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        with (
+            patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
+            patch.object(
+                wechat_resign,
+                "revalidate_wechat_resign_target",
+                side_effect=wechat_resign.WeChatResignError("wechat_target_changed"),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                wechat_resign.WeChatResignError,
+                "wechat_target_changed",
+            ):
+                wechat_resign.resign_wechat_bundle(
+                    self.app,
+                    allow=True,
+                    runner=runner,
+                )
+
+        self.assertEqual(calls, [["sudo", "-v"]])
+
+    def test_missing_explicit_authorization_performs_no_discovery_or_mutation(self):
+        with (
+            patch.object(wechat_resign, "resolve_wechat_resign_target") as resolve,
+            patch.object(wechat_resign.subprocess, "run") as run,
+        ):
+            with self.assertRaisesRegex(
+                wechat_resign.WeChatResignError,
+                "wechat_resign_not_authorized",
+            ):
+                wechat_resign.resign_wechat_bundle(self.app, allow=False)
+
+        resolve.assert_not_called()
+        run.assert_not_called()
+
+    def test_termination_timeout_never_calls_codesign(self):
+        calls = []
+
+        def runner(args, **_kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        with (
+            patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "revalidate_wechat_resign_target", return_value=self.target),
+            patch.object(
+                wechat_resign,
+                "terminate_wechat_target",
+                side_effect=wechat_resign.WeChatResignError("wechat_target_quit_timeout"),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                wechat_resign.WeChatResignError,
+                "wechat_target_quit_timeout",
+            ):
+                wechat_resign.resign_wechat_bundle(
+                    self.app,
+                    allow=True,
+                    runner=runner,
+                )
+
+        self.assertEqual(calls, [["sudo", "-v"]])
+
+    def test_sign_success_without_independent_verification_does_not_reopen(self):
+        calls = []
+
+        def runner(args, **_kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        with (
+            patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "revalidate_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "terminate_wechat_target"),
+            patch.object(
+                wechat_resign,
+                "verify_resigned_wechat_bundle",
+                side_effect=wechat_resign.WeChatResignError("wechat_signature_invalid"),
+            ),
+            patch.object(wechat_resign, "reopen_wechat_target") as reopen,
+        ):
+            with self.assertRaisesRegex(
+                wechat_resign.WeChatResignError,
+                "wechat_signature_invalid",
+            ):
+                wechat_resign.resign_wechat_bundle(
+                    self.app,
+                    allow=True,
+                    runner=runner,
+                )
+
+        self.assertEqual(calls[1][-1], self.bundle.app_path)
+        reopen.assert_not_called()
+
+    def test_verification_accepts_native_codedirectory_adhoc_output(self):
+        results = iter((
+            subprocess.CompletedProcess(["codesign", "--verify"], 0, "", ""),
+            subprocess.CompletedProcess(
+                ["codesign", "--display"],
+                0,
+                "",
+                "Executable=/fixture/WeChat\n"
+                "CodeDirectory v=20400 size=755 flags=0x2(adhoc) hashes=14+2 location=embedded\n"
+                "Signature=adhoc\n",
+            ),
+        ))
+
+        with patch.object(
+            wechat_resign,
+            "inspect_wechat_bundle",
+            return_value=self.bundle,
+        ):
+            observed = wechat_resign.verify_resigned_wechat_bundle(
+                self.bundle,
+                runner=lambda *_args, **_kwargs: next(results),
+            )
+
+        self.assertEqual(observed, self.bundle)
+
+    def test_verification_rejects_non_adhoc_signature(self):
+        results = iter((
+            subprocess.CompletedProcess(["codesign", "--verify"], 0, "", ""),
+            subprocess.CompletedProcess(
+                ["codesign", "--display"],
+                0,
+                "",
+                "CodeDirectory v=20500 size=755 flags=0x10000(runtime) hashes=14+2 location=embedded\n"
+                "Signature size=8979\n",
+            ),
+        ))
+
+        with self.assertRaisesRegex(
+            wechat_resign.WeChatResignError,
+            "wechat_signature_not_adhoc",
+        ):
+            wechat_resign.verify_resigned_wechat_bundle(
+                self.bundle,
+                runner=lambda *_args, **_kwargs: next(results),
+            )
+
+    def test_verification_rejects_runtime_flag_even_when_adhoc(self):
+        results = iter((
+            subprocess.CompletedProcess(["codesign", "--verify"], 0, "", ""),
+            subprocess.CompletedProcess(
+                ["codesign", "--display"],
+                0,
+                "",
+                "CodeDirectory v=20500 size=755 flags=0x10002(adhoc,runtime) hashes=14+2 location=embedded\n"
+                "Signature=adhoc\n",
+            ),
+        ))
+
+        with self.assertRaisesRegex(
+            wechat_resign.WeChatResignError,
+            "wechat_hardened_runtime_still_enabled",
+        ):
+            wechat_resign.verify_resigned_wechat_bundle(
+                self.bundle,
+                runner=lambda *_args, **_kwargs: next(results),
+            )
+
+    def test_exact_target_is_passed_through_sign_verify_and_reopen(self):
+        calls = []
+
+        def runner(args, **_kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        reopened = key_extractor.ScanTarget(
+            44,
+            self.bundle.app_path,
+            self.bundle.executable_path,
+            200.0,
+            (self.bundle.version, self.bundle.build, "arm64"),
+            self.bundle.executable_identity,
+        )
+        with (
+            patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "revalidate_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "terminate_wechat_target") as terminate,
+            patch.object(
+                wechat_resign,
+                "verify_resigned_wechat_bundle",
+                return_value=self.bundle,
+            ) as verify,
+            patch.object(
+                wechat_resign,
+                "reopen_wechat_target",
+                return_value=reopened,
+            ) as reopen,
+        ):
+            outcome = wechat_resign.resign_wechat_bundle(
+                self.app,
+                allow=True,
+                explicit_target=True,
+                runner=runner,
+            )
+
+        terminate.assert_called_once_with(self.running)
+        verify.assert_called_once_with(self.bundle, runner=runner)
+        reopen.assert_called_once_with(self.bundle, previous=self.running)
+        self.assertEqual(outcome.running, reopened)
+        self.assertEqual(calls[1], [
+            "sudo", "-n", "codesign", "--force", "--deep", "--sign", "-",
+            self.bundle.app_path,
+        ])
+
+    def test_launcher_has_no_name_bound_termination_or_rediscovered_reopen(self):
+        launcher = repo_path("launchers", "启动.command").read_text(encoding="utf-8")
+        self.assertNotIn("killall WeChat", launcher)
+        self.assertNotIn('tell application "WeChat" to quit', launcher)
+        self.assertIn("scripts/resign_wechat.py", launcher)
+        self.assertNotIn('open "$app_path"', launcher)
+        self.assertIn('grep -qx "Signature=adhoc"', launcher)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make key recovery admit only freshly page-verified candidates while preserving the existing cache on partial/failed scans
- bind explicit WeChat re-signing to one exact bundle/process identity and independently verify the ad-hoc signature before exact-path reopen
- publish scanner source/binary/receipt through immutable build directories selected by one atomic current pointer
- stop replacement/new source generations before page or provider work and separate stable logical message identity from physical generation
- journal canonical-event Digest invalidations, atomically republish existing pages, and adopt committed source batches before provider replay
- connect catch-up output/receipt tests to the real projection producer contract

## Baseline and review

- exact public baseline: `c9e5fdaf342674661ce40a5eea3a3ded1321e6d7`
- supplied recovery patch was checksum-verified, generated against that baseline, and passed `git apply --check` before independent review
- the supplied patch was treated as a candidate; the four trust gates and additional regressions were implemented in this branch

## Verification

- focused recovery/source/projection suite: 225 tests passed
- named acceptance chain: 11 tests passed, including real repo Digest producer → catch-up apply → receipt and corrupt zstd decode → unchanged cursor
- full suite: 1042 tests passed, 16 skipped
- `compileall` and all `.command` shell syntax checks passed
- native macOS C warning gate passed with `/usr/bin/cc -Wall -Wextra -O2 -arch arm64`; output was an arm64 Mach-O with valid linker ad-hoc signature
- production `compile_scanner()` canary passed in an isolated temporary HOME, including receipt identities and current-pointer reuse

## Acceptance boundary

This is source acceptance only. It did not read real chats, mutate private config, clear cache, reset checkpoints, re-sign WeChat, reload a LaunchAgent, run live catch-up, install/rebuild the app bundle, or create a release tag. The generation-admission plan intentionally blocks ordinary monitoring but remains non-executable until a later explicit stable-prefix proof or bounded replay/reconciliation workflow is authorized. Installed state and live AppKit/task-memory acceptance therefore remain unverified.