### PR TITLE
Stabilize macOS app identity; fail-closed transient WeChat source reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@
   unknown, separate Direct Drive verification, disabled link preview, legacy
   read-only/send-retired MCP, and the Windows W0.2B.1 lock-and-path-only boundary.
   Health inspection must not scan source, initialize/migrate the source
-  inventory, open CAS payload objects, or promote mounted evidence to remote
+  inventory, open CAS payload objects, `stat` the protected WeChat container,
+  or promote mounted evidence to remote
   verification. Local details require explicit `--sensitive`.
 - `setup.py` is the py2app packaging entrypoint. These are the only Python
   files that belong at repository root.
@@ -78,6 +79,11 @@
 - `scripts/` contains thin operator entrypoints and compatibility cleanup
   commands. Put
   reusable behavior in the owning package rather than duplicating it in a CLI.
+  Transient maintenance CLIs that would read the protected WeChat source
+  (`refresh_data_source.py`, `catch_up_monitor.py`) must fail closed before any
+  source open/stat unless the operator explicitly passes
+  `--allow-transient-wechat-source-read`; the flag authorizes only that one
+  short-lived process, which may still get its own macOS App Data prompt.
 - Source-guard and mounted-resource timers run inside the long-lived py2app
   menu-bar process. macOS App Data consent is process-lifetime access, so their
   retired short-lived LaunchAgent modes must remain no-op cleanup surfaces and
@@ -92,6 +98,11 @@
 - `launchers/` owns the canonical Finder-friendly `.command` entrypoints. The
   root `启动.command` is a compatibility stub for deployed source-mode
   LaunchAgents and must not grow a second implementation.
+  `launchers/启动.command` builds and validates the ad-hoc-signed local alias
+  bundle `dist/WeGroupchatObsidian.app` and launches through that stable bundle
+  identity; it must never fall back to a short-lived `python app.py`, and new
+  autostart installs bind the same bundle via
+  `scripts/autostart.py install --app-bundle`.
 - `tests/` is an importable unittest package. New tests belong there and use
   `tests.<module>` for focused invocation.
 

--- a/README.md
+++ b/README.md
@@ -289,9 +289,21 @@ cd we-groupchat-obsidian
 
 On the first run, or after `requirements.txt` changes, `启动.command` asks before
 creating/updating `.venv` and installing dependencies. It proceeds only after an
-explicit `y`; declining exits without installing anything. This is a
-source-distributed macOS menu-bar app, with no signed installer, `.dmg`, or
-bundled Python runtime.
+explicit `y`; declining exits without installing anything. A successful first
+setup also builds and ad-hoc signs the machine-local alias bundle at
+`dist/WeGroupchatObsidian.app`. Ordinary starts and newly installed LaunchAgents
+reuse that stable bundle identity; the launcher no longer falls back to
+`python app.py`. The alias bundle still depends on this checkout and its
+`.venv`, so this remains a source-distributed macOS menu-bar app with no signed
+installer, `.dmg`, or bundled Python runtime.
+
+macOS may request access when each long-lived menu-app process first reads
+WeChat App Data. The ordinary monitor, source guard, and resource timers stay
+inside that process instead of spawning a Python process per interval. Default
+health inspection does not `stat` the protected WeChat container. A separate
+short-lived maintenance process may read the source only when
+`--allow-transient-wechat-source-read` is explicit, and macOS may show that
+one-shot process its own consent prompt.
 
 If WeChat was updated or key extraction needs a fresh authorization:
 
@@ -359,8 +371,8 @@ entrypoint for existing source installs and LaunchAgents.
 | --- | --- |
 | `./启动.command` | Start the menu bar app |
 | `./launchers/配置关注推送.command` | Configure topic monitoring without using the menu bar UI |
-| `./launchers/健康检查.command` | Redacted-by-default health check; use `--sensitive` only for local debugging |
-| `./launchers/刷新数据源.command` | Refresh WeChat database keys after updates |
+| `./launchers/健康检查.command` | Redacted durable-state health check; it does not probe the protected WeChat container |
+| `./launchers/刷新数据源.command` | Handle any exact-target re-sign, open the stable app, then use `🔄 刷新数据源` in its menu |
 | `./launchers/历史总结到Obsidian.command` | Backfill historical summaries into Markdown |
 | `./launchers/整理Obsidian输出.command` | Re-export and organize Markdown notes |
 | `./launchers/安装自动启动.command` | Install LaunchAgent autostart |
@@ -598,21 +610,18 @@ them off does not stop monitoring, knowledge writes, or Daily Digest generation;
 manual action feedback and the explicit notification test remain available.
 
 If system notifications do not appear, check the `Notification identity` line
-in `./launchers/健康检查.command`. Source installs launched through a virtualenv can run as
-`Python / org.python.python`, which may schedule notifications without showing a
-stable app entry in macOS notification settings. A bundled `.app` build should
-use `io.github.indeliblevivi.we-groupchat-obsidian` as its notification bundle
-identity. The py2app build also uses `resources/app_icon.icns`, so macOS
-Notification Center shows the project icon instead of py2app's default Python icon.
+in `./launchers/健康检查.command`. Ordinary startup now builds and reuses
+`dist/WeGroupchatObsidian.app`, whose bundle ID is
+`io.github.indeliblevivi.we-groupchat-obsidian` and whose icon comes from
+`resources/app_icon.icns`. If health still reports
+`Python / org.python.python`, an old source-mode process is still running; exit
+that menu process and reopen WGO through the ordinary launcher.
 
-For a local app-bundle LaunchAgent identity:
+New autostart installs bind to the same local app bundle. To write the plist and
+load it immediately:
 
 ```bash
-.venv/bin/python -m pip install py2app
-# If this virtualenv's pip is unavailable:
-# uv pip install --python .venv/bin/python py2app
-.venv/bin/python setup.py py2app --alias
-.venv/bin/python scripts/autostart.py install --app-bundle dist/WeGroupchatObsidian.app --load-now
+./launchers/安装自动启动.command --load-now
 ```
 
 The `--alias` app points back to this source checkout and its `.venv`; it is
@@ -648,11 +657,15 @@ The topic monitor is designed to preserve useful signal without turning every in
 If WeChat or the provider was unavailable and the monitor has a checkpointed backlog, use the guarded catch-up entry instead of advancing state by hand:
 
 ```bash
-./launchers/补跑遗漏笔记.command          # read-only pending audit
-./launchers/补跑遗漏笔记.command --apply  # pause, back up, drain, rebuild, validate, restore
+./launchers/补跑遗漏笔记.command --allow-transient-wechat-source-read
+./launchers/补跑遗漏笔记.command --allow-transient-wechat-source-read --apply
 ```
 
-Write mode requires the explicit `--apply` flag. It refuses chats without recoverable state and uses the normal paginated `TopicMonitor` path. Monitor state is a locked, revisioned atomic file: only a truly absent file initializes to now; corrupt JSON, symlinks, and non-regular files fail closed. Canonical progress is `source_cursors` per chat and logical-shard generation, using opaque raw-row tokens; `last_checked_ts` remains only a derived compatibility/diagnostic value. Each bounded batch reads every shard under one complete inventory, merges raw envelopes by `create_time` then `source_message_id`, and advances only rows actually consumed. Here “complete source” means the expected logical-shard inventory is complete, every generation remains the one bound to the batch, and all required reads succeed. Filtered/system rows advance the source cursor but never enter the AI prompt; `source_advanced_no_visible` is therefore progress, while `no_messages` means verified raw EOF. AI failure, source-generation change, or stale state revision commits no cursor. A retryable provider failure CAS-writes only a content-free failure count/code/timestamp and bounded backoff deadline against the revision that was read; source cursors, inventory bindings and checkpoints remain unchanged, and an interval inside that backoff makes no provider call. If a Knowledge event commits before a state CAS conflict, the retry reuses its source-batch identity instead of inserting a duplicate canonical event; if its managed topic Markdown is missing, the same reuse repairs that projection and the date indexes without changing event identity. Catch-up stops the managed LaunchAgent, then must acquire the same menu-app singleton lock before any backup, state, database, or projection write. `menu_app_active` means a manually started app still owns that lock, so catch-up writes no canonical data. With ownership established, it stores a private partial-recovery backup under `~/.we-groupchat-obsidian/backups/monitor-catch-up/`, drains to verified raw EOF under an unchanged complete inventory, rebuilds affected source-date indexes and historical Daily Digests, validates SQLite/FTS/hash parity, and durably writes a provisional reconciliation receipt while still holding the lock. It then releases ownership, restores a previously loaded LaunchAgent, and atomically finalizes the same `run_id` receipt with the observed restore result.
+Even the read-only pending audit reads the protected WeChat source, so
+`--allow-transient-wechat-source-read` is required for audit and apply. The flag
+authorizes only that maintenance process; macOS may still show it one App Data
+consent prompt. Without the flag, the command exits before opening or `stat`ing
+the source. Write mode additionally requires the explicit `--apply` flag. It refuses chats without recoverable state and uses the normal paginated `TopicMonitor` path. Monitor state is a locked, revisioned atomic file: only a truly absent file initializes to now; corrupt JSON, symlinks, and non-regular files fail closed. Canonical progress is `source_cursors` per chat and logical-shard generation, using opaque raw-row tokens; `last_checked_ts` remains only a derived compatibility/diagnostic value. Each bounded batch reads every shard under one complete inventory, merges raw envelopes by `create_time` then `source_message_id`, and advances only rows actually consumed. Here “complete source” means the expected logical-shard inventory is complete, every generation remains the one bound to the batch, and all required reads succeed. Filtered/system rows advance the source cursor but never enter the AI prompt; `source_advanced_no_visible` is therefore progress, while `no_messages` means verified raw EOF. AI failure, source-generation change, or stale state revision commits no cursor. A retryable provider failure CAS-writes only a content-free failure count/code/timestamp and bounded backoff deadline against the revision that was read; source cursors, inventory bindings and checkpoints remain unchanged, and an interval inside that backoff makes no provider call. If a Knowledge event commits before a state CAS conflict, the retry reuses its source-batch identity instead of inserting a duplicate canonical event; if its managed topic Markdown is missing, the same reuse repairs that projection and the date indexes without changing event identity. Catch-up stops the managed LaunchAgent, then must acquire the same menu-app singleton lock before any backup, state, database, or projection write. `menu_app_active` means a manually started app still owns that lock, so catch-up writes no canonical data. With ownership established, it stores a private partial-recovery backup under `~/.we-groupchat-obsidian/backups/monitor-catch-up/`, drains to verified raw EOF under an unchanged complete inventory, rebuilds affected source-date indexes and historical Daily Digests, validates SQLite/FTS/hash parity, and durably writes a provisional reconciliation receipt while still holding the lock. It then releases ownership, restores a previously loaded LaunchAgent, and atomically finalizes the same `run_id` receipt with the observed restore result.
 
 The catch-up backup currently contains only canonical SQLite plus per-chat checkpoints. It is useful for recovery evidence, but it is not a complete rollback bundle: Review Queue JSONL and Obsidian Markdown/index/Digest projections are not copied. A failed run may therefore retain successfully committed pages before the LaunchAgent resumes. Do not describe this backup as full rollback until a separate recovery policy covers every managed surface.
 
@@ -661,7 +674,7 @@ Catch-up uses a page-level partial-commit contract. Every `--apply` invocation w
 - `complete / drained`: every selected chat reached `no_messages` with `source_eof=true` under an unchanged complete inventory, projections and canonical validation passed, and the final receipt proves that a previously loaded LaunchAgent was restored after lock release (or that none was loaded).
 - `partial / drain_complete_restore_pending`: canonical drain and validation completed, but the durable receipt is still provisional and does not yet prove LaunchAgent restoration. This can remain after interruption between lock release and finalization; it is never terminal success.
 - `partial / launch_agent_restore_failed`: canonical work may already be committed, but restoration was attempted and failed. The final receipt records that failure and the command exits nonzero; inspect or repair the runtime before treating catch-up as closed.
-- `partial / resume_required`: at least one page or managed projection committed, but a chat was blocked or a later operation failed. When `resume_supported` is `true`, rerun `./launchers/补跑遗漏笔记.command --apply`; each chat continues from its committed checkpoint.
+- `partial / resume_required`: at least one page or managed projection committed, but a chat was blocked or a later operation failed. When `resume_supported` is `true`, rerun the same command with both `--allow-transient-wechat-source-read` and `--apply`; each chat continues from its committed checkpoint.
 - `failed / no_progress`: no monitor page committed. Inspect the receipt's error type/status and runtime state before retrying.
 - `failed / menu_app_active`: another menu app still owns the singleton lock. No backup, monitor, database, or projection write occurred; close that instance deliberately before retrying maintenance.
 - `complete / no_op`: the audit found zero pending messages, so no backup, write, or LaunchAgent switch occurred.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -245,7 +245,9 @@ cd we-groupchat-obsidian
 ./启动.command
 ```
 
-第一次运行或 `requirements.txt` 更新时，`启动.command` 会先询问是否创建/更新 `.venv` 并安装 dependencies；只有明确输入 `y` 才会继续，不同意则直接退出。项目是 source-distributed macOS menu-bar app，目前不提供已签名 installer、`.dmg` 或 bundled Python runtime。若 macOS 阻止打开 `.command` 文件，右键它，选择“打开”，再确认打开。
+第一次运行或 `requirements.txt` 更新时，`启动.command` 会先询问是否创建/更新 `.venv` 并安装 dependencies；只有明确输入 `y` 才会继续，不同意则直接退出。首次成功 setup 还会构建并 ad-hoc sign `dist/WeGroupchatObsidian.app` 这只本机 alias bundle，之后普通启动与新安装的 LaunchAgent 都复用它的稳定 bundle identity；启动器不会再回退成 `python app.py`。Alias bundle 仍依赖当前源码目录与 `.venv`，所以项目依然是 source-distributed macOS menu-bar app，目前不提供已签名 installer、`.dmg` 或 bundled Python runtime。若 macOS 阻止打开 `.command` 文件，右键它，选择“打开”，再确认打开。
+
+macOS 可能在每只长驻 menu-app process 第一次读取 WeChat App Data 时请求授权。普通 monitor、source guard 与 resource timer 都留在同一只 app 内，不会每个 interval 启动新 Python。默认 health 也不会 `stat` 受保护的 WeChat container。只有显式运行带 `--allow-transient-wechat-source-read` 的 maintenance CLI，才允许另一只短命进程读取 source；这类单次操作仍可能产生自己的一次系统授权窗。
 
 如果提示微信需要重新授权，请阅读终端说明后手动运行：
 
@@ -308,8 +310,8 @@ source install 与 LaunchAgent 继续使用。
 | `./启动.command` | 启动菜单栏应用 |
 | `./启动.command --setup-only` | 只检查环境和依赖，不启动 app |
 | `./launchers/配置关注推送.command` | 不依赖菜单栏，配置监控群聊、关注描述、AI Key 和 Obsidian 输出 |
-| `./launchers/健康检查.command` | 打印 redacted-by-default 状态；只有本地排查时才加 `--sensitive` |
-| `./launchers/刷新数据源.command` | 微信更新后刷新数据库 key，不需要找到菜单栏图标 |
+| `./launchers/健康检查.command` | 打印 redacted-by-default durable 状态；不会探测受保护的 WeChat container |
+| `./launchers/刷新数据源.command` | 微信更新后处理 exact-target 重签并打开稳定 app；随后在菜单点 `🔄 刷新数据源` |
 | `./launchers/历史总结到Obsidian.command` | 把历史消息按天总结并导出到 Obsidian |
 | `./launchers/整理Obsidian输出.command` | 只整理/重导出知识库 Markdown，不调用 AI |
 | `./launchers/安装自动启动.command` | 安装 macOS LaunchAgent 登录自启 |
@@ -481,21 +483,16 @@ App 与 CLI 共用这套 coverage classifier。为兼容现有 automation，`com
 心跳、后台错误和 Digest 通知；手动操作反馈与“测试系统通知”仍会显示。
 
 如果系统级通知一直不出现，先看 `./launchers/健康检查.command` 里的
-`Notification identity`。源码目录 + virtualenv 启动时，进程可能显示为
-`Python / org.python.python`；这种情况下 rumps 可以成功 schedule 通知，但
-macOS 可能不会给项目一个稳定的通知设置入口，也不一定弹 banner。正式 `.app`
-打包应使用 `io.github.indeliblevivi.we-groupchat-obsidian` 作为通知 bundle
-identity，并使用仓库里的 `resources/app_icon.icns`，避免通知中心显示 py2app
-默认的 Python 图标。
+`Notification identity`。当前普通 `启动.command` 会构建并复用
+`dist/WeGroupchatObsidian.app`，其 bundle ID 是
+`io.github.indeliblevivi.we-groupchat-obsidian`，并使用仓库里的
+`resources/app_icon.icns`；如果 health 仍显示 `Python / org.python.python`，
+说明正在运行旧 source-mode process，应先从旧菜单退出，再通过普通启动器打开稳定 app。
 
-如果想让登录自启直接走本地 `.app` 身份：
+新安装的登录自启同样会绑定这只本地 `.app`。若要写入 plist 并立即加载：
 
 ```bash
-.venv/bin/python -m pip install py2app
-# 如果这个 virtualenv 的 pip 不可用：
-# uv pip install --python .venv/bin/python py2app
-.venv/bin/python setup.py py2app --alias
-.venv/bin/python scripts/autostart.py install --app-bundle dist/WeGroupchatObsidian.app --load-now
+./launchers/安装自动启动.command --load-now
 ```
 
 这里的 `--alias` app 依赖当前源码目录和 `.venv`，适合本机 LaunchAgent /
@@ -565,9 +562,14 @@ Review Queue 文件保存在 `~/.we-groupchat-obsidian/review_queue/`；里面�
 不要手改 state：
 
 ```bash
-./launchers/补跑遗漏笔记.command          # 只读 audit
-./launchers/补跑遗漏笔记.command --apply  # 显式写入补跑
+./launchers/补跑遗漏笔记.command --allow-transient-wechat-source-read
+./launchers/补跑遗漏笔记.command --allow-transient-wechat-source-read --apply
 ```
+
+即使是 read-only pending audit 也会读取受保护的 WeChat source，因此必须显式给出
+`--allow-transient-wechat-source-read`。Flag 只授权这一只 maintenance process；
+macOS 仍可能为它显示一次 App Data 权限窗。没有 flag 时命令会在 load config 后、
+打开/`stat` source 之前退出。
 
 Monitor state 现在由 locked、revisioned、atomic store 持有。只有 state 文件真的不存在时
 才会初始化到 now；corrupt JSON、symlink 或 non-regular file 一律 fail closed。Canonical

--- a/docs/share-package-guide.zh-CN.md
+++ b/docs/share-package-guide.zh-CN.md
@@ -52,8 +52,12 @@ bundled Python runtime。
 ./launchers/整理Obsidian输出.command
 ./launchers/安装自动启动.command
 ./launchers/卸载自动启动.command
-./launchers/补跑遗漏笔记.command
+./launchers/补跑遗漏笔记.command --allow-transient-wechat-source-read
 ```
+
+补跑（包括只读 audit）会读取受保护的微信数据目录，所以必须显式加
+`--allow-transient-wechat-source-read`；macOS 可能为这次单独运行弹一次文件权限窗。
+没有这个 flag 时命令会在读取前直接退出。
 
 ## 建议先跑一次健康检查
 

--- a/launchers/刷新数据源.command
+++ b/launchers/刷新数据源.command
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Refresh WeChat database keys without using the menu bar UI.
+# Open the stable menu app after any required exact-target re-sign.
 
 set -euo pipefail
 

--- a/launchers/启动.command
+++ b/launchers/启动.command
@@ -12,6 +12,8 @@ VENV_DIR="$PROJECT_DIR/.venv"
 PYTHON_BIN="$VENV_DIR/bin/python"
 REQ_FILE="$PROJECT_DIR/requirements.txt"
 REQ_STAMP="$VENV_DIR/.requirements.sha256"
+APP_BUNDLE="$PROJECT_DIR/dist/WeGroupchatObsidian.app"
+APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/WeGroupchatObsidian"
 USER_DATA_DIR="$HOME/.we-groupchat-obsidian"
 PYTHON3_CMD="python3"
 SETUP_ONLY=0
@@ -247,6 +249,38 @@ ensure_venv() {
     fi
 }
 
+app_bundle_is_valid() {
+    [[ -x "$APP_EXECUTABLE" ]] && /usr/bin/codesign --verify "$APP_BUNDLE" >/dev/null 2>&1
+}
+
+ensure_app_bundle() {
+    if app_bundle_is_valid; then
+        echo "[app] 稳定本地 app bundle 已就绪"
+        return 0
+    fi
+
+    if [[ -e "$APP_BUNDLE" ]]; then
+        echo "❌ 现有 app bundle 未通过签名/可执行验证，不会自动覆盖："
+        echo "   $APP_BUNDLE"
+        echo "   请先确认菜单 app 已退出，再手动移开这个 derived bundle 后重试。"
+        pause_and_exit 1
+    fi
+
+    if [[ "$AUTOSTART_MODE" -eq 1 ]]; then
+        echo "❌ 旧 source-mode LaunchAgent 找不到稳定 app bundle；为避免在后台构建或重复触发权限，本次停止。"
+        echo "   请在 Finder/Terminal 中显式运行 ./启动.command 完成一次本地 bundle 构建。"
+        exit 1
+    fi
+
+    echo "[app] 首次构建稳定本地 app identity..."
+    "$PYTHON_BIN" "$PROJECT_DIR/setup.py" py2app --alias
+    if ! app_bundle_is_valid; then
+        echo "❌ 本地 app bundle 构建后未通过验证，程序不会回退到短命 Python 进程。"
+        pause_and_exit 1
+    fi
+    echo "[app] 稳定本地 app bundle 构建完成"
+}
+
 is_wechat_signed() {
     "$PYTHON_BIN" -c '
 from core.wechat_signature import inspect_wechat_signature
@@ -351,7 +385,8 @@ if [[ "$HEALTH_CHECK" -eq 1 || "$INSTALL_AUTOSTART" -eq 1 || "$UNINSTALL_AUTOSTA
         exec "$PYTHON_BIN" "$PROJECT_DIR/scripts/health_check.py"
     fi
     if [[ "$INSTALL_AUTOSTART" -eq 1 ]]; then
-        exec "$PYTHON_BIN" "$PROJECT_DIR/scripts/autostart.py" install
+        ensure_app_bundle
+        exec "$PYTHON_BIN" "$PROJECT_DIR/scripts/autostart.py" install --app-bundle "$APP_BUNDLE"
     fi
     if [[ "$UNINSTALL_AUTOSTART" -eq 1 ]]; then
         exec "$PYTHON_BIN" "$PROJECT_DIR/scripts/autostart.py" uninstall
@@ -361,7 +396,8 @@ fi
 run_setup
 
 if [[ "$SETUP_ONLY" -eq 1 ]]; then
-    echo "配置完成。后续直接双击「启动.command」即可。"
+    ensure_app_bundle
+    echo "配置与本地 app bundle 已就绪。后续直接双击「启动.command」即可。"
     pause_and_exit 0
 fi
 
@@ -378,11 +414,19 @@ if [[ "$ORGANIZE_OBSIDIAN" -eq 1 ]]; then
 fi
 
 if [[ "$REFRESH_DATA_SOURCE" -eq 1 ]]; then
-    exec "$PYTHON_BIN" "$PROJECT_DIR/scripts/refresh_data_source.py"
+    ensure_app_bundle
+    echo "已用稳定 app identity 打开微信总结。"
+    echo "请在菜单栏点击「🔄 刷新数据源」；不再为这个 Finder 入口启动另一只短命 Python 进程。"
+    /usr/bin/open "$APP_BUNDLE"
+    pause_and_exit 0
 fi
 
+ensure_app_bundle
 echo "正在启动微信总结..."
 echo "菜单栏会出现 💬 图标"
-echo "（关闭此窗口会退出程序，Ctrl+C 也可退出）"
+echo "（本窗口关闭不会退出菜单 app；请从菜单退出）"
 echo ""
-exec "$PYTHON_BIN" "$PROJECT_DIR/app.py"
+if [[ "$AUTOSTART_MODE" -eq 1 ]]; then
+    exec "$APP_EXECUTABLE" --autostart
+fi
+exec /usr/bin/open "$APP_BUNDLE"

--- a/launchers/安装自动启动.command
+++ b/launchers/安装自动启动.command
@@ -6,9 +6,4 @@ set -euo pipefail
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_DIR"
 
-if [[ ! -x "$PROJECT_DIR/.venv/bin/python" ]]; then
-    echo "还没有 .venv，先做一次环境检查..."
-    "$PROJECT_DIR/启动.command" --setup-only
-fi
-
-exec "$PROJECT_DIR/.venv/bin/python" "$PROJECT_DIR/scripts/autostart.py" install "$@"
+exec "$PROJECT_DIR/启动.command" --install-autostart "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 rumps>=0.4.0; sys_platform == "darwin"
+py2app>=0.28.9,<0.30; sys_platform == "darwin"
 pycryptodome>=3.20.0
 zstandard>=0.22.0
 pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"

--- a/scripts/catch_up_monitor.py
+++ b/scripts/catch_up_monitor.py
@@ -834,6 +834,14 @@ def apply_catch_up(config: dict, chats: list[dict], db, args) -> int:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Audit or safely catch up missed monitor notes.")
     parser.add_argument("--apply", action="store_true", help="Pause, back up, write notes, rebuild projections, and restore the monitor.")
+    parser.add_argument(
+        "--allow-transient-wechat-source-read",
+        action="store_true",
+        help=(
+            "Explicitly allow this one short-lived process to read the protected "
+            "WeChat source; macOS may show one App Data consent prompt."
+        ),
+    )
     parser.add_argument("--audit-limit", type=int, default=100000, help="Maximum pending messages counted per chat in audit mode.")
     parser.add_argument("--max-pages-per-chat", type=int, default=100, help="Safety bound for TopicMonitor pages per chat.")
     parser.add_argument("--max-minutes", type=int, default=45, help="Transaction runtime safety bound.")
@@ -841,12 +849,25 @@ def main(argv: list[str] | None = None) -> int:
     args.audit_limit = max(1, args.audit_limit)
     args.max_pages_per_chat = max(1, args.max_pages_per_chat)
     args.max_minutes = max(1, args.max_minutes)
+    if not args.allow_transient_wechat_source_read:
+        print(
+            "已在读取 WeChat source 之前停止：这个 maintenance CLI 会启动一只短命进程，"
+            "macOS 可能因此另外弹出一次 App Data 权限。\n"
+            "确定要运行本次 audit/apply 时，显式加上 "
+            "--allow-transient-wechat-source-read。",
+            file=sys.stderr,
+        )
+        return 2
     try:
         config, chats, db = _load_runtime()
         if args.apply:
             return apply_catch_up(config, chats, db, args)
         _print_audit(audit_pending(db, chats, limit=args.audit_limit))
-        print("\n只做了 audit，没有写入。执行补跑：./launchers/补跑遗漏笔记.command --apply")
+        print(
+            "\n只做了 audit，没有写入。执行补跑："
+            "./launchers/补跑遗漏笔记.command "
+            "--allow-transient-wechat-source-read --apply"
+        )
         return 0
     except Exception as exc:
         print(f"补跑入口不可用: {type(exc).__name__}: {exc}", file=sys.stderr)

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -423,7 +423,11 @@ def main(argv: list[str] | None = None) -> int:
     print("")
     db_dir = config.get("db_dir") or ""
     db_label = db_dir if args.sensitive else _path_status(db_dir)
-    print(f"[{ok(bool(db_dir and os.path.isdir(db_dir)))}] WeChat DB: {db_label}")
+    # Health is a durable-state inspection surface. Do not stat the protected
+    # WeChat container from this short-lived CLI process: doing so can trigger a
+    # separate macOS App Data consent prompt. Source reachability belongs to the
+    # long-lived menu app and is represented here by its durable inventory.
+    print(f"[{ok(bool(str(db_dir).strip()))}] WeChat DB: {db_label}")
     print(f"[{ok(bool(keys))}] DB keys cache: {len(keys)} 个数据库 key")
     if api_key_available:
         ai_note = "Keychain 可读取"

--- a/scripts/refresh_data_source.py
+++ b/scripts/refresh_data_source.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Refresh observed WeChat keys; report source completeness separately."""
 from __future__ import annotations
+import argparse
 from dataclasses import dataclass
 import sys
 from pathlib import Path
@@ -44,7 +45,25 @@ def refresh_data_source() -> RefreshResult:
     )
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Refresh verified WeChat database keys.")
+    parser.add_argument(
+        "--allow-transient-wechat-source-read",
+        action="store_true",
+        help=(
+            "Explicitly allow this one short-lived process to read the protected "
+            "WeChat source; macOS may show one App Data consent prompt."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if not args.allow_transient_wechat_source_read:
+        print(
+            "已在读取 WeChat source 之前停止：请优先在长驻菜单 app 里点击「🔄 刷新数据源」。\n"
+            "只有确定要让这只短命 CLI 进程读取时，才加上 "
+            "--allow-transient-wechat-source-read；macOS 可能另外弹出一次 App Data 权限。",
+            file=sys.stderr,
+        )
+        return 2
     result = refresh_data_source()
     print("微信总结 数据源 key 验证")
     print(f"state: {result.status}")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""py2app 打包配置（可选；默认仍推荐源码目录 + 启动.command 分发）"""
+"""Build the stable local alias app used by source-distributed installs."""
 import os
 from pathlib import Path
 import py_compile
@@ -50,8 +50,8 @@ def finalize_alias_bundle(bundle, *, config_target=None, runner=subprocess.run):
     resources = bundle / "Contents" / "Resources"
     python_lib = resources / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}"
 
-    # py2app 0.28.10 creates ../../site.pyc but omits its target on
-    # Python 3.13. Compile the bundled alias bootstrap at that target.
+    # Some py2app/Python combinations create ../../site.pyc but omit its
+    # target. Compile the bundled alias bootstrap at that target.
     site_source = resources / "site.py"
     site_target = resources / "site.pyc"
     py_compile.compile(str(site_source), cfile=str(site_target), doraise=True)

--- a/tests/test_catch_up_monitor.py
+++ b/tests/test_catch_up_monitor.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import sqlite3
 import tempfile
 import unittest
+from contextlib import redirect_stderr
+from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +21,7 @@ from scripts.catch_up_monitor import (
     rebuild_projections,
     validate_knowledge_db,
     write_reconciliation_receipt,
+    main,
 )
 
 
@@ -53,6 +56,33 @@ class CatchUpMonitorTests(unittest.TestCase):
 
     def tearDown(self):
         self.instance_lock_patcher.stop()
+
+    def test_cli_requires_explicit_transient_source_consent_before_loading_runtime(self):
+        stderr = StringIO()
+        with (
+            patch("scripts.catch_up_monitor._load_runtime") as load_runtime,
+            redirect_stderr(stderr),
+        ):
+            code = main([])
+
+        self.assertEqual(code, 2)
+        load_runtime.assert_not_called()
+        self.assertIn("--allow-transient-wechat-source-read", stderr.getvalue())
+
+    def test_cli_explicit_transient_source_consent_allows_audit(self):
+        with (
+            patch(
+                "scripts.catch_up_monitor._load_runtime",
+                return_value=({}, [{"username": "chat", "name": "Chat"}], object()),
+            ) as load_runtime,
+            patch("scripts.catch_up_monitor.audit_pending", return_value=[]) as audit,
+            patch("scripts.catch_up_monitor._print_audit"),
+        ):
+            code = main(["--allow-transient-wechat-source-read"])
+
+        self.assertEqual(code, 0)
+        load_runtime.assert_called_once_with()
+        audit.assert_called_once()
 
     def test_pending_messages_preserves_unprocessed_same_timestamp_rows(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -565,6 +565,12 @@ gui/501/com.example.wechat-summary = {
                     "last_exit_code": "1",
                 },
             )()
+            real_isdir = os.path.isdir
+
+            def reject_protected_source_stat(path):
+                if os.fspath(path) == str(db_dir):
+                    raise AssertionError("health must not stat protected source")
+                return real_isdir(path)
 
             with patch("scripts.health_check.load_config", return_value=config), \
                  patch("scripts.health_check.get_cached_keys", return_value={"message/message_0.db": {"enc_key": "x"}}), \
@@ -654,6 +660,7 @@ gui/501/com.example.wechat-summary = {
                      },
                  ), \
                  patch("core.key_extractor.check_new_databases", side_effect=AssertionError("health must not scan source")), \
+                 patch("scripts.health_check.os.path.isdir", side_effect=reject_protected_source_stat), \
                  patch("scripts.health_check.EXTRACT_LOG", str(key_log)):
                 output = StringIO()
                 with redirect_stdout(output):

--- a/tests/test_refresh_data_source.py
+++ b/tests/test_refresh_data_source.py
@@ -1,7 +1,9 @@
 import unittest
+from contextlib import redirect_stderr
+from io import StringIO
 from unittest.mock import patch
 from core.key_extractor import KeyRecoveryResult
-from scripts.refresh_data_source import refresh_data_source
+from scripts.refresh_data_source import main, refresh_data_source
 
 
 class RefreshDataSourceTests(unittest.TestCase):
@@ -41,3 +43,35 @@ class RefreshDataSourceTests(unittest.TestCase):
 
     def test_empty_fresh_result_cannot_claim_success(self):
         self.assertFalse(self.run_result(KeyRecoveryResult('fresh_verified',verified_count=1)).ok)
+
+    def test_cli_requires_explicit_transient_source_consent_before_refresh(self):
+        stderr = StringIO()
+        with patch("scripts.refresh_data_source.refresh_data_source") as refresh, \
+             redirect_stderr(stderr):
+            code = main([])
+
+        self.assertEqual(code, 2)
+        refresh.assert_not_called()
+        self.assertIn("--allow-transient-wechat-source-read", stderr.getvalue())
+
+    def test_cli_explicit_transient_source_consent_runs_refresh(self):
+        outcome = type(
+            "Outcome",
+            (),
+            {
+                "ok": True,
+                "status": "fresh_verified",
+                "message": "verified",
+                "reason": "",
+                "key_count": 1,
+                "missing_databases": [],
+            },
+        )()
+        with patch(
+            "scripts.refresh_data_source.refresh_data_source",
+            return_value=outcome,
+        ) as refresh:
+            code = main(["--allow-transient-wechat-source-read"])
+
+        self.assertEqual(code, 0)
+        refresh.assert_called_once_with()

--- a/tests/test_startup_helpers.py
+++ b/tests/test_startup_helpers.py
@@ -73,18 +73,45 @@ class StartupHelperTests(unittest.TestCase):
         self.assertLess(confirmation, install_dependencies)
         self.assertIn("已取消安装，程序不会启动。", contents)
 
-    def test_refresh_uses_the_exact_target_reopened_by_resign_orchestration(self):
+    def test_refresh_opens_the_stable_app_after_exact_target_resign_orchestration(self):
         launcher = repo_path("launchers", "启动.command")
         contents = launcher.read_text(encoding="utf-8")
 
         bound = contents.index('export WE_GROUPCHAT_OBSIDIAN_WECHAT_APP_PATH="$app_path"')
         signed = contents.index("scripts/resign_wechat.py")
         refresh = contents.index('if [[ "$REFRESH_DATA_SOURCE" -eq 1 ]]')
-        execute_refresh = contents.index("scripts/refresh_data_source.py", refresh)
+        open_bundle = contents.index('/usr/bin/open "$APP_BUNDLE"', refresh)
         self.assertLess(bound, signed)
         self.assertLess(signed, refresh)
-        self.assertLess(refresh, execute_refresh)
+        self.assertLess(refresh, open_bundle)
+        self.assertNotIn("scripts/refresh_data_source.py", contents)
         self.assertNotIn('open "$app_path"', contents)
+
+    def test_normal_start_never_falls_back_to_transient_python_app(self):
+        launcher = repo_path("launchers", "启动.command")
+        contents = launcher.read_text(encoding="utf-8")
+
+        self.assertIn("ensure_app_bundle", contents)
+        self.assertIn('exec /usr/bin/open "$APP_BUNDLE"', contents)
+        self.assertIn('exec "$APP_EXECUTABLE" --autostart', contents)
+        self.assertNotIn('exec "$PYTHON_BIN" "$PROJECT_DIR/app.py"', contents)
+
+    def test_autostart_install_is_bound_to_the_stable_app_bundle(self):
+        launcher = repo_path("launchers", "启动.command").read_text(encoding="utf-8")
+        finder_helper = repo_path(
+            "launchers", "安装自动启动.command"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            'scripts/autostart.py" install --app-bundle "$APP_BUNDLE"',
+            launcher,
+        )
+        self.assertIn('--install-autostart "$@"', finder_helper)
+
+    def test_macos_runtime_requirements_include_py2app(self):
+        requirements = repo_path("requirements.txt").read_text(encoding="utf-8")
+
+        self.assertIn('py2app>=0.28.9,<0.30; sys_platform == "darwin"', requirements)
 
     def test_launcher_has_no_legacy_key_cache_rewrite_block(self):
         launcher = repo_path("launchers", "启动.command")


### PR DESCRIPTION
## Why

Operators reported repeated macOS App Data consent prompts. Diagnosis: the prompts came from short-lived Python processes each binding their own process identity — and the distributed entrypoints made that easy: ordinary `启动.command` fell back to `python app.py`, maintenance CLIs read the protected WeChat source with no explicit consent, and default health inspection stat'ed the protected container. macOS App Data consent is process-lifetime access, so every transient process can prompt again.

## What changes

- `launchers/启动.command` builds and validates the ad-hoc-signed local alias bundle `dist/WeGroupchatObsidian.app` (py2app `--alias`) and launches through that stable identity; it never falls back to `python app.py`. A missing bundle in autostart mode fails closed with operator instructions instead of building in the background; an invalid existing bundle is never overwritten.
- New autostart installs bind the same bundle via `scripts/autostart.py install --app-bundle`; `安装自动启动.command` delegates to `启动.command --install-autostart`.
- `刷新数据源.command` re-signs the exact WeChat target when required and opens the stable app; key refresh happens from the long-lived menu app.
- `scripts/refresh_data_source.py` and `scripts/catch_up_monitor.py` fail closed (exit 2) before any source open/stat unless `--allow-transient-wechat-source-read` is passed explicitly.
- Default `scripts/health_check.py` no longer stats the protected WeChat container.
- `py2app>=0.28.9,<0.30` becomes a macOS runtime requirement.
- README EN/ZH, `docs/share-package-guide.zh-CN.md`, and AGENTS.md document the new boundaries.

## Verification

- Focused: `tests.test_catch_up_monitor tests.test_refresh_data_source tests.test_health_check tests.test_startup_helpers tests.test_setup` — 59 passed.
- Full suite: 1088 passed, 16 skipped.
- `compileall` clean; all 10 root/launcher `.command` files pass `bash -n`; `git diff --check` clean.
- Live smoke: both CLIs without the flag exit 2 before touching the source.

Not done here: no live runtime/LaunchAgent reload (separate gate).