### PR TITLE
Re-sign WeChat with a persistent per-machine identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,10 +239,19 @@ documentation surfaces.
   lookup and Python architecture must never choose the scan mask.
 - `core/wechat_resign.py` owns explicit exact-target re-sign orchestration;
   `scripts/resign_wechat.py` and `launchers/启动.command` are thin entrypoints.
-  Bind canonical bundle, PID/launch/executable identity across sudo, graceful
-  termination, signing, independent verification and exact-path reopen. Never
-  restore process-name kill, post-mutation default-app discovery or implicit
-  re-sign permission.
+  Bind canonical bundle, PID/launch/executable identity across privilege
+  acquisition, graceful termination, signing, independent verification and
+  exact-path reopen. Signing must use the persistent per-machine self-signed
+  identity from `core/wechat_signing_identity.py`
+  (`~/Library/Keychains/wgo-wechat-identity.keychain-db` plus its mode-0600
+  password sidecar); never fall back to a bare ad-hoc `codesign --sign -`,
+  because macOS TCC cannot retain consent granted to a bare cdhash. sudo is
+  acquired only to chown the exact target bundle back to the operator when it
+  is not writable; signing itself runs unprivileged against the managed
+  keychain, and post-sign verification must require the designated
+  requirement to anchor the managed certificate root and reject ad-hoc
+  output. Never restore process-name kill, post-mutation default-app
+  discovery or implicit re-sign permission.
 - Scanner execution authority is an immutable private build directory plus a
   single atomic `scanner-current.json` pointer. The receipt binds source,
   compiler, target architecture, flags and binary identity. A legacy fixed
@@ -266,8 +275,12 @@ documentation surfaces.
   advance that exact batch; lookup failure preserves the checkpoint.
 - Catch-up prints the actual `rebuild_projections` notes/actions contract;
   tests must connect the real producer to apply/output/receipt.
-- `core/wechat_signature.py` owns the read-only strict/ad-hoc/no-runtime
-  predicate. Startup, Python runtime, and explicit re-sign verification share
+- `core/wechat_signature.py` owns the read-only strict/identity/no-runtime
+  predicate: strict verification must pass, the CS_RUNTIME bit must be
+  absent, and the signature must be either legacy ad-hoc or anchored to the
+  managed stable signing identity; explicit re-sign verification passes the
+  expected certificate root so ad-hoc output is rejected there. Startup,
+  Python runtime, and explicit re-sign verification share
   it. `get_wechat_app_path()` honors the session-bound target first; an invalid
   explicit binding never selects a different installation.
 - `core/monitor_result.py` owns catch-up outcome interpretation. Only the

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ independently deployed microservices. Editable sources:
   bodies/XML, `source_message_id`, `wxid`, and WeChat cache paths are not Drive
   metadata. The project does not delete Drive files, WeChat cache, or local CAS
   objects.
-- Extracting database keys may require ad-hoc re-signing `WeChat.app`. The regular double-click flow does not silently do this; commands that perform it are explicit. Re-signing binds one canonical bundle path and, when running, its exact PID/launch/executable identity through privilege acquisition, graceful termination, signing, independent verification, and exact-path reopen. Ambiguity or identity change stops the operation.
+- Extracting database keys may require re-signing `WeChat.app`. The regular double-click flow does not silently do this; commands that perform it are explicit. Re-signing binds one canonical bundle path and, when running, its exact PID/launch/executable identity through privilege acquisition, graceful termination, signing, independent verification, and exact-path reopen. Ambiguity or identity change stops the operation. Signing uses a persistent per-machine self-signed identity (`WGO WeChat Stable Identity`) created on first use in `~/Library/Keychains/wgo-wechat-identity.keychain-db` with a mode-0600 password sidecar; macOS retains consent granted to that stable identity across restarts, while a bare ad-hoc signature is re-prompted repeatedly. A WeChat update restores the official signature, so the explicit re-sign step must be run again after each update.
 - macOS may ask once per menu-app process for access to WeChat App Data. The
   project does not schedule short-lived source/resource workers that would make
   that process-lifetime consent recur; attachment-byte resolution is a separate

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,7 @@ DeepSeek 按实际 token 用量计费，输入缓存命中、输入缓存未命�
 这个项目适合个人本地使用。它涉及微信本地数据库和进程内 key 提取，所以公开使用前请先理解这些边界：
 
 - 程序读取本机微信数据库副本，不修改微信聊天数据库。
-- 首次提取数据库 key，或微信更新后重新提取 key，可能需要对 `WeChat.app` 做 ad-hoc re-sign。脚本不会在普通双击启动时偷偷执行这一步，必须显式运行带 `--allow-wechat-resign` 的命令。重签会把一次操作绑定到 canonical bundle path，以及运行时的 exact PID、launch 与 executable identity；取得 sudo 后会复核，只正常退出该 target，再对同一 bundle 签名、独立验签并按 exact path reopen。歧义、超时或 identity 变化都会停止。
+- 首次提取数据库 key，或微信更新后重新提取 key，可能需要对 `WeChat.app` 重签。脚本不会在普通双击启动时偷偷执行这一步，必须显式运行带 `--allow-wechat-resign` 的命令。重签会把一次操作绑定到 canonical bundle path，以及运行时的 exact PID、launch 与 executable identity；只在 bundle 不可写时才用 sudo 把该 exact target chown 回当前用户，随后正常退出该 target、对同一 bundle 签名、独立验签并按 exact path reopen。歧义、超时或 identity 变化都会停止。签名使用首次运行时自动创建的本机持久自签身份 `WGO WeChat Stable Identity`（keychain 位于 `~/Library/Keychains/wgo-wechat-identity.keychain-db`，密码 sidecar `wgo-wechat-identity.pw` 权限 0600）；macOS 会跨重启记住授予这只稳定身份的授权，而裸 ad-hoc 签名会被系统反复索要授权。微信更新会恢复官方签名，每次更新后需要重新显式执行重签。
 - macOS 可能在每次菜单 app 进程启动时询问一次 WeChat App Data 权限。项目不会再调度短命 source/resource
   worker 反复消耗这个 process-lifetime consent；附件 bytes 解析是仅存在于内存、本次 app 会话有效的
   显式授权，重启后必定归零，也不会从 config 恢复；关闭后，in-flight resolver 会在下一次读取附件

--- a/core/wechat_resign.py
+++ b/core/wechat_resign.py
@@ -14,10 +14,16 @@ import plistlib
 import re
 import stat
 import subprocess
+import tempfile
 import threading
 import time
 
 from . import key_extractor
+from .wechat_signing_identity import (
+    WeChatSigningIdentityError,
+    ensure_stable_signing_identity,
+    unlock_signing_keychain,
+)
 
 
 class WeChatResignError(RuntimeError):
@@ -204,9 +210,14 @@ def verify_resigned_wechat_bundle(
     expected: WeChatBundleIdentity,
     *,
     runner=subprocess.run,
+    expected_certificate_root=None,
 ) -> WeChatBundleIdentity:
     from .wechat_signature import inspect_wechat_signature
-    status = inspect_wechat_signature(expected.app_path, runner=runner)
+    status = inspect_wechat_signature(
+        expected.app_path,
+        runner=runner,
+        expected_certificate_root=expected_certificate_root,
+    )
     if not status.ok:
         raise WeChatResignError(status.code)
     observed = inspect_wechat_bundle(expected.app_path)
@@ -264,6 +275,42 @@ def reopen_wechat_target(
     return target
 
 
+def _wechat_bundle_writable(bundle: WeChatBundleIdentity) -> bool:
+    return os.access(bundle.app_path, os.W_OK) and os.access(
+        bundle.executable_path, os.W_OK
+    )
+
+
+def _write_resign_entitlements(app_path: str, *, runner=subprocess.run) -> str:
+    entitlements = {}
+    try:
+        dumped = runner(
+            ["/usr/bin/codesign", "-d", "--entitlements", ":-", app_path],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        dumped = None
+    if dumped is not None and dumped.returncode == 0:
+        try:
+            parsed = plistlib.loads((dumped.stdout or "").encode("utf-8"))
+            if isinstance(parsed, dict):
+                entitlements = parsed
+        except (ValueError, plistlib.InvalidFileException):
+            entitlements = {}
+    entitlements["com.apple.security.get-task-allow"] = True
+    try:
+        descriptor, path = tempfile.mkstemp(
+            prefix="wgo-resign-entitlements-", suffix=".plist"
+        )
+        try:
+            os.write(descriptor, plistlib.dumps(entitlements))
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise WeChatResignError("wechat_entitlements_unavailable") from exc
+    return path
+
+
 def resign_wechat_bundle(
     app_path,
     *,
@@ -277,9 +324,15 @@ def resign_wechat_bundle(
         app_path,
         explicit_target=explicit_target,
     )
-    privilege = runner(["sudo", "-v"], timeout=60)
-    if privilege.returncode:
-        raise WeChatResignError("wechat_privilege_unavailable")
+    try:
+        identity = ensure_stable_signing_identity(runner=runner)
+    except WeChatSigningIdentityError as exc:
+        raise WeChatResignError(exc.code) from exc
+    needs_ownership = not _wechat_bundle_writable(target.bundle)
+    if needs_ownership:
+        privilege = runner(["sudo", "-v"], timeout=60)
+        if privilege.returncode:
+            raise WeChatResignError("wechat_privilege_unavailable")
     target = revalidate_wechat_resign_target(
         target,
         explicit_target=explicit_target,
@@ -287,18 +340,49 @@ def resign_wechat_bundle(
     terminate_wechat_target(target.running)
     if inspect_wechat_bundle(target.bundle.app_path) != target.bundle:
         raise WeChatResignError("wechat_target_changed")
-    try:
-        signed = runner(
+    if needs_ownership:
+        chown = runner(
             [
-                "sudo", "-n", "codesign", "--force", "--deep", "--sign", "-",
+                "sudo", "-n", "chown", "-R",
+                f"{os.getuid()}:{os.getgid()}",
                 target.bundle.app_path,
             ],
-            timeout=120,
+            timeout=60,
         )
-    except subprocess.TimeoutExpired as exc:
-        raise WeChatResignError("wechat_resign_outcome_ambiguous") from exc
-    if signed.returncode:
-        raise WeChatResignError("wechat_resign_failed")
-    verified = verify_resigned_wechat_bundle(target.bundle, runner=runner)
+        if chown.returncode:
+            raise WeChatResignError("wechat_ownership_change_failed")
+    try:
+        unlock_signing_keychain(identity, runner=runner)
+    except WeChatSigningIdentityError as exc:
+        raise WeChatResignError(exc.code) from exc
+    entitlements_path = _write_resign_entitlements(
+        target.bundle.app_path, runner=runner
+    )
+    try:
+        try:
+            signed = runner(
+                [
+                    "/usr/bin/codesign", "--force", "--deep",
+                    "--sign", identity.common_name,
+                    "--keychain", identity.keychain_path,
+                    "--entitlements", entitlements_path,
+                    target.bundle.app_path,
+                ],
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise WeChatResignError("wechat_resign_outcome_ambiguous") from exc
+        if signed.returncode:
+            raise WeChatResignError("wechat_resign_failed")
+    finally:
+        try:
+            os.unlink(entitlements_path)
+        except OSError:
+            pass
+    verified = verify_resigned_wechat_bundle(
+        target.bundle,
+        runner=runner,
+        expected_certificate_root=identity.certificate_root,
+    )
     reopened = reopen_wechat_target(verified, previous=target.running)
     return WeChatResignOutcome(verified, reopened)

--- a/core/wechat_signature.py
+++ b/core/wechat_signature.py
@@ -1,8 +1,12 @@
 """One read-only codesign predicate for startup, health, and explicit re-sign.
 
 No discovery, privilege escalation, process control, or source reads occur here.
-A caller supplies the already selected app path. This is a macOS adapter; its
-subprocess runner is injectable so signature parsing can be tested off-device.
+A caller supplies the already selected app path. A strict-verified bundle is
+acceptable when the CS_RUNTIME bit is absent and the signature is either the
+legacy ad-hoc form or anchored to the managed stable signing identity; explicit
+re-sign verification passes ``expected_certificate_root`` so ad-hoc output and
+foreign certificates are both rejected. This is a macOS adapter; its subprocess
+runner is injectable so signature parsing can be tested off-device.
 """
 from __future__ import annotations
 
@@ -20,8 +24,13 @@ class WeChatSignatureStatus:
         return self.code == "wechat_signature_valid"
 
 
-def inspect_wechat_signature(app_path, *, runner=None) -> WeChatSignatureStatus:
-    """Require strict verification, ad-hoc identity, and no runtime flag."""
+def inspect_wechat_signature(
+    app_path,
+    *,
+    runner=None,
+    expected_certificate_root=None,
+) -> WeChatSignatureStatus:
+    """Require strict verification, an acceptable identity, and no runtime flag."""
     if not isinstance(app_path, str) or not app_path or "\0" in app_path:
         return WeChatSignatureStatus("wechat_signature_unavailable")
     run = runner if runner is not None else subprocess.run
@@ -39,10 +48,6 @@ def inspect_wechat_signature(app_path, *, runner=None) -> WeChatSignatureStatus:
         if displayed.returncode != 0:
             return WeChatSignatureStatus("wechat_signature_invalid")
         detail = "\n".join((displayed.stdout or "", displayed.stderr or ""))
-        signatures = [line.strip() for line in detail.splitlines()
-                      if line.strip().startswith("Signature=")]
-        if signatures != ["Signature=adhoc"]:
-            return WeChatSignatureStatus("wechat_signature_not_adhoc")
         directories = [line.strip() for line in detail.splitlines()
                        if line.strip().startswith("CodeDirectory ")]
         if not directories:
@@ -55,6 +60,32 @@ def inspect_wechat_signature(app_path, *, runner=None) -> WeChatSignatureStatus:
             # a path or unrelated codesign text that happens to say runtime.
             if int(flags.group(1), 16) & 0x10000:
                 return WeChatSignatureStatus("wechat_hardened_runtime_still_enabled")
+        signatures = [line.strip() for line in detail.splitlines()
+                      if line.strip().startswith("Signature=")]
+        if signatures == ["Signature=adhoc"]:
+            if expected_certificate_root is None:
+                return WeChatSignatureStatus("wechat_signature_valid")
+            return WeChatSignatureStatus("wechat_signature_not_stable_identity")
+        if len(signatures) > 1:
+            return WeChatSignatureStatus("wechat_signature_invalid")
+        root = expected_certificate_root
+        if root is None:
+            from .wechat_signing_identity import managed_certificate_root_hash
+            root = managed_certificate_root_hash(runner=run)
+        if not root:
+            return WeChatSignatureStatus("wechat_signature_not_stable_identity")
+        designated = run(
+            ["/usr/bin/codesign", "--display", "-r-", app_path],
+            capture_output=True, text=True, timeout=60,
+        )
+        if designated.returncode != 0:
+            return WeChatSignatureStatus("wechat_signature_invalid")
+        requirement = "\n".join(
+            (designated.stdout or "", designated.stderr or "")
+        ).lower()
+        anchor = f'certificate root = h"{str(root).lower()}"'
+        if anchor not in requirement:
+            return WeChatSignatureStatus("wechat_signature_not_stable_identity")
         return WeChatSignatureStatus("wechat_signature_valid")
     except (OSError, subprocess.SubprocessError, TypeError, ValueError, AttributeError):
         return WeChatSignatureStatus("wechat_signature_unavailable")

--- a/core/wechat_signing_identity.py
+++ b/core/wechat_signing_identity.py
@@ -1,0 +1,282 @@
+"""Persistent per-machine self-signed identity for WeChat re-signing.
+
+macOS TCC does not retain consent granted to a bare ad-hoc cdhash, so a
+WeChat bundle re-signed with ``codesign --sign -`` keeps re-prompting for
+App Data and folder access. Signing with a stable self-signed certificate
+gives that consent a durable identity. This module creates the identity on
+first use and locates it afterwards; nothing runs at import time and every
+external command goes through the injectable runner.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import secrets
+import shutil
+import stat
+import subprocess
+import tempfile
+
+
+IDENTITY_COMMON_NAME = "WGO WeChat Stable Identity"
+_KEYCHAIN_NAME = "wgo-wechat-identity.keychain-db"
+_PASSWORD_NAME = "wgo-wechat-identity.pw"
+_CERTIFICATE_DAYS = "3650"
+
+_OPENSSL_CONFIG = """[req]
+distinguished_name = dn
+x509_extensions = codesign
+[dn]
+[codesign]
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature
+extendedKeyUsage = codeSigning
+"""
+
+
+class WeChatSigningIdentityError(RuntimeError):
+    def __init__(self, code: str):
+        self.code = str(code or "wechat_signing_identity_unavailable")
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True)
+class WeChatSigningIdentity:
+    common_name: str
+    keychain_path: str
+    certificate_root: str
+
+
+def identity_keychain_path(home=None) -> Path:
+    base = Path(home) if home is not None else Path.home()
+    return base / "Library" / "Keychains" / _KEYCHAIN_NAME
+
+
+def identity_password_path(home=None) -> Path:
+    base = Path(home) if home is not None else Path.home()
+    return base / "Library" / "Keychains" / _PASSWORD_NAME
+
+
+def _run_checked(run, args, *, timeout: int = 60, capture: bool = False):
+    kwargs = {"timeout": timeout}
+    if capture:
+        kwargs.update(capture_output=True, text=True)
+    try:
+        result = run(args, **kwargs)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise WeChatSigningIdentityError(
+            "wechat_signing_identity_unavailable"
+        ) from exc
+    if result.returncode:
+        raise WeChatSigningIdentityError("wechat_signing_identity_unavailable")
+    return result
+
+
+def _certificate_root_from_pem(pem_text: str) -> str | None:
+    body = []
+    inside = False
+    for line in pem_text.splitlines():
+        marker = line.strip()
+        if marker == "-----BEGIN CERTIFICATE-----":
+            inside = True
+            continue
+        if marker == "-----END CERTIFICATE-----":
+            break
+        if inside:
+            body.append(marker)
+    if not body:
+        return None
+    try:
+        der = base64.b64decode("".join(body), validate=True)
+    except (ValueError, binascii.Error):
+        return None
+    return hashlib.sha1(der).hexdigest()
+
+
+def managed_certificate_root_hash(
+    *,
+    runner=None,
+    keychain_path=None,
+) -> str | None:
+    run = runner if runner is not None else subprocess.run
+    keychain = str(keychain_path or identity_keychain_path())
+    try:
+        found = run(
+            [
+                "security", "find-certificate",
+                "-c", IDENTITY_COMMON_NAME,
+                "-p", keychain,
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if found.returncode != 0:
+        return None
+    return _certificate_root_from_pem(found.stdout or "")
+
+
+def _read_password(path: Path) -> str:
+    try:
+        existing = os.lstat(path)
+    except FileNotFoundError as exc:
+        raise WeChatSigningIdentityError(
+            "wechat_signing_identity_password_missing"
+        ) from exc
+    if not stat.S_ISREG(existing.st_mode):
+        raise WeChatSigningIdentityError(
+            "wechat_signing_identity_password_invalid"
+        )
+    password = path.read_text(encoding="ascii").strip()
+    if not password:
+        raise WeChatSigningIdentityError(
+            "wechat_signing_identity_password_invalid"
+        )
+    return password
+
+
+def _read_or_create_password(path: Path) -> str:
+    try:
+        return _read_password(path)
+    except WeChatSigningIdentityError as exc:
+        if exc.code != "wechat_signing_identity_password_missing":
+            raise
+    password = secrets.token_hex(24)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        os.write(descriptor, password.encode("ascii"))
+    finally:
+        os.close(descriptor)
+    return password
+
+
+def _openssl_supports_legacy_flag(run, openssl: str) -> bool:
+    version = _run_checked(run, [openssl, "version"], timeout=30, capture=True)
+    return (version.stdout or "").startswith("OpenSSL 3")
+
+
+def _ensure_user_search_list(run, keychain: Path) -> None:
+    try:
+        listed = run(
+            ["security", "list-keychains", "-d", "user"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if listed.returncode != 0:
+            return
+        entries = [
+            line.strip().strip('"')
+            for line in (listed.stdout or "").splitlines()
+            if line.strip()
+        ]
+        if str(keychain) in entries:
+            return
+        run(
+            ["security", "list-keychains", "-d", "user", "-s", *entries, str(keychain)],
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return
+
+
+def ensure_stable_signing_identity(
+    *,
+    runner=None,
+    home=None,
+) -> WeChatSigningIdentity:
+    run = runner if runner is not None else subprocess.run
+    keychain = identity_keychain_path(home)
+    password_path = identity_password_path(home)
+    existing = managed_certificate_root_hash(runner=run, keychain_path=keychain)
+    if existing:
+        return WeChatSigningIdentity(
+            IDENTITY_COMMON_NAME, str(keychain), existing
+        )
+    if keychain.exists() and not password_path.exists():
+        raise WeChatSigningIdentityError(
+            "wechat_signing_identity_password_missing"
+        )
+    password = _read_or_create_password(password_path)
+    openssl = shutil.which("openssl") or "/usr/bin/openssl"
+    workspace = Path(tempfile.mkdtemp(prefix="wgo-signing-identity-"))
+    try:
+        config = workspace / "openssl.cnf"
+        config.write_text(_OPENSSL_CONFIG, encoding="ascii")
+        key = workspace / "identity.key.pem"
+        certificate = workspace / "identity.cert.pem"
+        package = workspace / "identity.p12"
+        _run_checked(
+            run,
+            [
+                openssl, "req", "-x509", "-newkey", "rsa:2048",
+                "-keyout", str(key), "-out", str(certificate),
+                "-days", _CERTIFICATE_DAYS, "-nodes",
+                "-subj", f"/CN={IDENTITY_COMMON_NAME}",
+                "-config", str(config),
+            ],
+            timeout=120,
+        )
+        export = [
+            openssl, "pkcs12", "-export",
+            "-out", str(package),
+            "-inkey", str(key), "-in", str(certificate),
+            "-passout", f"pass:{password}",
+        ]
+        if _openssl_supports_legacy_flag(run, openssl):
+            export.append("-legacy")
+        _run_checked(run, export, timeout=60)
+        if not keychain.exists():
+            _run_checked(
+                run,
+                ["security", "create-keychain", "-p", password, str(keychain)],
+            )
+        _run_checked(
+            run,
+            [
+                "security", "import", str(package),
+                "-k", str(keychain), "-P", password,
+                "-T", "/usr/bin/codesign",
+            ],
+        )
+        _run_checked(
+            run,
+            ["security", "unlock-keychain", "-p", password, str(keychain)],
+        )
+        _run_checked(
+            run,
+            [
+                "security", "set-key-partition-list",
+                "-S", "apple-tool:,apple:,codesign:",
+                "-k", password, str(keychain),
+            ],
+        )
+        _ensure_user_search_list(run, keychain)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+    root = managed_certificate_root_hash(runner=run, keychain_path=keychain)
+    if not root:
+        raise WeChatSigningIdentityError("wechat_signing_identity_unavailable")
+    return WeChatSigningIdentity(IDENTITY_COMMON_NAME, str(keychain), root)
+
+
+def unlock_signing_keychain(
+    identity: WeChatSigningIdentity,
+    *,
+    runner=None,
+    home=None,
+) -> None:
+    run = runner if runner is not None else subprocess.run
+    password_path = identity_password_path(home)
+    password = _read_password(password_path)
+    _run_checked(
+        run,
+        ["security", "unlock-keychain", "-p", password, identity.keychain_path],
+    )

--- a/docs/WINDOWS-PORT-MAP.md
+++ b/docs/WINDOWS-PORT-MAP.md
@@ -82,7 +82,7 @@ root, `ai/`, `core/`, `ui/`, and `scripts/` Python module and imports every
 | `core/google_drive_file_sync.py` | `deferred-w0.2` | Direct `fcntl` and attachment/config dependencies; Windows activation is later. |
 | `core/image_decoder.py` | `windows-import-safe` | Platform-neutral byte decoding. |
 | `core/key_extractor.py` | `macos-only` | macOS process scanner, codesign, sudo, and osascript source adapter. |
-| `core/wechat_signature.py` | `macos-only` | Shared read-only macOS codesign predicate; injectable runner only, no Windows signature or key support. |
+| `core/wechat_signature.py` | `macos-only` | Shared read-only macOS codesign predicate (strict, no runtime flag, legacy ad-hoc or managed stable identity); injectable runner only, no Windows signature or key support. |
 | `core/keychain.py` | `macos-only` | macOS `security` adapter; shared secret contract is defined for W0.3 wiring. |
 | `core/knowledge.py` | `deferred-w0.2` | Transitively imports ConfigStore/path/private storage; Windows activation is W3. |
 | `core/launch_agent.py` | `macos-only` | macOS LaunchAgent adapter; Windows autostart is W6. |
@@ -116,6 +116,7 @@ root, `ai/`, `core/`, `ui/`, and `scripts/` Python module and imports every
 | `core/url_safety.py` | `windows-import-safe` | Stdlib-only canonical URL display/export/prompt redaction. |
 | `core/wechat_db.py` | `windows-import-safe` | Existing shared crypto/query import surface; schema/source adapters are W1.1+. |
 | `core/wechat_resign.py` | `macos-only` | Exact-target AppKit/codesign/sudo re-sign orchestration; Windows key-provider authorization belongs to W1+. |
+| `core/wechat_signing_identity.py` | `macos-only` | macOS `security`/openssl adapter owning the persistent self-signed re-sign identity keychain; no Windows signing support. |
 | `core/wechat_source_guard.py` | `macos-only` | `fcntl`, macOS key/process adapter, and osascript notification behavior. |
 | `ui/__init__.py` | `windows-import-safe` | Empty reusable UI package boundary; Windows tray is W6. |
 | `scripts/__init__.py` | `windows-import-safe` | Empty operator package boundary. |

--- a/docs/reliability-closure.md
+++ b/docs/reliability-closure.md
@@ -15,9 +15,13 @@ changed, and a separately launched process does not inherit it automatically.
 
 `core/wechat_signature.py` provides the common read-only predicate for the
 launcher, `is_wechat_signed()`, and explicit re-sign verification. It invokes
-`/usr/bin/codesign`, requires strict verification and exactly one ad-hoc
-signature result, and reads the numeric `CS_RUNTIME` bit from CodeDirectory
-flags. Paths containing the word `runtime` do not cause a false rejection.
+`/usr/bin/codesign`, requires strict verification, reads the numeric
+`CS_RUNTIME` bit from CodeDirectory flags, and accepts either one legacy
+ad-hoc signature or a signature whose designated requirement anchors the
+managed stable identity from `core/wechat_signing_identity.py`. Explicit
+re-sign verification passes the expected certificate root, so ad-hoc output
+and foreign certificates are rejected there. Paths containing the word
+`runtime` do not cause a false rejection.
 Missing or malformed verification evidence fails closed with a bounded code.
 The caller still owns exact bundle/process binding around mutation. This
 predicate is not an atomic filesystem identity or process-termination proof.

--- a/launchers/启动.command
+++ b/launchers/启动.command
@@ -304,7 +304,9 @@ ensure_wechat_signed() {
     fi
 
     echo "[2/3] 检测到微信需要重新授权..."
-    echo "  为了读取本地微信数据库，本项目需要对 WeChat.app 做 ad-hoc re-sign。"
+    echo "  为了读取本地微信数据库，本项目需要用本机稳定签名身份重签 WeChat.app。"
+    echo "  首次会自动创建自签证书（WGO WeChat Stable Identity），存入"
+    echo "  ~/Library/Keychains/wgo-wechat-identity.keychain-db，之后 macOS 会记住授权。"
     echo "  这是高影响操作：会修改下列 exact target 的签名，微信更新后可能失效。"
     echo "  Target: $app_path"
     echo ""

--- a/tests/test_reliability_closure_modules.py
+++ b/tests/test_reliability_closure_modules.py
@@ -1,7 +1,7 @@
 """No platform process or network calls: the codesign runner is always mocked."""
 import subprocess
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qsl, urlsplit
 
 from core.monitor_result import classify_monitor_result, monitor_status
@@ -81,12 +81,81 @@ class SignaturePredicateTests(unittest.TestCase):
         for detail in (
             'Signature=adhoc\n',
             'CodeDirectory flags=garbage\nSignature=adhoc\n',
-            'CodeDirectory flags=0x2(adhoc)\nSignature size=500\n',
             'CodeDirectory flags=0x2(adhoc)\nSignature=adhoc\nSignature=other\n',
             'CodeDirectory flags=0x2(adhoc)\nCodeDirectory flags=0x10002\nSignature=adhoc\n',
         ):
             with self.subTest(detail=detail):
                 self.assertFalse(inspect_wechat_signature('/fixture/WeChat.app', runner=self.runner(detail)).ok)
+        with patch(
+            'core.wechat_signing_identity.managed_certificate_root_hash',
+            return_value=None,
+        ):
+            detail = 'CodeDirectory flags=0x2(adhoc)\nSignature size=500\n'
+            self.assertFalse(inspect_wechat_signature('/fixture/WeChat.app', runner=self.runner(detail)).ok)
+
+    def test_managed_stable_identity_is_accepted(self):
+        path = '/fixture/runtime directory/WeChat.app'
+        runner = Mock(side_effect=[
+            subprocess.CompletedProcess([], 0, '', ''),
+            subprocess.CompletedProcess(
+                [], 0, '',
+                'CodeDirectory v=20500 size=755 flags=0x0(none) hashes=14+2 location=embedded\n'
+                'Signature size=1840\n',
+            ),
+            subprocess.CompletedProcess(
+                [], 0, '',
+                'Executable=/fixture/WeChat\n'
+                'designated => identifier "com.tencent.xinWeChat" and '
+                'certificate root = H"0123abcdef"\n',
+            ),
+        ])
+        result = inspect_wechat_signature(
+            path, runner=runner, expected_certificate_root='0123ABCDEF',
+        )
+        self.assertTrue(result.ok)
+        self.assertEqual(len(runner.call_args_list), 3)
+        for call in runner.call_args_list:
+            self.assertNotIn('sudo', call.args[0])
+            self.assertNotIn('--sign', call.args[0])
+
+    def test_foreign_certificate_is_rejected(self):
+        runner = Mock(side_effect=[
+            subprocess.CompletedProcess([], 0, '', ''),
+            subprocess.CompletedProcess(
+                [], 0, '',
+                'CodeDirectory v=20500 size=755 flags=0x0(none) hashes=14+2 location=embedded\n'
+                'Signature size=8979\n',
+            ),
+            subprocess.CompletedProcess(
+                [], 0, '',
+                'designated => identifier "com.tencent.xinWeChat" and anchor apple generic\n',
+            ),
+        ])
+        result = inspect_wechat_signature(
+            '/fixture/WeChat.app', runner=runner,
+            expected_certificate_root='0123abcdef',
+        )
+        self.assertEqual(result.code, 'wechat_signature_not_stable_identity')
+
+    def test_adhoc_is_rejected_when_stable_identity_is_required(self):
+        runner = self.runner('CodeDirectory flags=0x2(adhoc)\nSignature=adhoc\n')
+        result = inspect_wechat_signature(
+            '/fixture/WeChat.app', runner=runner,
+            expected_certificate_root='0123abcdef',
+        )
+        self.assertEqual(result.code, 'wechat_signature_not_stable_identity')
+        self.assertEqual(len(runner.call_args_list), 2)
+
+    def test_certificate_signature_without_managed_identity_fails_closed(self):
+        runner = self.runner(
+            'CodeDirectory flags=0x0(none)\nSignature size=1840\n'
+        )
+        with patch(
+            'core.wechat_signing_identity.managed_certificate_root_hash',
+            return_value=None,
+        ):
+            result = inspect_wechat_signature('/fixture/WeChat.app', runner=runner)
+        self.assertEqual(result.code, 'wechat_signature_not_stable_identity')
 
     def test_failed_display_is_not_success(self):
         runner = self.runner('CodeDirectory flags=0x2(adhoc)\nSignature=adhoc\n', display_code=1)

--- a/tests/test_wechat_resign.py
+++ b/tests/test_wechat_resign.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from core import key_extractor
 from core import wechat_resign
+from core.wechat_signing_identity import WeChatSigningIdentity
 from tests.paths import repo_path
 
 
@@ -36,6 +37,25 @@ class WeChatResignTests(unittest.TestCase):
             self.bundle.executable_identity,
         )
         self.target = wechat_resign.WeChatResignTarget(self.bundle, self.running)
+        self.identity = WeChatSigningIdentity(
+            "WGO WeChat Stable Identity",
+            "/fixture/wgo-wechat-identity.keychain-db",
+            "0123abcdef",
+        )
+
+    def _identity_patches(self):
+        return (
+            patch.object(
+                wechat_resign,
+                "ensure_stable_signing_identity",
+                return_value=self.identity,
+            ),
+            patch.object(wechat_resign, "unlock_signing_keychain"),
+        )
+
+    @staticmethod
+    def _sign_call(calls):
+        return next(call for call in calls if "--sign" in call)
 
     def test_ambiguous_running_copies_are_rejected_before_mutation(self):
         other = key_extractor.ScanTarget(
@@ -80,14 +100,17 @@ class WeChatResignTests(unittest.TestCase):
             )
         self.assertEqual(target.running, self.running)
 
-    def test_target_change_after_privilege_check_stops_before_signing(self):
+    def test_target_change_after_identity_check_stops_before_signing(self):
         calls = []
 
         def runner(args, **_kwargs):
             calls.append(args)
             return subprocess.CompletedProcess(args, 0, "", "")
 
+        ensure, unlock = self._identity_patches()
         with (
+            ensure,
+            unlock,
             patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
             patch.object(
                 wechat_resign,
@@ -105,11 +128,12 @@ class WeChatResignTests(unittest.TestCase):
                     runner=runner,
                 )
 
-        self.assertEqual(calls, [["sudo", "-v"]])
+        self.assertEqual(calls, [])
 
     def test_missing_explicit_authorization_performs_no_discovery_or_mutation(self):
         with (
             patch.object(wechat_resign, "resolve_wechat_resign_target") as resolve,
+            patch.object(wechat_resign, "ensure_stable_signing_identity") as ensure,
             patch.object(wechat_resign.subprocess, "run") as run,
         ):
             with self.assertRaisesRegex(
@@ -119,6 +143,7 @@ class WeChatResignTests(unittest.TestCase):
                 wechat_resign.resign_wechat_bundle(self.app, allow=False)
 
         resolve.assert_not_called()
+        ensure.assert_not_called()
         run.assert_not_called()
 
     def test_termination_timeout_never_calls_codesign(self):
@@ -128,7 +153,10 @@ class WeChatResignTests(unittest.TestCase):
             calls.append(args)
             return subprocess.CompletedProcess(args, 0, "", "")
 
+        ensure, unlock = self._identity_patches()
         with (
+            ensure,
+            unlock,
             patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
             patch.object(wechat_resign, "revalidate_wechat_resign_target", return_value=self.target),
             patch.object(
@@ -147,7 +175,7 @@ class WeChatResignTests(unittest.TestCase):
                     runner=runner,
                 )
 
-        self.assertEqual(calls, [["sudo", "-v"]])
+        self.assertFalse(any("codesign" in call for call in calls))
 
     def test_sign_success_without_independent_verification_does_not_reopen(self):
         calls = []
@@ -156,7 +184,10 @@ class WeChatResignTests(unittest.TestCase):
             calls.append(args)
             return subprocess.CompletedProcess(args, 0, "", "")
 
+        ensure, unlock = self._identity_patches()
         with (
+            ensure,
+            unlock,
             patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
             patch.object(wechat_resign, "revalidate_wechat_resign_target", return_value=self.target),
             patch.object(wechat_resign, "terminate_wechat_target"),
@@ -177,7 +208,7 @@ class WeChatResignTests(unittest.TestCase):
                     runner=runner,
                 )
 
-        self.assertEqual(calls[1][-1], self.bundle.app_path)
+        self.assertEqual(self._sign_call(calls)[-1], self.bundle.app_path)
         reopen.assert_not_called()
 
     def test_verification_accepts_native_codedirectory_adhoc_output(self):
@@ -205,25 +236,54 @@ class WeChatResignTests(unittest.TestCase):
 
         self.assertEqual(observed, self.bundle)
 
-    def test_verification_rejects_non_adhoc_signature(self):
+    def test_verification_rejects_certificate_foreign_to_expected_root(self):
         results = iter((
             subprocess.CompletedProcess(["codesign", "--verify"], 0, "", ""),
             subprocess.CompletedProcess(
                 ["codesign", "--display"],
                 0,
                 "",
-                "CodeDirectory v=20500 size=755 flags=0x10000(runtime) hashes=14+2 location=embedded\n"
+                "CodeDirectory v=20500 size=755 flags=0x0(none) hashes=14+2 location=embedded\n"
                 "Signature size=8979\n",
+            ),
+            subprocess.CompletedProcess(
+                ["codesign", "--display", "-r-"],
+                0,
+                "",
+                'designated => identifier "com.tencent.xinWeChat" and anchor apple generic\n',
             ),
         ))
 
         with self.assertRaisesRegex(
             wechat_resign.WeChatResignError,
-            "wechat_signature_not_adhoc",
+            "wechat_signature_not_stable_identity",
         ):
             wechat_resign.verify_resigned_wechat_bundle(
                 self.bundle,
                 runner=lambda *_args, **_kwargs: next(results),
+                expected_certificate_root=self.identity.certificate_root,
+            )
+
+    def test_verification_rejects_adhoc_when_stable_identity_is_required(self):
+        results = iter((
+            subprocess.CompletedProcess(["codesign", "--verify"], 0, "", ""),
+            subprocess.CompletedProcess(
+                ["codesign", "--display"],
+                0,
+                "",
+                "CodeDirectory v=20400 size=755 flags=0x2(adhoc) hashes=14+2 location=embedded\n"
+                "Signature=adhoc\n",
+            ),
+        ))
+
+        with self.assertRaisesRegex(
+            wechat_resign.WeChatResignError,
+            "wechat_signature_not_stable_identity",
+        ):
+            wechat_resign.verify_resigned_wechat_bundle(
+                self.bundle,
+                runner=lambda *_args, **_kwargs: next(results),
+                expected_certificate_root=self.identity.certificate_root,
             )
 
     def test_verification_rejects_runtime_flag_even_when_adhoc(self):
@@ -262,7 +322,10 @@ class WeChatResignTests(unittest.TestCase):
             (self.bundle.version, self.bundle.build, "arm64"),
             self.bundle.executable_identity,
         )
+        ensure, unlock = self._identity_patches()
         with (
+            ensure,
+            unlock,
             patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
             patch.object(wechat_resign, "revalidate_wechat_resign_target", return_value=self.target),
             patch.object(wechat_resign, "terminate_wechat_target") as terminate,
@@ -285,13 +348,96 @@ class WeChatResignTests(unittest.TestCase):
             )
 
         terminate.assert_called_once_with(self.running)
-        verify.assert_called_once_with(self.bundle, runner=runner)
+        verify.assert_called_once_with(
+            self.bundle,
+            runner=runner,
+            expected_certificate_root=self.identity.certificate_root,
+        )
         reopen.assert_called_once_with(self.bundle, previous=self.running)
         self.assertEqual(outcome.running, reopened)
-        self.assertEqual(calls[1], [
-            "sudo", "-n", "codesign", "--force", "--deep", "--sign", "-",
+        signed = self._sign_call(calls)
+        self.assertNotIn("sudo", signed)
+        self.assertEqual(signed[0], "/usr/bin/codesign")
+        self.assertEqual(
+            signed[signed.index("--sign") + 1], self.identity.common_name
+        )
+        self.assertEqual(
+            signed[signed.index("--keychain") + 1], self.identity.keychain_path
+        )
+        self.assertIn("--entitlements", signed)
+        self.assertEqual(signed[-1], self.bundle.app_path)
+
+    def test_unwritable_bundle_repairs_ownership_before_signing(self):
+        calls = []
+
+        def runner(args, **_kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        reopened = key_extractor.ScanTarget(
+            44,
             self.bundle.app_path,
-        ])
+            self.bundle.executable_path,
+            200.0,
+            (self.bundle.version, self.bundle.build, "arm64"),
+            self.bundle.executable_identity,
+        )
+        ensure, unlock = self._identity_patches()
+        with (
+            ensure,
+            unlock,
+            patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "revalidate_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "terminate_wechat_target"),
+            patch.object(wechat_resign, "_wechat_bundle_writable", return_value=False),
+            patch.object(
+                wechat_resign, "verify_resigned_wechat_bundle", return_value=self.bundle
+            ),
+            patch.object(wechat_resign, "reopen_wechat_target", return_value=reopened),
+        ):
+            wechat_resign.resign_wechat_bundle(
+                self.app,
+                allow=True,
+                runner=runner,
+            )
+
+        self.assertEqual(calls[0], ["sudo", "-v"])
+        chown = next(call for call in calls if "chown" in call)
+        self.assertEqual(
+            chown,
+            [
+                "sudo", "-n", "chown", "-R",
+                f"{os.getuid()}:{os.getgid()}",
+                self.bundle.app_path,
+            ],
+        )
+        self.assertLess(
+            calls.index(chown), calls.index(self._sign_call(calls))
+        )
+
+    def test_failed_privilege_check_stops_before_termination(self):
+        def runner(args, **_kwargs):
+            return subprocess.CompletedProcess(args, 1, "", "")
+
+        ensure, unlock = self._identity_patches()
+        with (
+            ensure,
+            unlock,
+            patch.object(wechat_resign, "resolve_wechat_resign_target", return_value=self.target),
+            patch.object(wechat_resign, "_wechat_bundle_writable", return_value=False),
+            patch.object(wechat_resign, "terminate_wechat_target") as terminate,
+        ):
+            with self.assertRaisesRegex(
+                wechat_resign.WeChatResignError,
+                "wechat_privilege_unavailable",
+            ):
+                wechat_resign.resign_wechat_bundle(
+                    self.app,
+                    allow=True,
+                    runner=runner,
+                )
+
+        terminate.assert_not_called()
 
     def test_launcher_has_no_name_bound_termination_or_rediscovered_reopen(self):
         launcher = repo_path("launchers", "启动.command").read_text(encoding="utf-8")

--- a/tests/test_wechat_signing_identity.py
+++ b/tests/test_wechat_signing_identity.py
@@ -1,0 +1,254 @@
+import base64
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from core import wechat_signing_identity as identity
+
+
+FIXTURE_PEM = """-----BEGIN CERTIFICATE-----
+MIIC6jCCAdKgAwIBAgIJAPRTSa4spWOwMA0GCSqGSIb3DQEBCwUAMBkxFzAVBgNV
+BAMMDldHTyBTbW9rZSBUZXN0MB4XDTI2MDkwNjAxNTQ1M1oXDTM2MDkwMzAxNTQ1
+M1owGTEXMBUGA1UEAwwOV0dPIFNtb2tlIFRlc3QwggEiMA0GCSqGSIb3DQEBAQUA
+A4IBDwAwggEKAoIBAQDVnEOxmm7i9Yq2c3aFtIzkWWTmkS2YsVZigZwtU+NeeiJH
+hfJkxvCu+kcHVnApI7dPYMHY38vJcANEkjycKXcMzxyAIQvVlC2QUhLnBR3KYEq5
+Rs8kc+zEAazjPRibhkkgCa77pgU3TOt5PgkGcIHS0QLSfTFWorta0XdoJFXZeKV8
+YPo2xJLaNXS1LEAc9GL5NEHgT3+61lEAVBhwhAsdoCge9lh+rNFfLVAiVXIH3fOm
+dcCjxShnnL5RpdFRLpGkM2vL2n6TmPtAHd+Pld7Y0G+fJ44uzRppVf6ExWFzA9II
+kQTpYabsq044n7m//8Vt6Pycm+YwEY+57hFoOpQJAgMBAAGjNTAzMAwGA1UdEwEB
+/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMA0GCSqG
+SIb3DQEBCwUAA4IBAQBXqdq9CByBCDJzmAc+eMGi+vbIFuFvs1pbWReMmHf/SRSi
+tRY/WykE4JPe8HqmyTtHfmfgo3/ndwwYt13yX6/cFV5bWM6ch7hxPd0WtVOc+m/f
+WQf0PlLaK2WALpnekeLOtpUvquBcuXvCjupH8ldgDV8pa0tcj2iIXOfkcQKOSc4X
+Efc4Yeq1HmaE8MJLHcCNertzfssQutDy1I2BU9VZ+hfhReP1B6u3T6n9mcUuJ31J
+HPGYDIX6ADzCxkVOiT9m0XnyvhQc373zT1DF2s+hWcwS8AY4gN3LQiTsOaqYPtkT
+NoDNNiYfsDDo8ehkSF6yWr/WrnpetzkI9A00mYHS
+-----END CERTIFICATE-----"""
+
+
+def fixture_root() -> str:
+    der = base64.b64decode("".join(FIXTURE_PEM.splitlines()[1:-1]))
+    return hashlib.sha1(der).hexdigest()
+
+
+def completed(args, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+
+class ManagedCertificateRootTests(unittest.TestCase):
+    def test_pem_is_hashed_as_sha1_of_der(self):
+        def runner(args, **_kwargs):
+            return completed(args, stdout=FIXTURE_PEM)
+
+        root = identity.managed_certificate_root_hash(
+            runner=runner, keychain_path="/fixture/wgo.keychain-db"
+        )
+        self.assertEqual(root, fixture_root())
+
+    def test_missing_certificate_returns_none(self):
+        def runner(args, **_kwargs):
+            return completed(args, returncode=44)
+
+        self.assertIsNone(
+            identity.managed_certificate_root_hash(
+                runner=runner, keychain_path="/fixture/wgo.keychain-db"
+            )
+        )
+
+    def test_runner_failure_returns_none_without_exception_text(self):
+        def runner(args, **_kwargs):
+            raise FileNotFoundError("PRIVATE_SENTINEL")
+
+        self.assertIsNone(
+            identity.managed_certificate_root_hash(
+                runner=runner, keychain_path="/fixture/wgo.keychain-db"
+            )
+        )
+
+
+class EnsureStableIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.home = Path(self.tmp.name)
+        self.keychain = identity.identity_keychain_path(self.home)
+        self.password_path = identity.identity_password_path(self.home)
+
+    def make_runner(self, *, openssl_version="LibreSSL 3.3.6", record=None):
+        calls = []
+        state = {"find_count": 0}
+
+        def runner(args, **_kwargs):
+            calls.append(list(args))
+            if record is not None:
+                record(args)
+            if args[:2] == ["security", "find-certificate"]:
+                state["find_count"] += 1
+                if state["find_count"] == 1:
+                    return completed(args, returncode=44)
+                return completed(args, stdout=FIXTURE_PEM)
+            if args[0].endswith("openssl") and args[1] == "version":
+                return completed(args, stdout=f"{openssl_version} smoke\n")
+            if args[:2] == ["security", "create-keychain"]:
+                self.keychain.parent.mkdir(parents=True, exist_ok=True)
+                self.keychain.touch()
+                return completed(args)
+            if args[:2] == ["security", "list-keychains"] and "-s" not in args:
+                return completed(args, stdout='    "/fixture/login.keychain-db"\n')
+            return completed(args)
+
+        return runner, calls
+
+    def test_existing_identity_is_reused_without_mutation(self):
+        def runner(args, **_kwargs):
+            return completed(args, stdout=FIXTURE_PEM)
+
+        result = identity.ensure_stable_signing_identity(
+            runner=runner, home=self.home
+        )
+        self.assertEqual(result.common_name, identity.IDENTITY_COMMON_NAME)
+        self.assertEqual(result.keychain_path, str(self.keychain))
+        self.assertEqual(result.certificate_root, fixture_root())
+
+    def test_missing_identity_creates_keychain_certificate_and_partition_list(self):
+        captured = {}
+
+        def record(args):
+            if "-config" in args:
+                captured["config"] = Path(
+                    args[args.index("-config") + 1]
+                ).read_text(encoding="ascii")
+            if args[0].endswith("openssl") and args[1] == "pkcs12":
+                captured["workspace"] = Path(args[args.index("-out") + 1]).parent
+
+        runner, calls = self.make_runner(record=record)
+        result = identity.ensure_stable_signing_identity(
+            runner=runner, home=self.home
+        )
+
+        verbs = [(call[0], call[1] if len(call) > 1 else "") for call in calls]
+        self.assertEqual(verbs[0], ("security", "find-certificate"))
+        self.assertIn("req", calls[1])
+        self.assertIn("pkcs12", calls[3])
+        self.assertNotIn("-legacy", calls[3])
+        self.assertEqual(calls[4][:2], ["security", "create-keychain"])
+        self.assertEqual(calls[5][:2], ["security", "import"])
+        self.assertIn("-T", calls[5])
+        self.assertEqual(
+            calls[5][calls[5].index("-T") + 1], "/usr/bin/codesign"
+        )
+        self.assertEqual(calls[6][:2], ["security", "unlock-keychain"])
+        self.assertEqual(calls[7][:2], ["security", "set-key-partition-list"])
+        self.assertIn("apple-tool:,apple:,codesign:", calls[7])
+        self.assertEqual(calls[-1][:2], ["security", "find-certificate"])
+        self.assertEqual(result.certificate_root, fixture_root())
+
+        self.assertIn("extendedKeyUsage = codeSigning", captured["config"])
+        self.assertFalse(captured["workspace"].exists())
+
+        mode = self.password_path.stat().st_mode & 0o777
+        self.assertEqual(mode, 0o600)
+        password = self.password_path.read_text(encoding="ascii")
+        self.assertEqual(len(password), 48)
+        self.assertIn(password, calls[4])
+
+    def test_openssl3_pkcs12_export_uses_legacy_flag(self):
+        runner, calls = self.make_runner(openssl_version="OpenSSL 3.6.3")
+        identity.ensure_stable_signing_identity(runner=runner, home=self.home)
+        export = next(call for call in calls if "pkcs12" in call)
+        self.assertEqual(export[-1], "-legacy")
+
+    def test_existing_keychain_without_password_fails_closed(self):
+        self.keychain.parent.mkdir(parents=True, exist_ok=True)
+        self.keychain.touch()
+
+        def runner(args, **_kwargs):
+            return completed(args, returncode=44)
+
+        with self.assertRaisesRegex(
+            identity.WeChatSigningIdentityError,
+            "wechat_signing_identity_password_missing",
+        ):
+            identity.ensure_stable_signing_identity(
+                runner=runner, home=self.home
+            )
+
+    def test_symlink_password_file_is_rejected(self):
+        self.password_path.parent.mkdir(parents=True, exist_ok=True)
+        target = self.home / "elsewhere"
+        target.write_text("x" * 48, encoding="ascii")
+        self.password_path.symlink_to(target)
+
+        def runner(args, **_kwargs):
+            return completed(args, returncode=44)
+
+        with self.assertRaisesRegex(
+            identity.WeChatSigningIdentityError,
+            "wechat_signing_identity_password_invalid",
+        ):
+            identity.ensure_stable_signing_identity(
+                runner=runner, home=self.home
+            )
+
+    def test_failed_keychain_creation_is_bounded(self):
+        def runner(args, **_kwargs):
+            if args[:2] == ["security", "find-certificate"]:
+                return completed(args, returncode=44)
+            if args[:2] == ["security", "create-keychain"]:
+                return completed(args, returncode=1)
+            return completed(args, stdout="LibreSSL 3.3.6\n")
+
+        with self.assertRaisesRegex(
+            identity.WeChatSigningIdentityError,
+            "wechat_signing_identity_unavailable",
+        ):
+            identity.ensure_stable_signing_identity(
+                runner=runner, home=self.home
+            )
+
+
+class UnlockKeychainTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.home = Path(self.tmp.name)
+        self.keychain = identity.identity_keychain_path(self.home)
+        self.password_path = identity.identity_password_path(self.home)
+        self.managed = identity.WeChatSigningIdentity(
+            identity.IDENTITY_COMMON_NAME, str(self.keychain), fixture_root()
+        )
+
+    def test_unlock_uses_stored_password(self):
+        self.password_path.parent.mkdir(parents=True, exist_ok=True)
+        self.password_path.write_text("p" * 48, encoding="ascii")
+        calls = []
+
+        def runner(args, **_kwargs):
+            calls.append(list(args))
+            return completed(args)
+
+        identity.unlock_signing_keychain(self.managed, runner=runner, home=self.home)
+        self.assertEqual(
+            calls,
+            [["security", "unlock-keychain", "-p", "p" * 48, str(self.keychain)]],
+        )
+
+    def test_missing_password_never_creates_a_new_one(self):
+        def runner(args, **_kwargs):
+            return completed(args)
+
+        with self.assertRaisesRegex(
+            identity.WeChatSigningIdentityError,
+            "wechat_signing_identity_password_missing",
+        ):
+            identity.unlock_signing_keychain(
+                self.managed, runner=runner, home=self.home
+            )
+        self.assertFalse(self.password_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

A WeChat bundle re-signed with a bare ad-hoc cdhash (`codesign --sign -`) cannot hold macOS TCC consent: the system re-prompts for App Data and folder access within minutes, even inside one process lifetime. Observed on WeChat 4.1.11 after the alpha.2 re-sign flow.

## What

- New `core/wechat_signing_identity.py`: idempotent creation and lookup of a persistent self-signed `WGO WeChat Stable Identity` certificate in a dedicated keychain (`~/Library/Keychains/wgo-wechat-identity.keychain-db`, mode-0600 password sidecar). Compatible with both system LibreSSL and OpenSSL 3 (`-legacy` pkcs12 export), sets the codesign key partition list so signing never prompts.
- `core/wechat_resign.py`: ensures the identity before any mutation, acquires sudo only to chown a non-writable exact target back to the operator, then signs unprivileged with the managed certificate and an explicit `get-task-allow` entitlement, and requires the post-sign designated requirement to anchor the managed certificate root.
- `core/wechat_signature.py`: the shared predicate keeps accepting legacy ad-hoc bundles at startup, but explicit re-sign verification passes the expected certificate root so ad-hoc output and foreign certificates are rejected.
- README EN/ZH, AGENTS.md, reliability-closure and WINDOWS-PORT-MAP updated; launcher copy now describes the stable identity.

## Behavior after this change

- Folder/data consent granted to WeChat survives restarts; macOS App Data remains a process-lifetime prompt (at most once per WeChat launch), unchanged platform behavior.
- A WeChat update restores the official signature; the explicit re-sign step must be re-run afterwards.
- Machines already signed ad-hoc keep working; re-running the explicit re-sign step upgrades them to the stable identity.

## Verification

- 1106 unittest OK (16 skipped), including new identity-management and resign-flow tests.
- compileall + all launcher `bash -n` + `git diff --check` clean.
- Live macOS check: predicate returns `wechat_signature_valid` on a bundle signed with the managed identity, and `ensure_stable_signing_identity` reuses the existing keychain without mutation.