### PR TITLE
Close reliability blockers for v0.1.0-alpha.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,21 @@ verification or deployment gates change.
   advance that exact batch; lookup failure preserves the checkpoint.
 - Catch-up prints the actual `rebuild_projections` notes/actions contract;
   tests must connect the real producer to apply/output/receipt.
+- `core/wechat_signature.py` owns the read-only strict/ad-hoc/no-runtime
+  predicate. Startup, Python runtime, and explicit re-sign verification share
+  it. `get_wechat_app_path()` honors the session-bound target first; an invalid
+  explicit binding never selects a different installation.
+- `core/monitor_result.py` owns catch-up outcome interpretation. Only the
+  existing post-commit progress codes may consume page budget; new/unknown
+  codes block. EOF must be the literal verified boolean. Health reports the
+  newest bounded code without falling back to old success. Preflight retains
+  source error reasons in the same reconciliation receipt schema.
+- A failed provisional receipt is sticky for the entire catch-up run, even
+  after a final receipt succeeds. Restore is still attempted; no retry may
+  erase missing recovery evidence or report the run complete.
+- Health must not call the protected-source key scanner. Keep native checks
+  and limits in `docs/reliability-closure.md`; source-window unit evidence is
+  not complete-repository or live macOS acceptance.
 - Source acceptance and remaining migration/live gates are described in
   `docs/recovery-acceptance.md`. Native Cocoa/C/macOS canary, installation,
   activation and deployment consent remain separate from source tests.

--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ the AI provider again.
 - `功能说明.txt`: concise current capability index, not an operational contract.
 - `docs/source-reliability*.md`: detailed source guard, archive, mounted backup,
   Drive, backup, and rollout contract.
+- `docs/reliability-closure.md`: shared signature/outcome interpretation,
+  credential redaction, sticky receipt failures, and source acceptance limits.
 - `docs/recovery-acceptance.md`: recovery hardening, migration boundaries, and
   source/installed/live acceptance status.
 - `docs/resource-capture-and-mounted-backup-spec.md`: formal resource occurrence,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -289,6 +289,7 @@ Digest 后才 ACK journal。如果 event 已 commit、monitor cursor 尚未 comm
 - `功能说明.txt`：当前能力的简明索引，不替代操作 contract。
 - `docs/source-reliability*.md`：source guard、archive、mounted backup、Drive、
   filesystem snapshot 和 safe rollout 的详细 contract。
+- `docs/reliability-closure.md`：签名与运行结果的共同判断、凭据脱敏、回执失败保留及验收边界。
 - `docs/recovery-acceptance.md`：恢复 hardening、migration boundary，以及
   source / installed / live 验收状态。
 - `docs/resource-capture-and-mounted-backup-spec.md`：resource occurrence、selection、

--- a/app.py
+++ b/app.py
@@ -87,6 +87,7 @@ from core.notification_target import (
     target_path_from_notification,
 )
 from core.keychain import save_key, load_key
+from core.url_safety import redact_urls_in_text
 from core.key_extractor import (
     is_wechat_running,
     is_wechat_signed,
@@ -1888,7 +1889,11 @@ class WeGroupchatObsidianApp(rumps.App):
                     self._handle_monitor_result(result, manual=manual, dry_run=dry_run)
                 except Exception as e:
                     had_error = True
-                    traceback.print_exc()
+                    print(
+                        redact_urls_in_text(traceback.format_exc()),
+                        file=sys.stderr,
+                        end="",
+                    )
                     self._handle_monitor_error(
                         f"{chat['name']}: 检查失败: {e}",
                         manual,
@@ -1898,7 +1903,11 @@ class WeGroupchatObsidianApp(rumps.App):
         except MonitorConfigError as e:
             self._handle_monitor_error(str(e), manual)
         except Exception as e:
-            traceback.print_exc()
+            print(
+                redact_urls_in_text(traceback.format_exc()),
+                file=sys.stderr,
+                end="",
+            )
             self._handle_monitor_error(f"检查失败: {e}", manual)
         finally:
             self._monitor_lock.release()
@@ -2030,11 +2039,12 @@ class WeGroupchatObsidianApp(rumps.App):
             print(f"[attachment-archive] consumer failed: {type(exc).__name__}")
 
     def _handle_monitor_error(self, message, manual=False):
-        print(f"[monitor] {message}")
+        safe_message = redact_urls_in_text(message)
+        print(f"[monitor] monitor_runtime_error: {safe_message}")
         notifications_enabled = self.config.get("background_notifications_enabled", True)
-        if manual or (notifications_enabled and message != self._monitor_last_error):
-            _notify("关注推送", "检查失败", message[:180])
-        self._monitor_last_error = message
+        if manual or (notifications_enabled and safe_message != self._monitor_last_error):
+            _notify("关注推送", "检查失败", safe_message[:180])
+        self._monitor_last_error = safe_message
 
     def _configure_daily_digest_timer(self):
         if self._daily_digest_timer:

--- a/core/key_extractor.py
+++ b/core/key_extractor.py
@@ -98,7 +98,14 @@ def is_wechat_running():
 
 
 def get_wechat_app_path():
-    """Get WeChat.app path, preferring system-installed location."""
+    """Resolve the session-bound app first; an invalid binding never falls back."""
+    variable = "WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH"
+    if variable in os.environ:
+        bound = os.environ[variable].strip()
+        if not bound or "\0" in bound:
+            return None
+        bound = os.path.realpath(os.path.expanduser(bound))
+        return bound if os.path.isdir(bound) else None
     if os.path.isdir(DEFAULT_WECHAT_APP):
         return DEFAULT_WECHAT_APP
     try:
@@ -348,23 +355,10 @@ def is_required_database(rel_path):
 
 
 def is_wechat_signed():
-    """Check if WeChat has been re-signed (hardened runtime removed)."""
+    """Apply the shared strict signature check to the session-bound target."""
+    from .wechat_signature import inspect_wechat_signature
     app_path = get_wechat_app_path()
-    if not app_path:
-        return False
-
-    try:
-        result2 = subprocess.run(
-            ["codesign", "-dvv", app_path],
-            capture_output=True, text=True,
-        )
-        if result2.returncode != 0:
-            return False
-        flags = result2.stderr
-        # Hardened runtime shows "runtime" in flags
-        return "runtime" not in flags.lower()
-    except Exception:
-        return False
+    return bool(app_path and inspect_wechat_signature(app_path).ok)
 
 
 _SCANNER_RECEIPT_SCHEMA = "we-groupchat-obsidian.scanner-build.v1"
@@ -721,10 +715,12 @@ def recover_keys():
         cached_keys = _read_keys_file(KEYS_FILE)
     except (OSError, KeyCacheError):
         return KeyRecoveryResult("failed", reason="key_cache_unreadable")
-    expected_app = str(
-        os.environ.get("WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH") or ""
-    ).strip()
-    target = select_wechat_scan_target(expected_app or None)
+    expected_app = None
+    if "WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH" in os.environ:
+        expected_app = get_wechat_app_path()
+        if expected_app is None:
+            return KeyRecoveryResult("failed", reason="target_identity_unavailable")
+    target = select_wechat_scan_target(expected_app)
     if target is None:
         return KeyRecoveryResult("failed", reason="target_identity_unavailable")
     pid = target.pid

--- a/core/monitor_result.py
+++ b/core/monitor_result.py
@@ -1,0 +1,46 @@
+"""Shared interpretation of monitor outcomes; unknown results never progress.
+
+This module does not run work, mutate cursors, or infer commit success from an
+arbitrary payload. The progress codes below belong to TopicMonitor's existing
+post-commit result contract. New codes stop catch-up until explicitly admitted.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import re
+from typing import Literal
+
+
+_PROGRESS_CODES = frozenset({
+    "no_match", "notified", "duplicate", "cooldown", "source_advanced_no_visible",
+})
+_STATUS_RE = re.compile(r"[a-z][a-z0-9_]{0,79}\Z")
+
+
+def monitor_status(value) -> str:
+    """Return a bounded content-free code, never a chat/error message."""
+    if not isinstance(value, str) or _STATUS_RE.fullmatch(value) is None:
+        return "unknown"
+    return value
+
+
+@dataclass(frozen=True)
+class MonitorOutcome:
+    code: str
+    action: Literal["progress", "complete", "blocked"]
+    reason: str = ""
+
+
+def classify_monitor_result(result) -> MonitorOutcome:
+    """Positive progress allowlist shared by operational consumers."""
+    if not isinstance(result, Mapping):
+        return MonitorOutcome("unknown", "blocked", "monitor_result_invalid")
+    code = monitor_status(result.get("status"))
+    if code == "no_messages":
+        if result.get("source_eof") is True:
+            return MonitorOutcome(code, "complete")
+        return MonitorOutcome(code, "blocked", "source_eof_unverified")
+    if code in _PROGRESS_CODES:
+        return MonitorOutcome(code, "progress")
+    return MonitorOutcome(code, "blocked", code)

--- a/core/url_safety.py
+++ b/core/url_safety.py
@@ -93,6 +93,16 @@ def sensitive_url_key(value) -> bool:
         return False
     if compact in _SENSITIVE_COMPACT_KEYS:
         return True
+    # Preserve word boundaries before case folding: shareToken, JWTToken,
+    # download_token and my-secret are credential names too. Matching whole
+    # components avoids redacting ordinary words such as tokenization.
+    words = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", str(value or ""))
+    words = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", words)
+    components = set(re.findall(r"[a-z0-9]+", words.casefold()))
+    if any(re.fullmatch(r"(?:token|secret|jwt)[0-9]*", word) for word in components):
+        return True
+    if re.search(r"(?:token|secret|jwt)[0-9]*$", compact):
+        return True
     return any(
         marker in compact
         for marker in (

--- a/core/wechat_resign.py
+++ b/core/wechat_resign.py
@@ -205,38 +205,10 @@ def verify_resigned_wechat_bundle(
     *,
     runner=subprocess.run,
 ) -> WeChatBundleIdentity:
-    verify = runner(
-        [
-            "codesign", "--verify", "--deep", "--strict", "--verbose=2",
-            expected.app_path,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    if verify.returncode:
-        raise WeChatResignError("wechat_signature_invalid")
-    display = runner(
-        ["codesign", "--display", "--verbose=4", expected.app_path],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    if display.returncode:
-        raise WeChatResignError("wechat_signature_invalid")
-    detail = "\n".join((display.stdout or "", display.stderr or ""))
-    signature = next(
-        (line.strip() for line in detail.splitlines() if line.strip().startswith("Signature=")),
-        "",
-    )
-    flags = next(
-        (line.strip() for line in detail.splitlines() if re.search(r"\bflags=", line)),
-        "",
-    )
-    if signature != "Signature=adhoc":
-        raise WeChatResignError("wechat_signature_not_adhoc")
-    if not flags or re.search(r"\bruntime\b", flags, flags=re.IGNORECASE):
-        raise WeChatResignError("wechat_hardened_runtime_still_enabled")
+    from .wechat_signature import inspect_wechat_signature
+    status = inspect_wechat_signature(expected.app_path, runner=runner)
+    if not status.ok:
+        raise WeChatResignError(status.code)
     observed = inspect_wechat_bundle(expected.app_path)
     if not _same_post_sign_bundle(expected, observed):
         raise WeChatResignError("wechat_target_changed")

--- a/core/wechat_signature.py
+++ b/core/wechat_signature.py
@@ -1,0 +1,60 @@
+"""One read-only codesign predicate for startup, health, and explicit re-sign.
+
+No discovery, privilege escalation, process control, or source reads occur here.
+A caller supplies the already selected app path. This is a macOS adapter; its
+subprocess runner is injectable so signature parsing can be tested off-device.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import subprocess
+
+
+@dataclass(frozen=True)
+class WeChatSignatureStatus:
+    code: str
+
+    @property
+    def ok(self) -> bool:
+        return self.code == "wechat_signature_valid"
+
+
+def inspect_wechat_signature(app_path, *, runner=None) -> WeChatSignatureStatus:
+    """Require strict verification, ad-hoc identity, and no runtime flag."""
+    if not isinstance(app_path, str) or not app_path or "\0" in app_path:
+        return WeChatSignatureStatus("wechat_signature_unavailable")
+    run = runner if runner is not None else subprocess.run
+    try:
+        verified = run(
+            ["/usr/bin/codesign", "--verify", "--deep", "--strict", "--verbose=2", app_path],
+            capture_output=True, text=True, timeout=60,
+        )
+        if verified.returncode != 0:
+            return WeChatSignatureStatus("wechat_signature_invalid")
+        displayed = run(
+            ["/usr/bin/codesign", "--display", "--verbose=4", app_path],
+            capture_output=True, text=True, timeout=60,
+        )
+        if displayed.returncode != 0:
+            return WeChatSignatureStatus("wechat_signature_invalid")
+        detail = "\n".join((displayed.stdout or "", displayed.stderr or ""))
+        signatures = [line.strip() for line in detail.splitlines()
+                      if line.strip().startswith("Signature=")]
+        if signatures != ["Signature=adhoc"]:
+            return WeChatSignatureStatus("wechat_signature_not_adhoc")
+        directories = [line.strip() for line in detail.splitlines()
+                       if line.strip().startswith("CodeDirectory ")]
+        if not directories:
+            return WeChatSignatureStatus("wechat_signature_invalid")
+        for directory in directories:
+            flags = re.search(r"\bflags=(0x[0-9a-fA-F]+)\b", directory)
+            if flags is None:
+                return WeChatSignatureStatus("wechat_signature_invalid")
+            # CS_RUNTIME is 0x10000; inspect CodeDirectory flags only, never
+            # a path or unrelated codesign text that happens to say runtime.
+            if int(flags.group(1), 16) & 0x10000:
+                return WeChatSignatureStatus("wechat_hardened_runtime_still_enabled")
+        return WeChatSignatureStatus("wechat_signature_valid")
+    except (OSError, subprocess.SubprocessError, TypeError, ValueError, AttributeError):
+        return WeChatSignatureStatus("wechat_signature_unavailable")

--- a/docs/WINDOWS-PORT-MAP.md
+++ b/docs/WINDOWS-PORT-MAP.md
@@ -82,12 +82,14 @@ root, `ai/`, `core/`, `ui/`, and `scripts/` Python module and imports every
 | `core/google_drive_file_sync.py` | `deferred-w0.2` | Direct `fcntl` and attachment/config dependencies; Windows activation is later. |
 | `core/image_decoder.py` | `windows-import-safe` | Platform-neutral byte decoding. |
 | `core/key_extractor.py` | `macos-only` | macOS process scanner, codesign, sudo, and osascript source adapter. |
+| `core/wechat_signature.py` | `macos-only` | Shared read-only macOS codesign predicate; injectable runner only, no Windows signature or key support. |
 | `core/keychain.py` | `macos-only` | macOS `security` adapter; shared secret contract is defined for W0.3 wiring. |
 | `core/knowledge.py` | `deferred-w0.2` | Transitively imports ConfigStore/path/private storage; Windows activation is W3. |
 | `core/launch_agent.py` | `macos-only` | macOS LaunchAgent adapter; Windows autostart is W6. |
 | `core/link_preview.py` | `windows-import-safe` | Platform-neutral exact URL extraction plus inert zero-network compatibility receipts; remote preview is retired. |
 | `core/mcp_config.py` | `windows-import-safe` | Pure configuration rendering; Windows command emission is activated later. |
 | `core/monitor.py` | `deferred-w0.2` | Transitively imports config/knowledge/review storage; Windows activation is W3. |
+| `core/monitor_result.py` | `windows-import-safe` | Pure bounded outcome interpretation; unknown results block catch-up. No platform or product activation. |
 | `core/monitor_source.py` | `windows-import-safe` | Pure bounded source-cursor merge helper; platform storage remains owned by callers. |
 | `core/monitor_state.py` | `windows-import-safe` | W0.2A shared/exclusive locking and revision CAS are portable; Windows monitor activation remains W3. |
 | `core/notification_identity.py` | `macos-only` | Foundation/app-bundle notification identity diagnostics. |

--- a/docs/reliability-closure.md
+++ b/docs/reliability-closure.md
@@ -1,0 +1,100 @@
+# Reliability closure: bounded source candidate
+
+Base: `9ab1eeab25d1e7450e7c1fc9eef8b5fb55e60f3b` (merged recovery PR #18).
+This change preserves the existing process topology, persisted schema versions,
+source-cursor identities and Windows staging. It does not authorize deployment.
+
+## Changed behavior
+
+The session binding `WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH` is resolved before
+ordinary application discovery. The launcher forwards an inherited binding or
+`--wechat-app=...` to Python, including its health entrypoint. A binding that is
+empty or unavailable blocks; it never silently falls back to another copy.
+This binding remains session-local. No LaunchAgent or persistent config is
+changed, and a separately launched process does not inherit it automatically.
+
+`core/wechat_signature.py` provides the common read-only predicate for the
+launcher, `is_wechat_signed()`, and explicit re-sign verification. It invokes
+`/usr/bin/codesign`, requires strict verification and exactly one ad-hoc
+signature result, and reads the numeric `CS_RUNTIME` bit from CodeDirectory
+flags. Paths containing the word `runtime` do not cause a false rejection.
+Missing or malformed verification evidence fails closed with a bounded code.
+The caller still owns exact bundle/process binding around mutation. This
+predicate is not an atomic filesystem identity or process-termination proof.
+
+URL redaction now recognizes `token`, `secret`, and `jwt` word components in
+snake_case, kebab-case, camelCase, dotted and bracketed names, plus compact
+credential suffixes. Query duplicates and routed fragments use the same helper.
+Private canonical URL identity is unchanged. Arbitrary unknown parameter names,
+path-embedded credentials, and credentials outside URLs are not made safe by
+this finite name policy; do not advertise universal secret detection.
+
+`core/monitor_result.py` interprets the existing TopicMonitor result contract.
+Only known post-commit progress statuses consume catch-up page budget. All
+other statuses stop that chat and preserve their bounded reason; a payload
+with no valid status is not success. `no_messages` completes only with
+`source_eof is True`. This is consumer classification, not a new commit ledger.
+Preflight errors retain their source reason in each chat receipt rather than
+being collapsed into missing-checkpoint errors. No source replay is authorized.
+
+A failed provisional receipt remains a failure for the whole catch-up run.
+The app lock is released and original LaunchAgent restoration is still
+attempted. A later successful final write records the missing evidence and
+cannot report `complete` or advertise safe automatic resume. If final
+publication fails, console success and a zero exit status are withheld. A
+failure after rename has an ambiguous durability outcome: inspect the recorded
+receipt and command outcome before retrying; visible bytes alone are not proof
+that the failed publication completed durably. The receipt schema stays v1.
+
+Health preserves the newest bounded result code, including unfamiliar stop
+codes, without substituting an older success. Its direct
+`check_new_databases()` import/call is removed. Key coverage comes from the
+existing durable inventory; current page-one verification belongs to explicit
+refresh. Other health subsystems are unchanged by this patch.
+
+## Regression and acceptance
+
+New repository-native tests:
+
+- `tests.test_reliability_closure_modules`: redaction, shared signature predicate,
+  positive outcome allowlist, malformed/unknown payloads and verified EOF.
+- `tests.test_operator_reliability_closure`: session binding, actual catch-up
+  orchestration and receipt writer with mocked external services, preflight
+  reasons, sticky write failures, and health source-scan exclusion.
+
+All test data is synthetic and temporary. Never run these by importing a live
+operator environment. Set a temporary HOME and data directory before imports:
+
+```bash
+TEST_HOME="$(mktemp -d)"
+export HOME="$TEST_HOME"
+export WE_GROUPCHAT_OBSIDIAN_DATA_DIR="$TEST_HOME/wgo-data"
+unset WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH
+unset WE_GROUPCHAT_OBSIDIAN_ALLOW_RESIGN WECHAT_SUMMARY_ALLOW_RESIGN
+# PYTHON must be an absolute path to an existing approved project interpreter.
+"$PYTHON" -m unittest tests.test_reliability_closure_modules tests.test_operator_reliability_closure
+"$PYTHON" -m unittest tests.test_wechat_resign tests.test_key_extractor tests.test_catch_up_monitor tests.test_health_check tests.test_startup_helpers
+"$PYTHON" -m unittest discover -s tests -t . -p 'test_*.py'
+"$PYTHON" -m compileall -q app.py mcp_server.py setup.py ai core ui scripts tests
+for launcher in 启动.command launchers/*.command; do bash -n "$launcher" || exit; done
+```
+
+The authoring environment could read pinned GitHub source but could not obtain
+a complete checkout. Its evidence is limited to isolated unit checks on captured
+production functions and the new modules. Full repository imports/tests, actual
+patch applicability to the complete tree, existing regression fixtures, and the
+hosted Windows/macOS matrix require native acceptance. Record that result
+separately; do not copy isolated test counts into full-suite claims.
+
+## Deliberately unclosed
+
+Generation-admission execution and stable-prefix/bounded replay migration;
+same-second cross-shard ordering; optional resource-backup completeness and
+symlink inspection; Digest concurrent-publication behavior; scanner build and
+re-sign race boundaries; durable custom-target autostart; installed bundle and
+live AppKit/task-memory/sleep-wake acceptance; release artifacts, tags, and
+upgrade/downgrade guarantees. None is implicitly approved by this patch.
+
+No real chats, keys, config, checkpoints, source databases, mounted targets,
+provider requests, permissions, app signatures or LaunchAgents are changed by
+source-only acceptance. Keep the existing long-lived macOS process boundary.

--- a/docs/reliability-closure.md
+++ b/docs/reliability-closure.md
@@ -25,6 +25,9 @@ predicate is not an atomic filesystem identity or process-termination proof.
 URL redaction now recognizes `token`, `secret`, and `jwt` word components in
 snake_case, kebab-case, camelCase, dotted and bracketed names, plus compact
 credential suffixes. Query duplicates and routed fragments use the same helper.
+The app-level monitor error handler applies that helper before writing its
+structured `monitor_runtime_error` line or sending a notification, and monitor
+tracebacks redact URLs before reaching the error log.
 Private canonical URL identity is unchanged. Arbitrary unknown parameter names,
 path-embedded credentials, and credentials outside URLs are not made safe by
 this finite name policy; do not advertise universal secret detection.
@@ -46,8 +49,10 @@ failure after rename has an ambiguous durability outcome: inspect the recorded
 receipt and command outcome before retrying; visible bytes alone are not proof
 that the failed publication completed durably. The receipt schema stays v1.
 
-Health preserves the newest bounded result code, including unfamiliar stop
-codes, without substituting an older success. Its direct
+Health treats the newest monitor event as authoritative. It preserves a bounded
+result code, including unfamiliar stop codes, and reports an unstructured event
+as `unknown` without substituting an older success. App-level failures use the
+bounded `monitor_runtime_error` code. Its direct
 `check_new_databases()` import/call is removed. Key coverage comes from the
 existing durable inventory; current page-one verification belongs to explicit
 refresh. Other health subsystems are unchanged by this patch.

--- a/launchers/启动.command
+++ b/launchers/启动.command
@@ -20,8 +20,11 @@ BACKFILL_HISTORY=0
 ORGANIZE_OBSIDIAN=0
 HEALTH_CHECK=0
 REFRESH_DATA_SOURCE=0
-WECHAT_APP_PATH_ARG=""
+WECHAT_APP_PATH_ARG="${WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH-}"
 WECHAT_EXPLICIT_TARGET=0
+if [[ "${WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH+x}" == "x" ]]; then
+    WECHAT_EXPLICIT_TARGET=1
+fi
 INSTALL_AUTOSTART=0
 UNINSTALL_AUTOSTART=0
 AUTOSTART_MODE=0
@@ -67,6 +70,12 @@ for arg in "$@"; do
     esac
 done
 
+# Carry the same binding into health/refresh entrypoints too. An explicit empty
+# value is retained so the shared resolver rejects it instead of rediscovering.
+if [[ "$WECHAT_EXPLICIT_TARGET" -eq 1 ]]; then
+    export WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH="$WECHAT_APP_PATH_ARG"
+fi
+
 pause_and_exit() {
     local exit_code="$1"
     if [[ "${WE_GROUPCHAT_OBSIDIAN_NO_PAUSE:-${WECHAT_SUMMARY_NO_PAUSE:-0}}" == "1" || "$AUTOSTART_MODE" -eq 1 ]]; then
@@ -77,24 +86,14 @@ pause_and_exit() {
 }
 
 get_wechat_app_path() {
-    local app_path=""
-    if [[ -n "$WECHAT_APP_PATH_ARG" ]]; then
-        if [[ -d "$WECHAT_APP_PATH_ARG" ]]; then
-            (cd "$WECHAT_APP_PATH_ARG" && pwd -P)
-            return 0
-        fi
-        return 1
-    fi
-    app_path="$(osascript -e 'POSIX path of (path to application "WeChat")' 2>/dev/null | tr -d '\r')"
-    if [[ -n "$app_path" && -d "$app_path" ]]; then
-        printf '%s\n' "${app_path%/}"
-        return 0
-    fi
-    if [[ -d "/Applications/WeChat.app" ]]; then
-        printf '%s\n' "/Applications/WeChat.app"
-        return 0
-    fi
-    return 1
+    "$PYTHON_BIN" -c '
+from core.key_extractor import get_wechat_app_path
+import sys
+path = get_wechat_app_path()
+if not path:
+    sys.exit(1)
+print(path)
+'
 }
 
 ensure_xcode_cli() {
@@ -249,26 +248,11 @@ ensure_venv() {
 }
 
 is_wechat_signed() {
-    local app_path="$1"
-    local codesign_output=""
-
-    if ! codesign --verify --deep --strict "$app_path" &>/dev/null; then
-        return 1
-    fi
-
-    if ! codesign_output="$(codesign -dvv "$app_path" 2>&1)"; then
-        return 1
-    fi
-
-    if printf '%s\n' "$codesign_output" | grep -qi "runtime"; then
-        return 1
-    fi
-
-    if ! printf '%s\n' "$codesign_output" | grep -qx "Signature=adhoc"; then
-        return 1
-    fi
-
-    return 0
+    "$PYTHON_BIN" -c '
+from core.wechat_signature import inspect_wechat_signature
+import sys
+sys.exit(0 if inspect_wechat_signature(sys.argv[1]).ok else 1)
+' "$1"
 }
 
 ensure_wechat_signed() {

--- a/scripts/catch_up_monitor.py
+++ b/scripts/catch_up_monitor.py
@@ -200,6 +200,7 @@ def drain_monitors(
     max_minutes: int,
     monotonic=time.monotonic,
 ) -> dict:
+    from core.monitor_result import classify_monitor_result
     deadline = monotonic() + max_minutes * 60
     page_counts = Counter()
     statuses = Counter()
@@ -238,35 +239,21 @@ def drain_monitors(
             try:
                 result = monitor.check_once()
             except Exception as exc:
-                block(username, f"{type(exc).__name__}: {exc}")
+                block(username, type(exc).__name__)
                 continue
 
-            status = str(result.get("status") or "unknown")
+            outcome = classify_monitor_result(result)
+            status = outcome.code
             statuses[status] += 1
             chat_statuses = Counter(per_chat[username]["statuses"])
             chat_statuses[status] += 1
             per_chat[username]["statuses"] = dict(chat_statuses)
-            if status == "no_messages":
-                if result.get("source_eof") is True:
-                    complete.add(username)
-                    per_chat[username]["outcome"] = "complete"
-                else:
-                    block(username, "source_eof_unverified")
+            if outcome.action == "complete":
+                complete.add(username)
+                per_chat[username]["outcome"] = "complete"
                 continue
-            if status in {
-                "ai_backoff",
-                "initialized",
-                "missing_topic",
-                "monitor_state_conflict",
-                "monitor_source_cursors_corrupt",
-                "source_generation_changed",
-                "source_inventory_incomplete",
-                "source_inventory_invalid",
-                "source_inventory_unavailable",
-                "source_shard_unavailable",
-                "source_message_decode_failed",
-            }:
-                block(username, status)
+            if outcome.action == "blocked":
+                block(username, outcome.reason)
                 continue
 
             page_counts[username] += 1
@@ -564,13 +551,15 @@ def validate_knowledge_db(config: dict) -> dict:
 
 
 def _print_audit(rows: list[dict]) -> None:
+    from core.monitor_result import monitor_status
     print("补跑审计（只读）")
     total = 0
     unknown = False
     for row in rows:
         if row["count"] is None:
             unknown = True
-            value = "无法补跑：缺少 checkpoint"
+            reason = monitor_status(row.get("reason") or "missing_checkpoint")
+            value = f"无法补跑：{reason}"
         else:
             total += row["count"]
             value = f"{row['count']}{'+' if row['capped'] else ''} 条待处理"
@@ -614,13 +603,29 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
     _print_audit(audit)
     missing = [row["name"] for row in audit if row["count"] is None]
     if missing:
+        from core.monitor_result import monitor_status
+        blocked = {
+            row["username"]: monitor_status(row.get("reason") or "missing_checkpoint")
+            for row in audit if row["count"] is None
+        }
+        preflight_error = (
+            "missing_checkpoint"
+            if set(blocked.values()) == {"missing_checkpoint"}
+            else "source_preflight_blocked"
+        )
         receipt = build_reconciliation_receipt(
             run_id=run_id,
             started_at=started_at,
             chats=chats,
             audit=audit,
             checkpoints_after={chat["username"]: _checkpoint_for_chat(chat["username"]) for chat in chats},
-            result=None,
+            result={
+                "blocked": blocked,
+                "per_chat": {
+                    username: {"outcome": "blocked", "blocked_reason": reason}
+                    for username, reason in blocked.items()
+                },
+            },
             projections=None,
             validation=None,
             backup_path=None,
@@ -631,11 +636,11 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
                 "restored": None,
                 "error": "",
             },
-            transaction_error="missing_checkpoint",
-            outcome_override="missing_checkpoint",
+            transaction_error=preflight_error,
+            outcome_override=preflight_error,
         )
         receipt_path = write_reconciliation_receipt(receipt)
-        print("拒绝写入：这些群没有可恢复 checkpoint：" + "、".join(missing))
+        print("拒绝推进：" + ", ".join(sorted(set(blocked.values()))))
         print(f"reconciliation receipt: {receipt_path}")
         return 2
     if all(row["count"] == 0 for row in audit):
@@ -674,6 +679,7 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
     receipt_path = None
     receipt = None
     provisional_receipt = None
+    provisional_receipt_failed = False
     result = None
     projections = None
     validation = None
@@ -700,8 +706,12 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
             validation=validation,
             backup_path=backup_path,
             launch_agent=launch_agent,
-            transaction_error=transaction_error,
-            outcome_override=outcome_override,
+            transaction_error=transaction_error or (
+                "provisional_receipt_failed" if provisional_receipt_failed else ""
+            ),
+            outcome_override=outcome_override or (
+                "provisional_receipt_failed" if provisional_receipt_failed else ""
+            ),
         )
 
     try:
@@ -749,9 +759,11 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
         try:
             receipt_path = write_reconciliation_receipt(provisional_receipt)
         except Exception as exc:
-            receipt_error = f"{type(exc).__name__}: {exc}"
+            provisional_receipt_failed = True
+            receipt_error = f"provisional_receipt_failed:{type(exc).__name__}"
     except Exception as exc:
-        receipt_error = f"{type(exc).__name__}: {exc}"
+        provisional_receipt_failed = True
+        receipt_error = f"provisional_receipt_failed:{type(exc).__name__}"
     finally:
         try:
             if instance_lock is not None:
@@ -767,16 +779,21 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
                     launch_agent["restored"] = False
                     launch_agent["error"] = restore_error
 
-    if original_status and original_status.loaded:
+    if (original_status and original_status.loaded) or provisional_receipt_failed:
         try:
             final_receipt = current_receipt()
             final_path = write_reconciliation_receipt(final_receipt)
         except Exception as exc:
-            receipt_error = f"{type(exc).__name__}: {exc}"
+            receipt_error = receipt_error or f"final_receipt_failed:{type(exc).__name__}"
+            # Never print an in-memory complete result after publication failed.
+            if receipt is not None:
+                receipt = dict(receipt)
+                receipt["state"] = "partial" if result else "failed"
+                receipt["outcome"] = "receipt_publication_failed"
         else:
             receipt = final_receipt
             receipt_path = final_path
-            receipt_error = ""
+            # A later successful write cannot supply the missing locked receipt.
 
     if receipt is None:
         print("补跑结果不可用：reconciliation_receipt_failed")

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -22,7 +22,6 @@ from core.knowledge import TAXONOMY_PROFILES
 from core.link_preview import LINK_PREVIEW_STATE
 from core.key_extractor import (
     EXTRACT_LOG,
-    check_new_databases,
     get_cached_keys,
     is_wechat_running,
     is_wechat_signed,
@@ -54,23 +53,7 @@ from core.wechat_source_guard import source_guard_status
 AUTOSTART_ERR_LOG = Path(DATA_DIR) / "logs" / "autostart.err.log"
 AUTOSTART_OUT_LOG = Path(DATA_DIR) / "logs" / "autostart.out.log"
 
-_MONITOR_RUNTIME_STATES = frozenset({
-    "ai_backoff",
-    "cooldown",
-    "duplicate",
-    "initialized",
-    "missing_topic",
-    "monitor_source_cursors_corrupt",
-    "monitor_state_conflict",
-    "monitor_state_corrupt",
-    "monitor_state_missing_checkpoint",
-    "no_match",
-    "no_messages",
-    "notified",
-    "source_advanced_no_visible",
-    "source_generation_changed",
-    "source_inventory_incomplete",
-})
+# Outcome codes are normalized by core.monitor_result, not a second allowlist.
 
 
 def ok(value: bool) -> str:
@@ -221,7 +204,8 @@ def _sensitive_log_status(delete: bool = False) -> tuple[str, bool]:
 def latest_monitor_runtime_result(
     path: str | os.PathLike[str] = AUTOSTART_OUT_LOG,
 ) -> str:
-    """Return the last content-free monitor result code from the app log."""
+    """Return the latest code without falling back to an older healthy outcome."""
+    from core.monitor_result import monitor_status
     try:
         lines = Path(path).read_text(
             encoding="utf-8", errors="replace"
@@ -233,8 +217,8 @@ def latest_monitor_runtime_result(
         if text.startswith("[monitor] 命中["):
             return "notified"
         match = re.match(r"^\[monitor\]\s+([a-z][a-z0-9_]*)(?::|$)", text)
-        if match and match.group(1) in _MONITOR_RUNTIME_STATES:
-            return match.group(1)
+        if match:
+            return monitor_status(match.group(1))
     return "unknown"
 
 
@@ -681,13 +665,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[{ok(not key_log_warn)}] Sensitive key extraction log: {key_log_status}")
     print("")
 
-    if keys and db_dir and os.path.isdir(db_dir):
-        missing = check_new_databases(db_dir, keys)
-        if missing:
-            print(f"[WARN] New encrypted DBs missing keys: {len(missing)} 个")
-            print("      微信更新/新增数据库后，可能需要重新运行 ./启动.command 提取 key。")
-        else:
-            print("[OK] New encrypted DBs missing keys: 0 个")
+    print("Source key coverage: durable inventory only; no protected-source scan performed.")
     return 0
 
 

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -214,11 +214,16 @@ def latest_monitor_runtime_result(
         return "unknown"
     for line in reversed(lines):
         text = line.strip()
+        if not text.startswith("[monitor]"):
+            continue
         if text.startswith("[monitor] 命中["):
             return "notified"
         match = re.match(r"^\[monitor\]\s+([a-z][a-z0-9_]*)(?::|$)", text)
         if match:
             return monitor_status(match.group(1))
+        # The newest monitor event is authoritative. An unstructured event is
+        # unknown, never permission to reuse an older healthy result.
+        return "unknown"
     return "unknown"
 
 

--- a/tests/test_app_monitor_resilience.py
+++ b/tests/test_app_monitor_resilience.py
@@ -1,5 +1,7 @@
 import threading
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from unittest.mock import patch
 
 from app import WeGroupchatObsidianApp
@@ -149,6 +151,59 @@ class AppMonitorResilienceTests(unittest.TestCase):
 
             app._handle_monitor_error("manual provider timeout", manual=True)
             notify.assert_called_once()
+
+    def test_monitor_error_redacts_compound_credentials_in_log_and_notification(self):
+        app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
+        app.config = {"background_notifications_enabled": True}
+        app._monitor_last_error = ""
+        output = StringIO()
+
+        with redirect_stdout(output), patch("app._notify") as notify:
+            app._handle_monitor_error(
+                "检查失败: https://example.test/callback?shareToken=PRIVATE_SENTINEL",
+                manual=False,
+            )
+
+        self.assertNotIn("PRIVATE_SENTINEL", output.getvalue())
+        self.assertIn("monitor_runtime_error", output.getvalue())
+        notify.assert_called_once()
+        self.assertNotIn("PRIVATE_SENTINEL", str(notify.call_args))
+        self.assertIn("shareToken=REDACTED", str(notify.call_args))
+        self.assertNotIn("PRIVATE_SENTINEL", app._monitor_last_error)
+
+    def test_monitor_traceback_redacts_compound_credentials(self):
+        app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)
+        app._monitor_lock = threading.Lock()
+        app.config = {"background_notifications_enabled": False}
+        app._monitor_last_error = ""
+        app.db = RefreshingDB()
+        app._monitor_chats = lambda: [
+            {"username": "synthetic@chatroom", "name": "Synthetic"},
+        ]
+        app._handle_monitor_result = unittest.mock.Mock()
+
+        class FailingMonitor:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def check_once(self, dry_run=False):
+                raise RuntimeError(
+                    "https://example.test/callback?accessJWT2=PRIVATE_SENTINEL"
+                )
+
+        stdout = StringIO()
+        stderr = StringIO()
+        with (
+            patch("app.TopicMonitor", FailingMonitor),
+            patch("app._notify"),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            app._run_monitor_check(manual=False, dry_run=False)
+
+        rendered = stdout.getvalue() + stderr.getvalue()
+        self.assertNotIn("PRIVATE_SENTINEL", rendered)
+        self.assertIn("accessJWT2=REDACTED", rendered)
 
     def test_toggle_background_notifications_keeps_monitor_running(self):
         app = WeGroupchatObsidianApp.__new__(WeGroupchatObsidianApp)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from core.config import (
     ConfigConflictError,
     ConfigError,
     ConfigStore,
+    DATA_DIR,
     DEFAULT_CONFIG,
     _sanitize_config,
     active_monitor_chats,
@@ -211,11 +212,21 @@ class ConfigTests(unittest.TestCase):
             [{"username": "current@chatroom", "name": "Current Room"}],
         )
 
-    def test_default_runtime_paths_use_new_project_data_dir(self):
-        self.assertIn(".we-groupchat-obsidian", DEFAULT_CONFIG["keys_file"])
-        self.assertIn(".we-groupchat-obsidian", DEFAULT_CONFIG["decrypted_dir"])
-        self.assertIn(".we-groupchat-obsidian", DEFAULT_CONFIG["monitor_knowledge_db"])
-        self.assertIn(".we-groupchat-obsidian", DEFAULT_CONFIG["monitor_obsidian_root"])
+    def test_default_runtime_paths_follow_effective_project_data_dir(self):
+        self.assertEqual(
+            DEFAULT_CONFIG["keys_file"], os.path.join(DATA_DIR, "all_keys.json")
+        )
+        self.assertEqual(
+            DEFAULT_CONFIG["decrypted_dir"], os.path.join(DATA_DIR, "decrypted")
+        )
+        self.assertEqual(
+            DEFAULT_CONFIG["monitor_knowledge_db"],
+            os.path.join(DATA_DIR, "monitor_knowledge.db"),
+        )
+        self.assertEqual(
+            DEFAULT_CONFIG["monitor_obsidian_root"],
+            os.path.join(DATA_DIR, "obsidian_knowledge"),
+        )
 
     def test_legacy_default_paths_are_rebased_to_new_data_dir(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -120,6 +120,30 @@ class HealthCheckTests(unittest.TestCase):
             )
             self.assertEqual(latest_monitor_runtime_result(log), "notified")
 
+    def test_latest_monitor_runtime_result_does_not_skip_latest_unstructured_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "out.log"
+            log.write_text(
+                "[monitor] no_messages: earlier successful cycle\n"
+                "[monitor] Synthetic Chat: 检查失败: provider timeout\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(latest_monitor_runtime_result(log), "unknown")
+
+    def test_latest_monitor_runtime_result_reports_structured_runtime_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "out.log"
+            log.write_text(
+                "[monitor] no_messages: earlier successful cycle\n"
+                "[monitor] monitor_runtime_error: redacted failure\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                latest_monitor_runtime_result(log), "monitor_runtime_error"
+            )
+
     def test_source_inventory_health_is_read_only_and_counts_degradation(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -629,7 +629,7 @@ gui/501/com.example.wechat-summary = {
                          "last_error_code": "",
                      },
                  ), \
-                 patch("scripts.health_check.check_new_databases", return_value=[]), \
+                 patch("core.key_extractor.check_new_databases", side_effect=AssertionError("health must not scan source")), \
                  patch("scripts.health_check.EXTRACT_LOG", str(key_log)):
                 output = StringIO()
                 with redirect_stdout(output):

--- a/tests/test_operator_reliability_closure.py
+++ b/tests/test_operator_reliability_closure.py
@@ -1,0 +1,297 @@
+"""Repository-native regression tests; all live/process entrypoints are mocked.
+
+These tests exercise production orchestration and the actual receipt builder /
+writer against temporary files. They never open WeChat, provider, vault, or
+LaunchAgent state. Run with a temporary HOME before imports, as in AGENTS.md.
+"""
+import ast
+from contextlib import ExitStack, redirect_stdout
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+from core import key_extractor
+from scripts import catch_up_monitor as catchup
+from scripts import health_check
+
+
+class TargetBindingTests(unittest.TestCase):
+    def test_explicit_session_target_wins_over_default_installation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            default = Path(directory) / 'Default.app'
+            selected = Path(directory) / 'Selected WeChat.app'
+            default.mkdir()
+            selected.mkdir()
+            with (patch.object(key_extractor, 'DEFAULT_WECHAT_APP', str(default)),
+                  patch.dict(os.environ, {'WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH': str(selected)}),
+                  patch.object(key_extractor.subprocess, 'run') as run):
+                self.assertEqual(key_extractor.get_wechat_app_path(), str(selected.resolve()))
+                run.assert_not_called()
+
+    def test_invalid_or_empty_binding_never_falls_back(self):
+        with tempfile.TemporaryDirectory() as directory:
+            default = Path(directory) / 'Default.app'
+            default.mkdir()
+            for value in ('', '  ', str(Path(directory) / 'Missing.app')):
+                with self.subTest(value=value):
+                    with (patch.object(key_extractor, 'DEFAULT_WECHAT_APP', str(default)),
+                          patch.dict(os.environ, {'WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH': value}),
+                          patch.object(key_extractor.subprocess, 'run') as run):
+                        self.assertIsNone(key_extractor.get_wechat_app_path())
+                        run.assert_not_called()
+
+    def test_unset_binding_retains_default_discovery(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with (patch.object(key_extractor, 'DEFAULT_WECHAT_APP', directory),
+                  patch.dict(os.environ, {}, clear=True)):
+                self.assertEqual(key_extractor.get_wechat_app_path(), directory)
+
+    def test_runtime_signature_uses_selected_path_and_strict_verification(self):
+        with tempfile.TemporaryDirectory() as directory:
+            selected = Path(directory) / 'Selected.app'
+            selected.mkdir()
+            completed = [
+                subprocess.CompletedProcess([], 0, '', ''),
+                subprocess.CompletedProcess([], 0, '', 'CodeDirectory flags=0x2(adhoc)\nSignature=adhoc\n'),
+            ]
+            with (patch.dict(os.environ, {'WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH': str(selected)}),
+                  patch.object(key_extractor.subprocess, 'run', side_effect=completed) as run):
+                self.assertTrue(key_extractor.is_wechat_signed())
+                self.assertEqual(run.call_count, 2)
+                self.assertIn('--verify', run.call_args_list[0].args[0])
+                self.assertIn('--strict', run.call_args_list[0].args[0])
+                for call in run.call_args_list:
+                    self.assertEqual(call.args[0][-1], str(selected.resolve()))
+
+    def test_invalid_binding_stops_recovery_before_process_selection(self):
+        with (patch.dict(os.environ, {'WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH': ''}),
+              patch.object(key_extractor, '_read_keys_file', return_value={}),
+              patch.object(key_extractor, 'select_wechat_scan_target', return_value=None) as select):
+            result = key_extractor.recover_keys()
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, 'target_identity_unavailable')
+        select.assert_not_called()
+
+
+class DrainClosureTests(unittest.TestCase):
+    def test_source_and_unknown_failures_do_not_burn_page_budget(self):
+        for code in ('source_generation_admission_required', 'source_page_invalid',
+                     'source_cursor_stalled', 'source_envelope_invalid',
+                     'knowledge_recovery_unavailable', 'future_stop_state'):
+            with self.subTest(code=code):
+                monitor = Mock()
+                monitor.check_once.return_value = {'status': code}
+                result = catchup.drain_monitors(
+                    [({'username': 'fixture', 'name': 'Synthetic'}, monitor)], 10, 1)
+                self.assertEqual(result['blocked'], {'fixture': code})
+                self.assertEqual(result['pages'], {})
+                monitor.check_once.assert_called_once()
+
+    def test_real_progress_then_verified_eof_still_completes(self):
+        monitor = Mock()
+        monitor.check_once.side_effect = [
+            {'status': 'no_match', 'raw_message_count': 1},
+            {'status': 'no_messages', 'source_eof': True},
+        ]
+        result = catchup.drain_monitors(
+            [({'username': 'fixture', 'name': 'Synthetic'}, monitor)], 10, 1)
+        self.assertEqual(result['complete'], ['fixture'])
+        self.assertEqual(result['pages'], {'fixture': 1})
+
+    def test_invalid_result_stops_and_does_not_expose_message(self):
+        for payload in (None, {'status': 'PRIVATE_SENTINEL: payload'}):
+            with self.subTest(payload=payload):
+                monitor = Mock()
+                monitor.check_once.return_value = payload
+                result = catchup.drain_monitors(
+                    [({'username': 'fixture', 'name': 'Synthetic'}, monitor)], 10, 1)
+                self.assertEqual(result['pages'], {})
+                self.assertNotIn('PRIVATE_SENTINEL', json.dumps(result))
+                monitor.check_once.assert_called_once()
+
+
+class PreflightOutcomeTests(unittest.TestCase):
+    def test_preflight_preserves_source_failure_without_launch_or_cursor_work(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            chat = {'username': 'fixture', 'name': 'Synthetic'}
+            for reason in ('source_generation_admission_required', 'source_page_invalid', '',
+                           'PRIVATE_SENTINEL: payload'):
+                with self.subTest(reason=reason), ExitStack() as stack:
+                    audit = [{'username': 'fixture', 'name': 'Synthetic', 'checkpoint': 10,
+                              'count': None, 'capped': False, 'reason': reason}]
+                    receipts = []
+                    real_write = catchup.write_reconciliation_receipt
+                    def write(receipt):
+                        path = real_write(receipt, receipts_dir=root / 'receipts')
+                        receipts.append(json.loads(path.read_text(encoding='utf-8')))
+                        return path
+                    stack.enter_context(patch.object(catchup, 'audit_pending', return_value=audit))
+                    stack.enter_context(patch.object(catchup, '_checkpoint_for_chat', return_value=10))
+                    stack.enter_context(patch.object(catchup, 'state_file_for_chat', return_value=str(root / 'state.json')))
+                    stack.enter_context(patch.object(catchup, 'write_reconciliation_receipt', side_effect=write))
+                    launch = stack.enter_context(patch.object(catchup, 'launch_agent_report'))
+                    drain = stack.enter_context(patch.object(catchup, 'drain_monitors'))
+                    output = io.StringIO()
+                    stack.enter_context(redirect_stdout(output))
+                    code = catchup.apply_catch_up({}, [chat], object(), SimpleNamespace(audit_limit=100))
+                    launch.assert_not_called()
+                    drain.assert_not_called()
+                    expected = reason or 'missing_checkpoint'
+                    if ':' in expected:
+                        expected = 'unknown'
+                    self.assertEqual(code, 2)
+                    self.assertEqual(receipts[-1]['state'], 'failed')
+                    self.assertEqual(receipts[-1]['chats'][0]['blocked_reason'], expected)
+                    self.assertEqual(receipts[-1]['chats'][0]['pages'], 0)
+                    self.assertIn(expected, output.getvalue())
+                    self.assertNotIn('PRIVATE_SENTINEL', output.getvalue())
+
+
+class ReceiptPublicationTests(unittest.TestCase):
+    def run_case(self, *, loaded=True, failed_writes=(), post_write_failures=(), restore_fails=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            chat = {'username': 'fixture', 'name': 'Synthetic'}
+            audit = [{'username': 'fixture', 'name': 'Synthetic', 'checkpoint': 10,
+                      'count': 1, 'capped': False}]
+            drained = {'complete': ['fixture'], 'blocked': {}, 'pages': {'fixture': 1},
+                       'statuses': {'no_match': 1}, 'affected_dates': [],
+                       'per_chat': {'fixture': {'pages': 1, 'statuses': {'no_match': 1},
+                           'event_ids': [], 'affected_dates': [], 'outcome': 'complete',
+                           'blocked_reason': ''}}}
+            lock_state = {'held': False}
+            lock = Mock()
+            def acquire():
+                lock_state['held'] = True
+                return lock
+            def release():
+                lock_state['held'] = False
+            lock.acquire.side_effect = acquire
+            lock.release.side_effect = release
+            attempts, persisted = [], []
+            real_write = catchup.write_reconciliation_receipt
+            def write(receipt):
+                attempts.append({'held': lock_state['held'], 'receipt': dict(receipt)})
+                if len(attempts) in failed_writes:
+                    raise OSError('PRIVATE_SENTINEL')
+                path = real_write(receipt, receipts_dir=root / 'receipts')
+                persisted.append(json.loads(path.read_text(encoding='utf-8')))
+                if len(attempts) in post_write_failures:
+                    raise OSError('PRIVATE_SENTINEL after publication')
+                return path
+            stdout = io.StringIO()
+            with ExitStack() as stack:
+                patches = {
+                    'audit_pending': {'return_value': audit},
+                    '_print_audit': {},
+                    'launch_agent_report': {'return_value': (SimpleNamespace(label='fixture'), SimpleNamespace(loaded=loaded))},
+                    '_stop_launch_agent': {},
+                    '_restore_launch_agent': {'side_effect': OSError('restore failed')} if restore_fails else {},
+                    'AppInstanceLock': {'return_value': lock},
+                    'backup_runtime_state': {'return_value': root / 'backup'},
+                    'TopicMonitor': {},
+                    'drain_monitors': {'return_value': drained},
+                    'rebuild_projections': {'return_value': None},
+                    'validate_knowledge_db': {'return_value': {'ok': True}},
+                    '_checkpoint_for_chat': {'return_value': 11},
+                    'state_file_for_chat': {'return_value': str(root / 'fixture.json')},
+                    'write_reconciliation_receipt': {'side_effect': write},
+                }
+                mocked = {name: stack.enter_context(patch.object(catchup, name, **kwargs))
+                          for name, kwargs in patches.items()}
+                stack.enter_context(redirect_stdout(stdout))
+                code = catchup.apply_catch_up({}, [chat], object(), SimpleNamespace(
+                    audit_limit=100, max_pages_per_chat=10, max_minutes=1))
+                self.assertEqual(mocked['_restore_launch_agent'].call_count, 1 if loaded else 0)
+            lock.release.assert_called_once()
+            self.assertTrue(attempts[0]['held'])
+            for attempt in attempts[1:]:
+                self.assertFalse(attempt['held'])
+            return code, attempts, persisted, stdout.getvalue()
+
+    def test_provisional_failure_cannot_be_cleared_by_final_success(self):
+        code, attempts, persisted, output = self.run_case(failed_writes={1})
+        self.assertEqual(code, 1)
+        self.assertEqual(len(attempts), 2)
+        self.assertNotEqual(persisted[-1]['state'], 'complete')
+        self.assertEqual(persisted[-1]['transaction_error'], 'provisional_receipt_failed')
+        self.assertEqual(persisted[-1]['outcome'], 'provisional_receipt_failed')
+        self.assertFalse(persisted[-1]['resume_supported'])
+        self.assertNotIn('PRIVATE_SENTINEL', output)
+
+    def test_provisional_error_after_visible_publication_is_still_sticky(self):
+        code, attempts, persisted, output = self.run_case(post_write_failures={1})
+        self.assertEqual(code, 1)
+        self.assertEqual(len(persisted), 2)
+        self.assertNotEqual(persisted[-1]['state'], 'complete')
+        self.assertEqual(persisted[-1]['transaction_error'], 'provisional_receipt_failed')
+        self.assertNotIn('PRIVATE_SENTINEL', output)
+
+    def test_unloaded_agent_also_records_sticky_publication_failure(self):
+        code, attempts, persisted, output = self.run_case(loaded=False, failed_writes={1})
+        self.assertEqual(code, 1)
+        self.assertEqual(len(attempts), 2)
+        self.assertNotEqual(persisted[-1]['state'], 'complete')
+        self.assertEqual(persisted[-1]['transaction_error'], 'provisional_receipt_failed')
+        self.assertNotIn('state: complete', output)
+
+    def test_total_publication_failure_never_prints_complete(self):
+        code, attempts, persisted, output = self.run_case(failed_writes={1, 2})
+        self.assertEqual(code, 1)
+        self.assertEqual(persisted, [])
+        self.assertNotIn('state: complete', output)
+
+    def test_final_failure_keeps_durable_provisional_receipt(self):
+        code, attempts, persisted, output = self.run_case(failed_writes={2})
+        self.assertEqual(code, 1)
+        self.assertEqual(persisted[-1]['finalization'], 'restore_pending')
+        self.assertNotEqual(persisted[-1]['state'], 'complete')
+        self.assertNotIn('state: complete', output)
+
+    def test_success_still_finalizes_the_same_run(self):
+        code, attempts, persisted, output = self.run_case()
+        self.assertEqual(code, 0)
+        self.assertEqual(persisted[-1]['state'], 'complete')
+        self.assertEqual(persisted[0]['run_id'], persisted[-1]['run_id'])
+        self.assertEqual(persisted[0]['finalization'], 'restore_pending')
+        self.assertEqual(persisted[-1]['finalization'], 'finalized')
+
+    def test_restore_failure_does_not_clear_provisional_failure(self):
+        code, attempts, persisted, output = self.run_case(failed_writes={1}, restore_fails=True)
+        self.assertEqual(code, 1)
+        self.assertEqual(persisted[-1]['transaction_error'], 'provisional_receipt_failed')
+        self.assertEqual(persisted[-1]['outcome'], 'launch_agent_restore_failed')
+
+
+class HealthOutcomeTests(unittest.TestCase):
+    def test_latest_new_stop_does_not_fall_back_to_old_success(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / 'synthetic.log'
+            for status in ('source_generation_admission_required', 'knowledge_recovery_unavailable',
+                           'future_stop_state', 'x' * 81):
+                with self.subTest(status=status):
+                    log.write_text('[monitor] no_messages: old success\n'
+                                   f'[monitor] {status}: PRIVATE_SENTINEL\n', encoding='utf-8')
+                    actual = health_check.latest_monitor_runtime_result(log)
+                    self.assertEqual(actual, status if len(status) <= 80 else 'unknown')
+                    self.assertNotIn('PRIVATE_SENTINEL', actual)
+
+    def test_health_has_no_protected_source_scanner_call(self):
+        source = Path(health_check.__file__).read_text(encoding='utf-8')
+        tree = ast.parse(source)
+        forbidden = {'check_new_databases', '_required_pages', 'recover_keys', 'extract_keys'}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                called = getattr(node.func, 'id', getattr(node.func, 'attr', ''))
+                self.assertNotIn(called, forbidden)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reliability_closure_modules.py
+++ b/tests/test_reliability_closure_modules.py
@@ -1,0 +1,146 @@
+"""No platform process or network calls: the codesign runner is always mocked."""
+import subprocess
+import unittest
+from unittest.mock import Mock
+from urllib.parse import parse_qsl, urlsplit
+
+from core.monitor_result import classify_monitor_result, monitor_status
+from core.wechat_signature import inspect_wechat_signature
+from core.url_safety import redact_url_for_display, redact_urls_in_text
+
+
+class CompoundCredentialTests(unittest.TestCase):
+    def test_compound_credentials_are_redacted(self):
+        for key in (
+            'download_token', 'shareToken', 'JWTToken', 'jwt_token', 'my_secret',
+            'my-secret', 'downloadtoken', 'sharetoken', 'mysecret', 'token2',
+            'download_token2', 'myJWT', 'token.download', 'private[secret]',
+        ):
+            with self.subTest(key=key):
+                result = redact_url_for_display(f'https://example.test/file?{key}=PRIVATE_SENTINEL&lang=zh')
+                self.assertNotIn('PRIVATE_SENTINEL', result)
+                self.assertIn('lang=zh', result)
+
+    def test_normal_words_and_exact_private_input_are_unchanged(self):
+        original = 'https://example.test/?tokenization=paper&secretary=person&monkey=animal'
+        self.assertEqual(redact_url_for_display(original), original)
+
+    def test_encoded_keys_duplicates_and_fragment_are_redacted(self):
+        original = 'https://example.test/?share%54oken=A&shareToken=B#route?my_secret=C'
+        redacted = redact_url_for_display(original)
+        self.assertEqual(parse_qsl(urlsplit(redacted).query),
+                         [('shareToken', 'REDACTED'), ('shareToken', 'REDACTED')])
+        self.assertEqual(urlsplit(redacted).fragment, 'route?my_secret=REDACTED')
+        self.assertIn('share%54oken=A', original)
+
+    def test_text_projection_redaction_is_idempotent(self):
+        original = '文件 https://example.test/?download_token=PRIVATE_SENTINEL'
+        redacted = redact_urls_in_text(original)
+        self.assertNotIn('PRIVATE_SENTINEL', redacted)
+        self.assertEqual(redact_urls_in_text(redacted), redacted)
+
+
+class SignaturePredicateTests(unittest.TestCase):
+    @staticmethod
+    def runner(detail, *, verify_code=0, display_code=0):
+        return Mock(side_effect=[
+            subprocess.CompletedProcess([], verify_code, '', ''),
+            subprocess.CompletedProcess([], display_code, '', detail),
+        ])
+
+    def test_valid_signature_uses_exact_target_twice_without_mutation(self):
+        path = '/fixture/runtime directory/WeChat.app'
+        runner = self.runner('CodeDirectory v=20400 flags=0x2(adhoc) hashes=14+2\nSignature=adhoc\n')
+        result = inspect_wechat_signature(path, runner=runner)
+        self.assertTrue(result.ok)
+        self.assertEqual(len(runner.call_args_list), 2)
+        for call in runner.call_args_list:
+            args = call.args[0]
+            self.assertEqual(args[-1], path)
+            self.assertNotIn('sudo', args)
+            self.assertNotIn('--sign', args)
+            self.assertIn('timeout', call.kwargs)
+        self.assertIn('--strict', runner.call_args_list[0].args[0])
+
+    def test_failed_strict_verify_never_accepts_display_only_flags(self):
+        runner = self.runner('CodeDirectory flags=0x2(adhoc)\nSignature=adhoc\n', verify_code=1)
+        self.assertEqual(inspect_wechat_signature('/fixture/WeChat.app', runner=runner).code,
+                         'wechat_signature_invalid')
+        runner.assert_called_once()
+
+    def test_runtime_bit_without_text_label_is_rejected(self):
+        runner = self.runner('CodeDirectory flags=0x10002\nSignature=adhoc\n')
+        self.assertEqual(inspect_wechat_signature('/fixture/WeChat.app', runner=runner).code,
+                         'wechat_hardened_runtime_still_enabled')
+
+    def test_unrelated_runtime_text_does_not_reject_valid_signature(self):
+        runner = self.runner('Executable=/fixture/runtime/WeChat\nCodeDirectory flags=0x2(adhoc)\nSignature=adhoc\n')
+        self.assertTrue(inspect_wechat_signature('/fixture/WeChat.app', runner=runner).ok)
+
+    def test_missing_malformed_or_contradictory_evidence_fails_closed(self):
+        for detail in (
+            'Signature=adhoc\n',
+            'CodeDirectory flags=garbage\nSignature=adhoc\n',
+            'CodeDirectory flags=0x2(adhoc)\nSignature size=500\n',
+            'CodeDirectory flags=0x2(adhoc)\nSignature=adhoc\nSignature=other\n',
+            'CodeDirectory flags=0x2(adhoc)\nCodeDirectory flags=0x10002\nSignature=adhoc\n',
+        ):
+            with self.subTest(detail=detail):
+                self.assertFalse(inspect_wechat_signature('/fixture/WeChat.app', runner=self.runner(detail)).ok)
+
+    def test_failed_display_is_not_success(self):
+        runner = self.runner('CodeDirectory flags=0x2(adhoc)\nSignature=adhoc\n', display_code=1)
+        self.assertFalse(inspect_wechat_signature('/fixture/WeChat.app', runner=runner).ok)
+
+    def test_timeout_and_absent_binary_do_not_expose_exception_text(self):
+        for error in (subprocess.TimeoutExpired('PRIVATE_SENTINEL', 60),
+                      FileNotFoundError('PRIVATE_SENTINEL')):
+            with self.subTest(kind=type(error).__name__):
+                result = inspect_wechat_signature('/fixture/WeChat.app', runner=Mock(side_effect=error))
+                self.assertFalse(result.ok)
+                self.assertNotIn('PRIVATE_SENTINEL', repr(result))
+
+    def test_invalid_target_makes_no_process_call(self):
+        for path in ('', None, '/bad\0path'):
+            with self.subTest(path=path):
+                runner = Mock()
+                self.assertFalse(inspect_wechat_signature(path, runner=runner).ok)
+                runner.assert_not_called()
+
+
+class MonitorOutcomeTests(unittest.TestCase):
+    def test_only_existing_post_commit_codes_count_as_progress(self):
+        for code in ('no_match', 'notified', 'duplicate', 'cooldown', 'source_advanced_no_visible'):
+            with self.subTest(code=code):
+                self.assertEqual(classify_monitor_result({'status': code}).action, 'progress')
+
+    def test_new_and_known_failures_stop_without_a_negative_allowlist(self):
+        for code in (
+            'source_generation_admission_required', 'source_page_invalid',
+            'source_cursor_stalled', 'source_envelope_invalid',
+            'knowledge_recovery_unavailable', 'ai_backoff', 'initialized',
+            'monitor_state_conflict', 'source_message_decode_failed', 'future_stop_state',
+        ):
+            with self.subTest(code=code):
+                outcome = classify_monitor_result({'status': code, 'source_eof': True})
+                self.assertEqual((outcome.action, outcome.reason), ('blocked', code))
+
+    def test_only_boolean_true_eof_completes(self):
+        self.assertEqual(classify_monitor_result({'status': 'no_messages', 'source_eof': True}).action, 'complete')
+        for eof in (False, None, 1, 'true', {}):
+            with self.subTest(eof=eof):
+                result = classify_monitor_result({'status': 'no_messages', 'source_eof': eof})
+                self.assertEqual((result.action, result.reason), ('blocked', 'source_eof_unverified'))
+
+    def test_invalid_payload_and_status_are_bounded_content_free_stops(self):
+        for result in (None, [], 'PRIVATE_SENTINEL', {'status': 10},
+                       {'status': 'source_error: PRIVATE_SENTINEL'}, {'status': 'x' * 81}):
+            with self.subTest(result=result):
+                outcome = classify_monitor_result(result)
+                self.assertEqual(outcome.action, 'blocked')
+                self.assertNotIn('PRIVATE_SENTINEL', repr(outcome))
+        self.assertEqual(monitor_status('future_safe_code'), 'future_safe_code')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_wechat_resign.py
+++ b/tests/test_wechat_resign.py
@@ -299,7 +299,8 @@ class WeChatResignTests(unittest.TestCase):
         self.assertNotIn('tell application "WeChat" to quit', launcher)
         self.assertIn("scripts/resign_wechat.py", launcher)
         self.assertNotIn('open "$app_path"', launcher)
-        self.assertIn('grep -qx "Signature=adhoc"', launcher)
+        self.assertIn("from core.wechat_signature import inspect_wechat_signature", launcher)
+        self.assertNotIn('grep -qx "Signature=adhoc"', launcher)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Exact candidate reliability-closure-787c16dc73c6 applied to baseline 9ab1eeab25d1e7450e7c1fc9eef8b5fb55e60f3b, followed by focused acceptance fixes in 5a8c653.

Purpose: reach the v0.1.0-alpha.1 final real-machine canary gate. This is source acceptance; it does not create a release tag or perform live WeChat mutation.

Resolved acceptance blockers:
1. Health treats the newest monitor event as authoritative, reports structured monitor_runtime_error, and never falls back from an unstructured newest event to older success.
2. App-level monitor errors and tracebacks apply canonical compound-token URL redaction before logs and notifications.
3. The config default-path test verifies the effective DATA_DIR contract, so the documented isolated HOME plus WE_GROUPCHAT_OBSIDIAN_DATA_DIR full-suite invocation passes.

Local macOS evidence under isolated HOME and data directory:
- reliability closure modules: 34 passed
- affected resign, key, catch-up, health, startup modules: 57 passed
- full suite: 1080 passed, 16 platform skips
- compileall, all command launcher bash syntax, and git diff checks: passed

GitHub evidence:
- PR matrix on 5a8c653: Windows import plus macOS Python 3.10-3.14 passed
- merged to main as 2353931
- main push matrix on 2353931: Windows import plus macOS Python 3.10-3.14 passed

No release tag was created and no live WeChat data, signature, LaunchAgent, configuration, cache, or checkpoint was changed.